### PR TITLE
chore: add docs, maintainer tooling, and issue/PR templates

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# Default owners for everything in the repo.
+* @KRoperUK

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,76 @@
+name: Bug report
+description: Report a problem with the Sungrow iSolarCloud integration
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to file a bug report!
+
+        **Before opening:** if you are seeing *"Invalid authentication"*, *"Operation failed"*,
+        or entities going *unavailable after a reboot*, please read the
+        [Troubleshooting guide](https://github.com/KRoperUK/sungrow-hass/blob/main/docs/TROUBLESHOOTING.md)
+        first — many of these are configuration or upstream API issues.
+  - type: checkboxes
+    id: preflight
+    attributes:
+      label: Pre-flight checks
+      options:
+        - label: I have read the Troubleshooting guide.
+          required: true
+        - label: I have searched existing issues and this is not a duplicate.
+          required: true
+        - label: I am running the latest released version of this integration.
+          required: true
+  - type: input
+    id: integration_version
+    attributes:
+      label: Integration version
+      placeholder: "e.g. 0.3.0"
+    validations:
+      required: true
+  - type: input
+    id: ha_version
+    attributes:
+      label: Home Assistant version
+      placeholder: "e.g. 2026.5.0"
+    validations:
+      required: true
+  - type: dropdown
+    id: gateway
+    attributes:
+      label: Gateway region
+      options:
+        - Europe
+        - International
+        - China
+        - Australia
+    validations:
+      required: true
+  - type: textarea
+    id: description
+    attributes:
+      label: Describe the bug
+      description: A clear and concise description of what the problem is and what you expected.
+    validations:
+      required: true
+  - type: textarea
+    id: reproduce
+    attributes:
+      label: Steps to reproduce
+      placeholder: |
+        1. Go to ...
+        2. Click on ...
+        3. See error
+    validations:
+      required: true
+  - type: textarea
+    id: logs
+    attributes:
+      label: Relevant log output
+      description: >
+        Enable debug logging (see Troubleshooting guide) and paste the relevant
+        `custom_components.sungrow` log lines. Redact any tokens, app keys or secrets.
+      render: shell
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Authentication / setup help
+    url: https://github.com/KRoperUK/sungrow-hass/blob/main/docs/TROUBLESHOOTING.md
+    about: "Most \"Invalid authentication\", \"Operation failed\" and \"unavailable after reboot\" problems are covered here. Please read before opening an issue."
+  - name: Questions & discussions
+    url: https://github.com/KRoperUK/sungrow-hass/discussions
+    about: Ask questions about sensors, automations, or general usage here.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,32 @@
+name: Feature request
+description: Suggest an idea or new capability for the integration
+labels: ["enhancement"]
+body:
+  - type: textarea
+    id: problem
+    attributes:
+      label: What problem are you trying to solve?
+      description: A clear description of the use case or limitation you've hit.
+    validations:
+      required: true
+  - type: textarea
+    id: solution
+    attributes:
+      label: Proposed solution
+      description: What you'd like to happen. Include API param codes / register numbers if known.
+    validations:
+      required: false
+  - type: textarea
+    id: hardware
+    attributes:
+      label: Hardware / setup details
+      description: Inverter model, dongle, battery, plant type, API plan — anything relevant.
+    validations:
+      required: false
+  - type: checkboxes
+    id: contribution
+    attributes:
+      label: Contribution
+      options:
+        - label: I am willing to help test an implementation.
+        - label: I am willing to submit a pull request.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,23 @@
+<!--
+Thanks for contributing! Please use a Conventional Commit style PR title,
+e.g. "fix: persist refreshed tokens" or "feat: add EV charger sensors".
+This drives automated changelog and versioning.
+-->
+
+## Summary
+
+<!-- What does this PR change and why? Link any related issues, e.g. "Closes #14". -->
+
+## Type of change
+
+- [ ] Bug fix (non-breaking change which fixes an issue)
+- [ ] New feature (non-breaking change which adds functionality)
+- [ ] Breaking change
+- [ ] Documentation / chore
+
+## Checklist
+
+- [ ] `ruff check custom_components/` passes
+- [ ] `ruff format --check custom_components/` passes
+- [ ] `pytest` passes and new/changed behaviour is covered by tests
+- [ ] I have updated documentation where relevant

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,40 @@
+# GitHub Copilot instructions
+
+This repo is a **Home Assistant custom integration** for Sungrow inverters via the
+iSolarCloud cloud API, built on the `pysolarcloud` library. Code lives in
+`custom_components/sungrow/`.
+
+## Module map
+
+- `__init__.py` — entry setup/unload; builds auth + per-plant coordinators;
+  **persists rotated tokens** to the config entry; maps errors to
+  `ConfigEntryNotReady` (retry) vs `ConfigEntryAuthFailed` (reauth).
+- `auth.py` — `SungrowAuth(pysolarcloud.Auth)` with a `token_updater` callback.
+- `coordinator.py` — `SungrowPlantCoordinator`; `is_auth_error()` classification.
+- `config_flow.py` — user, reauth, and options (polling interval) flows.
+- `sensor.py` — entities + `infer_device_class()` (units → device/state class).
+- `const.py` — domain, config keys, gateways, scan-interval defaults.
+
+## Must-follow rules
+
+1. **Never drop token persistence.** `pysolarcloud` rotates the refresh token in
+   memory on refresh; the `token_updater` callback writes it back to the config
+   entry. Removing it reintroduces the "entities unavailable after reboot" bug.
+2. **Keep `pysolarcloud` pinned** in `manifest.json` (and `requirements_test.txt`).
+3. **Keep `strings.json` and `translations/en.json` in sync.**
+4. **Add/update tests** for any behaviour change. Tests mock `SungrowAuth` and
+   `Plants` (see `tests/conftest.py`).
+5. **Conventional Commits** for commits and PR titles.
+6. **`main` is protected** — work on a branch and open a PR. CI runs ruff
+   (lint + format), pytest with coverage, and HACS/hassfest validation.
+
+## Local checks (match CI)
+
+```bash
+ruff check custom_components/ tests/
+ruff format --check custom_components/ tests/
+pytest
+```
+
+Style: Python 3.12+/3.13, ruff line length 120. See `CLAUDE.md` for the full guide
+and `docs/TROUBLESHOOTING.md` for user-facing auth/setup guidance.

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,17 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    labels:
+      - "dependencies"
+      - "github-actions"
+
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    labels:
+      - "dependencies"
+      - "python"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,26 +43,21 @@ jobs:
                   git-user-email: "41898282+github-actions[bot]@users.noreply.github.com"
                   create-release: false
 
-            - name: Sync version to pyproject.toml
+            # NOTE: This job intentionally does NOT push commits to `main`.
+            # `main` is a protected branch (PRs + status checks required), so the
+            # version bump / CHANGELOG commit happens via the Release PR workflow
+            # (`release-pr.yml`). Here we only move a lightweight dev tag, which is
+            # not blocked by branch protection. This also avoids the self-retrigger
+            # loop a `chore(release)` commit pushed back to `main` would cause.
+            - name: Create dev tag
               if: steps.changelog.outputs.skipped != 'true'
               run: |
-                  VERSION="${{ steps.changelog.outputs.version }}"
-                  sed -i "s/^version = \".*\"/version = \"${VERSION}\"/" pyproject.toml
-                  echo "Updated pyproject.toml to version ${VERSION}"
-
-            - name: Commit and tag
-              if: steps.changelog.outputs.skipped != 'true'
-              run: |
-                  git config user.name "github-actions[bot]"
-                  git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-                  git add CHANGELOG.md custom_components/sungrow/manifest.json pyproject.toml
-                  git commit -m "chore(release): dev-v${{ steps.changelog.outputs.version }}"
-                  git tag "dev-v${{ steps.changelog.outputs.version }}"
-                  git push --follow-tags
+                  git tag -f "dev-v${{ steps.changelog.outputs.version }}"
+                  git push -f origin "dev-v${{ steps.changelog.outputs.version }}"
 
             - name: Show dev tag summary
               if: steps.changelog.outputs.skipped != 'true'
               run: |
                   echo "Dev Version: ${{ steps.changelog.outputs.version }}"
                   echo "Dev Tag: dev-v${{ steps.changelog.outputs.version }}"
-                  echo "Changelog file updated (commit not auto-pushed; awaiting PR approval)."
+                  echo "No commit pushed to main — releases are cut via release-pr.yml."

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,75 @@
+# CLAUDE.md
+
+Guidance for AI coding agents (Claude Code, etc.) working in this repository.
+
+## What this is
+
+A **Home Assistant custom integration** (`custom_components/sungrow`) that polls
+Sungrow inverters via the **iSolarCloud** cloud API, using the
+[`pysolarcloud`](https://pypi.org/project/pysolarcloud/) library. Distributed via
+HACS. `iot_class` is `cloud_polling`.
+
+## Architecture
+
+| File | Responsibility |
+| --- | --- |
+| `__init__.py` | Entry setup/unload. Builds `SungrowAuth` + `Plants`, creates one coordinator per plant, **persists rotated tokens back to the config entry**, classifies errors into `ConfigEntryNotReady` (transient) vs `ConfigEntryAuthFailed` (reauth). Registers the OAuth callback HTTP view. |
+| `auth.py` | `SungrowAuth(pysolarcloud.Auth)` — adds a `token_updater` callback that fires when the access token is refreshed (pysolarcloud rotates the refresh token in memory). `AUTH_ERRORS` lists upstream error codes that mean "credentials dead". |
+| `coordinator.py` | `SungrowPlantCoordinator(DataUpdateCoordinator)` — fetches realtime data per plant; reads the scan interval from `entry.options`; `is_auth_error()` maps exceptions to reauth vs retry. |
+| `config_flow.py` | User setup, **reauth** (`async_step_reauth`), and **options** (`SungrowOptionsFlow`, polling interval) flows. Sets a unique ID (App ID) to prevent duplicates. |
+| `sensor.py` | Builds `SungrowSensor` entities from the stored coordinators. `infer_device_class()` maps units → device/state class so the Energy dashboard works. |
+| `const.py` | Domain, config keys, `GATEWAYS`, scan-interval defaults. |
+
+### Critical invariant — token persistence
+
+`pysolarcloud.Auth.async_get_access_token()` refreshes the access token when it
+expires and **assigns a brand-new `tokens` dict containing a rotated refresh
+token**. If the new tokens are not written back to the config entry, the next
+Home Assistant restart reloads an invalidated refresh token and every entity goes
+unavailable (the historical bug behind issues #14/#15/#20/#21). The
+`token_updater` callback wired in `__init__.py.async_setup_entry` is what keeps
+this working — **do not remove it**, and keep `pysolarcloud` pinned in
+`manifest.json`.
+
+## Commands
+
+```bash
+# Environment (uv recommended; any Py3.13 venv works)
+uv venv --python 3.13 .venv
+uv pip install --python .venv -r requirements_test.txt
+
+# Lint, format, test (mirror CI)
+.venv/bin/ruff check custom_components/ tests/
+.venv/bin/ruff format --check custom_components/ tests/
+.venv/bin/python -m pytest tests/
+
+# Live tests (need real creds in .env; skipped otherwise)
+.venv/bin/python -m pytest -m live
+```
+
+Coverage threshold (`fail_under`) is set in `pyproject.toml`; keep it green.
+
+## Conventions
+
+- **Python 3.12+/3.13**, ruff (line length 120) for lint + format.
+- **Conventional Commits** for commit and PR titles (`fix:`, `feat:`, `chore:`,
+  `docs:`) — this drives changelog and version bumps.
+- Every behaviour change needs tests. Tests mock `pysolarcloud` (`SungrowAuth`,
+  `Plants`) — see `tests/conftest.py` fixtures (`mock_setup_auth`,
+  `mock_plants_service`, `mock_auth`).
+- `strings.json` and `translations/en.json` must stay in sync (a test enforces
+  the strings shape).
+
+## Workflow / repo rules
+
+- **`main` is protected**: open a feature branch and a PR; do not push to `main`.
+  Required checks: `lint`, `test`, `hacs_validate`. Re-apply rules with
+  `scripts/setup-branch-protection.sh`.
+- Releases are cut via `release-pr.yml` → merge → `publish-release.yml`.
+  `release.yml` only moves a lightweight `dev-v*` tag (it must **not** commit to
+  `main`).
+
+## User-facing docs
+
+`docs/TROUBLESHOOTING.md` is the first stop for auth/setup/"unavailable" reports;
+keep it current when changing the auth or setup flow.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,56 @@
+# Contributing
+
+Thanks for your interest in improving the Sungrow iSolarCloud integration!
+
+## Development setup
+
+This project targets Python 3.13 and Home Assistant's custom-component test
+harness. Using [uv](https://docs.astral.sh/uv/) is the quickest path:
+
+```bash
+uv venv --python 3.13 .venv
+uv pip install --python .venv -r requirements_test.txt
+```
+
+(Any virtualenv with `pip install -r requirements_test.txt` works too.)
+
+## Before you push
+
+Run the same checks CI runs:
+
+```bash
+.venv/bin/ruff check custom_components/
+.venv/bin/ruff format --check custom_components/
+.venv/bin/python -m pytest tests/
+```
+
+- Tests must pass and coverage must stay at or above the configured threshold
+  (`fail_under` in `pyproject.toml`).
+- Live tests (marked `live`) are skipped by default and require real iSolarCloud
+  credentials in a `.env` file (see `.env.example`).
+- A `.pre-commit-config.yaml` is provided; `pre-commit install` will run ruff on
+  commit.
+
+## Pull requests
+
+- Use **Conventional Commits** for PR titles and commits (`fix:`, `feat:`,
+  `chore:`, `docs:` …). This drives automated changelog and version bumps.
+- Keep changes focused; add or update tests for any behaviour change.
+- All PRs target `main` and must pass CI (lint, tests, HACS + hassfest validation)
+  and at least one review before merge.
+
+## Project layout
+
+| Path | Purpose |
+| --- | --- |
+| `custom_components/sungrow/__init__.py` | Entry setup, token persistence, error handling |
+| `custom_components/sungrow/auth.py` | Token-persisting `Auth` wrapper |
+| `custom_components/sungrow/coordinator.py` | Per-plant `DataUpdateCoordinator` |
+| `custom_components/sungrow/config_flow.py` | Config, reauth, and options flows |
+| `custom_components/sungrow/sensor.py` | Sensor entities + device-class inference |
+| `tests/` | Unit/integration tests |
+
+## Reporting issues
+
+Please use the issue templates and read
+[docs/TROUBLESHOOTING.md](docs/TROUBLESHOOTING.md) first.

--- a/README.md
+++ b/README.md
@@ -10,8 +10,10 @@ Custom component that integrates Sungrow inverters via the iSolarCloud API into 
 
 - **Cloud Polling** — fetches real-time data from the iSolarCloud API.
 - **Auto-Discovery** — automatically finds all plants linked to your account.
-- **Sensors** — creates sensors for every available data point (power, energy, battery SOC, etc.).
+- **Sensors** — creates sensors for every available data point (power, energy, battery SOC, etc.) with correct device/state classes for the Energy dashboard.
 - **Config Flow** — set up entirely through the Home Assistant UI.
+- **Token persistence & re-auth** — refreshed tokens are saved automatically, so entities stay available across restarts; if credentials expire you're prompted to re-authorize in place (no delete & re-add).
+- **Configurable polling interval** — tune how often data is fetched via the integration options.
 
 ## Installation
 
@@ -54,12 +56,29 @@ Or manually:
 
 Register an application on the [iSolarCloud Developer Platform](https://developer-api.isolarcloud.com/#/application) to get your App Key, App Secret, and App ID.
 
+> **Note:** New developer applications must be **approved by Sungrow** (and have **OAuth 2.0** enabled) before authorization will work — this can take up to a week.
+
+### Options
+
+After setup, go to **Settings → Devices & Services → Sungrow → Configure** to change the **polling interval** (default 5 minutes).
+
+## Troubleshooting
+
+Having trouble authorizing, or entities showing as *unavailable*? See the
+[Troubleshooting guide](docs/TROUBLESHOOTING.md) — it covers the common
+"Invalid authentication" / "Operation failed" setup errors and the
+unavailable-after-reboot problem.
+
 ## Development
+
+See [CONTRIBUTING.md](CONTRIBUTING.md) for full developer setup and guidelines.
 
 ### Running Tests
 
 ```bash
 pip install -r requirements_test.txt
+ruff check custom_components/
+ruff format --check custom_components/
 pytest
 ```
 

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -1,0 +1,92 @@
+# Troubleshooting
+
+This page covers the most common problems reported with the Sungrow iSolarCloud
+integration. Please read it before opening an issue.
+
+## Enable debug logging
+
+Add this to your `configuration.yaml`, restart Home Assistant, and reproduce the
+problem:
+
+```yaml
+logger:
+  default: info
+  logs:
+    custom_components.sungrow: debug
+    pysolarcloud: debug
+```
+
+When sharing logs, **redact your App Key, App Secret, and any tokens.**
+
+---
+
+## "Invalid authentication" / "Operation failed" during setup
+
+These are almost always caused by the App ID, redirect URI, or API approval, not
+by the integration itself.
+
+1. **Use only the numeric App ID.** In the iSolarCloud developer portal the
+   application URL looks like `.../editApplication?id=1234`. Enter **`1234`** in
+   the *App ID* field — not the whole URL.
+2. **Your API access must be approved by Sungrow.** New applications sit in
+   *pending approval* and authorization will fail until approved. This commonly
+   takes about a week. You cannot proceed before approval.
+3. **Enable OAuth 2.0** for your application in the developer portal.
+4. **The redirect URI must match exactly** in three places: the developer portal,
+   the value you enter in Home Assistant, and what gets used during the token
+   exchange. Scheme (`http`/`https`), host/IP, and path must all match.
+   - Local: `http://homeassistant.local:8123/api/sungrow_hass/callback`
+   - Nabu Casa: `https://<your-id>.ui.nabu.casa/api/sungrow_hass/callback`
+5. After agreeing to authorize you may land on a **404 page** — that's expected.
+   Copy the `code` value from the URL bar (or paste the whole URL; the integration
+   extracts the code for you).
+
+---
+
+## Entities go "unavailable" after restarting / updating Home Assistant
+
+**This is fixed in v0.3.0+.** Earlier versions did not persist the rotated
+refresh token, so after a restart the stored token was already invalid and every
+entity went unavailable — the only workaround was to delete and re-add the
+integration.
+
+As of v0.3.0:
+
+- Refreshed tokens are saved back to the config entry automatically, so they
+  survive restarts.
+- If the stored credentials ever do become invalid, Home Assistant shows a
+  **"Reconfigure"/reauth** prompt for the integration. Click it and re-authorize
+  — you no longer need to delete and re-add the integration or lose your entity
+  history.
+
+If you are on an older version, please update first.
+
+---
+
+## Sensors update too often / not often enough
+
+The default polling interval is **5 minutes**. You can change it:
+
+**Settings → Devices & Services → Sungrow → Configure → Polling interval.**
+
+iSolarCloud typically allows ~2000 API calls/hour, so very low intervals across
+many sensors can still be served, but a conservative interval is gentler on the
+API and your account.
+
+---
+
+## The Energy dashboard can't use my sensors
+
+v0.3.0+ infers `device_class` and `state_class` from each sensor's unit (energy,
+power, voltage, current, temperature, etc.). Energy sensors (`Wh`/`kWh`/`MWh`) are
+exposed with `device_class: energy` and `state_class: total_increasing`, which the
+Energy dashboard requires. If a specific sensor still isn't selectable, open an
+issue with the sensor's unit and the `code` shown in its attributes.
+
+---
+
+## Still stuck?
+
+Open a [bug report](https://github.com/KRoperUK/sungrow-hass/issues/new/choose)
+with your integration version, Home Assistant version, gateway region, and debug
+logs (tokens redacted).

--- a/scripts/setup-branch-protection.sh
+++ b/scripts/setup-branch-protection.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+#
+# Configure branch protection for the default branch.
+#
+# Requires the GitHub CLI (`gh`) authenticated as a repo admin.
+# Usage: scripts/setup-branch-protection.sh [owner/repo] [branch]
+#
+set -euo pipefail
+
+REPO="${1:-KRoperUK/sungrow-hass}"
+BRANCH="${2:-main}"
+
+echo "Applying branch protection to ${REPO}@${BRANCH}..."
+
+gh api \
+  --method PUT \
+  -H "Accept: application/vnd.github+json" \
+  "repos/${REPO}/branches/${BRANCH}/protection" \
+  --input - <<'JSON'
+{
+  "required_status_checks": {
+    "strict": true,
+    "contexts": ["lint", "test", "hacs_validate"]
+  },
+  "enforce_admins": false,
+  "required_pull_request_reviews": {
+    "dismiss_stale_reviews": true,
+    "require_code_owner_reviews": false,
+    "required_approving_review_count": 1
+  },
+  "restrictions": null,
+  "required_linear_history": true,
+  "allow_force_pushes": false,
+  "allow_deletions": false,
+  "required_conversation_resolution": true
+}
+JSON
+
+echo "Done. Current protection summary:"
+gh api "repos/${REPO}/branches/${BRANCH}/protection" \
+  --jq '{required_checks: .required_status_checks.contexts, strict: .required_status_checks.strict, reviews: .required_pull_request_reviews.required_approving_review_count, linear: .required_linear_history.enabled, force_pushes: .allow_force_pushes.enabled, deletions: .allow_deletions.enabled}'


### PR DESCRIPTION
## Summary

Repo-hygiene and documentation pass (first of two PRs). No runtime/integration code changes here — this lands docs, templates, and maintainer tooling so the follow-up **token-persistence & hardening** PR is easy to review and the project is easier to contribute to going forward.

### Docs
- **README**: troubleshooting + options sections, OAuth/approval note, links to CONTRIBUTING & TROUBLESHOOTING.
- **`docs/TROUBLESHOOTING.md`**: covers the recurring *"Invalid authentication" / "Operation failed"* setup errors and the *unavailable-after-reboot* problem (captures the fixes buried in issue threads).
- **`CONTRIBUTING.md`**: dev setup (uv), local checks, Conventional Commits, project layout.
- **`CLAUDE.md`** + **`.github/copilot-instructions.md`**: architecture/module map and must-follow rules for AI agents.

### Maintainer tooling
- `.github/CODEOWNERS`, `.github/dependabot.yml` (actions + pip, weekly).
- Issue forms (bug report / feature request) + `config.yml` routing to the troubleshooting guide & discussions.
- `.github/PULL_REQUEST_TEMPLATE.md`.
- `scripts/setup-branch-protection.sh` — reproducible `main` branch protection (already applied).
- `release.yml`: the dev-tag job is now **tag-only** so it doesn't push commits to the protected `main` (releases go through `release-pr.yml` → `publish-release.yml`).

> Note: the architecture documented in `CLAUDE.md` is implemented by the companion fix PR, which follows immediately.

## Type of change
- [x] Documentation / chore

## Checklist
- [x] YAML/templates validated
- [x] No integration code touched (CI lint/test unaffected)