### PR TITLE
fix: persist refreshed tokens and harden setup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,10 @@ on:
   pull_request:
     branches: [main]
 
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   lint:
     runs-on: ubuntu-latest
@@ -19,13 +23,13 @@ jobs:
 
       - name: Install dependencies
         run: |
-          pip install ruff
+          pip install ruff==0.15.16
 
       - name: Lint with ruff
-        run: ruff check custom_components/
+        run: ruff check custom_components/ tests/
 
       - name: Check formatting
-        run: ruff format --check custom_components/
+        run: ruff format --check custom_components/ tests/
 
   test:
     runs-on: ubuntu-latest

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.3.4
+    rev: v0.15.16
     hooks:
       - id: ruff
         args: [--fix, --exit-non-zero-on-fix]

--- a/custom_components/sungrow/__init__.py
+++ b/custom_components/sungrow/__init__.py
@@ -10,13 +10,25 @@ from homeassistant.components.http import HomeAssistantView
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import ConfigEntryAuthFailed, ConfigEntryNotReady
+from homeassistant.helpers.aiohttp_client import async_get_clientsession
+from pysolarcloud.plants import Plants
 
-from .const import DOMAIN
+from .auth import SungrowAuth
+from .const import (
+    CONF_APP_ID,
+    CONF_APP_KEY,
+    CONF_APP_SECRET,
+    CONF_GATEWAY,
+    DEFAULT_HOST,
+    DOMAIN,
+    GATEWAYS,
+)
+from .coordinator import SungrowPlantCoordinator, is_auth_error
 
-# TODO List the platforms that you want to support.
-# For your initial example we don't have sensors yet but usually:
-# PLATFORMS: list[Platform] = [Platform.SENSOR]
 PLATFORMS: list[Platform] = [Platform.SENSOR]
+
+_LOGGER = logging.getLogger(__name__)
 
 
 class IterableSchema(vol.Schema):
@@ -34,8 +46,6 @@ class IterableSchema(vol.Schema):
 # Workaround for HA 2025.2+ treating the schema function/object as the config dict
 CONFIG_SCHEMA = IterableSchema({}, extra=vol.ALLOW_EXTRA)
 
-_LOGGER = logging.getLogger(__name__)
-
 
 async def async_setup(hass: HomeAssistant, config: dict) -> bool:
     """Set up the Sungrow iSolarCloud component."""
@@ -45,13 +55,52 @@ async def async_setup(hass: HomeAssistant, config: dict) -> bool:
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up Sungrow iSolarCloud from a config entry."""
+    if "tokens" not in entry.data:
+        # Nothing to authenticate with — ask the user to re-authorize.
+        raise ConfigEntryAuthFailed("No stored tokens; re-authorization required")
 
-    # TODO: Initialize the API client here using entry.data
-    # For now, just store the config so we know it's loaded
-    hass.data.setdefault(DOMAIN, {})
-    hass.data[DOMAIN][entry.entry_id] = entry.data
+    session = async_get_clientsession(hass)
+    host = GATEWAYS.get(entry.data[CONF_GATEWAY], DEFAULT_HOST)
+
+    def _save_tokens(tokens: dict) -> None:
+        """Persist refreshed/rotated tokens back to the config entry."""
+        hass.config_entries.async_update_entry(entry, data={**entry.data, "tokens": tokens})
+
+    auth = SungrowAuth(
+        host=host,
+        appkey=entry.data[CONF_APP_KEY],
+        access_key=entry.data[CONF_APP_SECRET],
+        app_id=entry.data[CONF_APP_ID],
+        websession=session,
+        token_updater=_save_tokens,
+    )
+    # Restore previously stored tokens (a copy so we never mutate entry.data in place).
+    auth.tokens = dict(entry.data["tokens"])
+
+    plants_service = Plants(auth)
+
+    try:
+        plant_list = await plants_service.async_get_plants()
+    except Exception as err:
+        if is_auth_error(err):
+            raise ConfigEntryAuthFailed(f"Authentication with iSolarCloud failed: {err}") from err
+        raise ConfigEntryNotReady(f"Unable to fetch plants from iSolarCloud: {err}") from err
+
+    coordinators: list[SungrowPlantCoordinator] = []
+    for plant_info in plant_list:
+        plant_id = str(plant_info["ps_id"])
+        plant_name = plant_info["ps_name"]
+        coordinator = SungrowPlantCoordinator(hass, entry, plants_service, plant_id, plant_name)
+        # Raises ConfigEntryNotReady / ConfigEntryAuthFailed as classified by the coordinator.
+        await coordinator.async_config_entry_first_refresh()
+        coordinators.append(coordinator)
+
+    hass.data.setdefault(DOMAIN, {})[entry.entry_id] = coordinators
 
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
+
+    # Reload the entry when its options (e.g. scan interval) change.
+    entry.async_on_unload(entry.add_update_listener(async_reload_entry))
 
     return True
 
@@ -62,6 +111,11 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         hass.data[DOMAIN].pop(entry.entry_id)
 
     return unload_ok
+
+
+async def async_reload_entry(hass: HomeAssistant, entry: ConfigEntry) -> None:
+    """Reload the config entry when its options change."""
+    await hass.config_entries.async_reload(entry.entry_id)
 
 
 class SungrowAuthCallbackView(HomeAssistantView):

--- a/custom_components/sungrow/auth.py
+++ b/custom_components/sungrow/auth.py
@@ -1,0 +1,58 @@
+"""Authentication helpers for the Sungrow iSolarCloud integration.
+
+The upstream :class:`pysolarcloud.Auth` client refreshes the access token when it
+expires and, in doing so, *rotates* the refresh token (iSolarCloud invalidates the
+previous one and returns a brand new ``tokens`` dict held only in memory).
+
+The integration must persist those rotated tokens back to the config entry,
+otherwise after a Home Assistant restart it would reload the now-invalid refresh
+token, the refresh would fail, and every entity would become unavailable until the
+user deleted and re-added the integration. This module wires a callback into the
+refresh path so the latest tokens are always saved.
+"""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Callable
+
+from pysolarcloud import Auth
+
+_LOGGER = logging.getLogger(__name__)
+
+# Errors raised by pysolarcloud that indicate the stored credentials/tokens are no
+# longer usable and the user must re-authorize (as opposed to a transient outage).
+AUTH_ERRORS = frozenset({"auth_not_initialised", "invalid_grant", "invalid_token"})
+
+
+class SungrowAuth(Auth):
+    """``pysolarcloud.Auth`` that persists rotated tokens via a callback.
+
+    ``token_updater`` is invoked with the new ``tokens`` dict whenever the upstream
+    client refreshes them, allowing the caller to write them back to the config
+    entry so they survive a restart.
+    """
+
+    def __init__(
+        self,
+        *args,
+        token_updater: Callable[[dict], None] | None = None,
+        **kwargs,
+    ) -> None:
+        """Initialize the auth client with an optional token-persistence callback."""
+        super().__init__(*args, **kwargs)
+        self._token_updater = token_updater
+
+    async def async_get_access_token(self) -> str:
+        """Return a valid access token, persisting any refreshed tokens.
+
+        pysolarcloud assigns a *new* ``tokens`` dict when it refreshes, so an
+        identity comparison reliably detects a rotation without persisting on every
+        call.
+        """
+        previous = self.tokens
+        token = await super().async_get_access_token()
+        if self._token_updater is not None and self.tokens is not previous:
+            _LOGGER.debug("Access token refreshed; persisting rotated tokens")
+            self._token_updater(self.tokens)
+        return token

--- a/custom_components/sungrow/config_flow.py
+++ b/custom_components/sungrow/config_flow.py
@@ -5,7 +5,9 @@ from typing import Any
 
 import voluptuous as vol
 from aiohttp import ClientError
-from homeassistant import config_entries
+from homeassistant import config_entries, data_entry_flow
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import callback
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.network import get_url
 
@@ -15,8 +17,12 @@ from .const import (
     CONF_APP_SECRET,
     CONF_GATEWAY,
     CONF_REDIRECT_URI,
+    CONF_SCAN_INTERVAL,
+    DEFAULT_SCAN_INTERVAL,
     DOMAIN,
     GATEWAYS,
+    MAX_SCAN_INTERVAL,
+    MIN_SCAN_INTERVAL,
 )
 
 # Try to import pysolarcloud, handle if missing gracefully for development
@@ -39,6 +45,24 @@ class SungrowConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         """Initialize the config flow."""
         self.init_info = {}
         self.auth_client = None
+        self._reauth_entry: ConfigEntry | None = None
+
+    @staticmethod
+    @callback
+    def async_get_options_flow(config_entry: ConfigEntry) -> "SungrowOptionsFlow":
+        """Return the options flow handler."""
+        return SungrowOptionsFlow()
+
+    async def async_step_reauth(self, entry_data: dict[str, Any]):
+        """Handle re-authentication when the stored tokens are no longer valid."""
+        self._reauth_entry = self.hass.config_entries.async_get_entry(self.context["entry_id"])
+        # Reuse the credentials already stored on the entry; only the tokens are stale.
+        self.init_info = {k: v for k, v in entry_data.items() if k != "tokens"}
+        return await self.async_step_reauth_confirm()
+
+    async def async_step_reauth_confirm(self, user_input: dict[str, Any] | None = None):
+        """Confirm re-authentication by re-running the authorization step."""
+        return await self.async_step_auth(user_input)
 
     async def async_step_user(self, user_input: dict[str, Any] | None = None):
         """Handle the initial step."""
@@ -149,8 +173,18 @@ class SungrowConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                     # We can store tokens in the config entry data
                     data = {**self.init_info, "tokens": tokens}
 
+                    if self._reauth_entry is not None:
+                        # Update the existing entry in place and reload it, so the user
+                        # never has to delete and re-add the integration (issue #14).
+                        return self.async_update_reload_and_abort(self._reauth_entry, data=data)
+
+                    await self.async_set_unique_id(str(self.init_info[CONF_APP_ID]))
+                    self._abort_if_unique_id_configured()
                     return self.async_create_entry(title=f"Sungrow {self.init_info[CONF_APP_ID]}", data=data)
 
+            except data_entry_flow.AbortFlow:
+                # Let HA handle flow aborts (e.g. already_configured) normally.
+                raise
             except ClientError as e:
                 _LOGGER.warning("Client connection error in async_step_auth: %s", e)
                 errors["base"] = "cannot_connect"
@@ -169,4 +203,26 @@ class SungrowConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             description_placeholders={"auth_url": auth_url},
             data_schema=vol.Schema({vol.Optional("code"): str}),
             errors=errors,
+        )
+
+
+class SungrowOptionsFlow(config_entries.OptionsFlow):
+    """Handle Sungrow integration options (e.g. polling interval)."""
+
+    async def async_step_init(self, user_input: dict[str, Any] | None = None):
+        """Manage the integration options."""
+        if user_input is not None:
+            return self.async_create_entry(title="", data=user_input)
+
+        current = self.config_entry.options.get(CONF_SCAN_INTERVAL, DEFAULT_SCAN_INTERVAL)
+        return self.async_show_form(
+            step_id="init",
+            data_schema=vol.Schema(
+                {
+                    vol.Required(CONF_SCAN_INTERVAL, default=current): vol.All(
+                        vol.Coerce(int),
+                        vol.Range(min=MIN_SCAN_INTERVAL, max=MAX_SCAN_INTERVAL),
+                    )
+                }
+            ),
         )

--- a/custom_components/sungrow/const.py
+++ b/custom_components/sungrow/const.py
@@ -10,9 +10,20 @@ CONF_REDIRECT_URI = "redirect_uri"
 CONF_USERNAME = "username"
 CONF_PASSWORD = "password"
 
+# Options
+CONF_SCAN_INTERVAL = "scan_interval"
+
 GATEWAYS = {
     "Europe": "https://gateway.isolarcloud.eu",
     "International": "https://gateway.isolarcloud.com.hk",
     "China": "https://gateway.isolarcloud.com",
     "Australia": "https://augateway.isolarcloud.com",
 }
+
+DEFAULT_HOST = GATEWAYS["Europe"]
+
+# Polling interval (minutes). iSolarCloud allows ~2000 calls/hour, so the default
+# is deliberately conservative; users can tune it via the integration options.
+DEFAULT_SCAN_INTERVAL = 5
+MIN_SCAN_INTERVAL = 1
+MAX_SCAN_INTERVAL = 1440

--- a/custom_components/sungrow/coordinator.py
+++ b/custom_components/sungrow/coordinator.py
@@ -1,0 +1,69 @@
+"""Data update coordinator for the Sungrow iSolarCloud integration."""
+
+from __future__ import annotations
+
+import logging
+from datetime import timedelta
+
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import ConfigEntryAuthFailed
+from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
+from pysolarcloud import PySolarCloudException
+from pysolarcloud.plants import Plants
+
+from .auth import AUTH_ERRORS
+from .const import CONF_SCAN_INTERVAL, DEFAULT_SCAN_INTERVAL
+
+_LOGGER = logging.getLogger(__name__)
+
+
+def is_auth_error(err: Exception) -> bool:
+    """Return True if the error means the stored credentials are no longer valid.
+
+    A failed token refresh surfaces as a ``KeyError`` from pysolarcloud (the refresh
+    response has no ``access_token``), while explicit auth problems raise
+    ``PySolarCloudException`` with a known error code. Both require the user to
+    re-authorize rather than waiting for a transient outage to clear.
+    """
+    if isinstance(err, KeyError):
+        return True
+    return isinstance(err, PySolarCloudException) and err.error in AUTH_ERRORS
+
+
+class SungrowPlantCoordinator(DataUpdateCoordinator):
+    """Coordinator to manage fetching data from a single plant."""
+
+    def __init__(
+        self,
+        hass: HomeAssistant,
+        config_entry: ConfigEntry,
+        plants_service: Plants,
+        plant_id: str,
+        plant_name: str,
+    ) -> None:
+        """Initialize the coordinator."""
+        scan_minutes = config_entry.options.get(CONF_SCAN_INTERVAL, DEFAULT_SCAN_INTERVAL)
+        super().__init__(
+            hass,
+            _LOGGER,
+            name=f"Sungrow Plant {plant_name}",
+            update_interval=timedelta(minutes=scan_minutes),
+            config_entry=config_entry,
+        )
+        self.plants_service = plants_service
+        self.plant_id = plant_id
+        self.plant_name = plant_name
+
+    async def _async_update_data(self):
+        """Fetch data from the API for this plant."""
+        try:
+            # async_get_realtime_data returns a dict of plants keyed by plant_id:
+            # { "123": { "code1": {...}, "code2": {...} } }
+            all_plants_data = await self.plants_service.async_get_realtime_data([self.plant_id])
+        except Exception as err:
+            if is_auth_error(err):
+                raise ConfigEntryAuthFailed(f"Authentication with iSolarCloud failed: {err}") from err
+            raise UpdateFailed(f"Error communicating with iSolarCloud API: {err}") from err
+
+        return all_plants_data.get(self.plant_id, {})

--- a/custom_components/sungrow/manifest.json
+++ b/custom_components/sungrow/manifest.json
@@ -1,7 +1,9 @@
 {
   "domain": "sungrow",
   "name": "Sungrow iSolarCloud",
-  "codeowners": [],
+  "codeowners": [
+    "@KRoperUK"
+  ],
   "config_flow": true,
   "dependencies": [
     "http"
@@ -10,7 +12,7 @@
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/KRoperUK/sungrow-hass/issues",
   "requirements": [
-    "pysolarcloud"
+    "pysolarcloud==0.4.0"
   ],
   "version": "0.2.2"
 }

--- a/custom_components/sungrow/sensor.py
+++ b/custom_components/sungrow/sensor.py
@@ -1,122 +1,103 @@
 from __future__ import annotations
 
 import logging
-from datetime import timedelta
 
 from homeassistant.components.sensor import SensorDeviceClass, SensorEntity, SensorStateClass
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.device_registry import DeviceEntryType
 from homeassistant.helpers.entity import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
-from homeassistant.helpers.update_coordinator import (
-    CoordinatorEntity,
-    DataUpdateCoordinator,
-    UpdateFailed,
-)
-from pysolarcloud import Auth
-from pysolarcloud.plants import Plants
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
-from .const import (
-    CONF_APP_ID,
-    CONF_APP_KEY,
-    CONF_APP_SECRET,
-    CONF_GATEWAY,
-    DOMAIN,
-    GATEWAYS,
-)
+from .const import DOMAIN
+from .coordinator import SungrowPlantCoordinator
 
 _LOGGER = logging.getLogger(__name__)
 
-SCAN_INTERVAL = timedelta(minutes=5)
+# Map a (lower-cased) unit of measurement to the appropriate device and state class.
+# Energy uses TOTAL_INCREASING so cumulative counters (and daily counters that reset)
+# are accepted by the Home Assistant Energy dashboard. See issue #19.
+MEASUREMENT = SensorStateClass.MEASUREMENT
+TOTAL_INCREASING = SensorStateClass.TOTAL_INCREASING
+
+_UNIT_CLASS_MAP: dict[str, tuple[SensorDeviceClass, SensorStateClass]] = {
+    # Power
+    "w": (SensorDeviceClass.POWER, MEASUREMENT),
+    "kw": (SensorDeviceClass.POWER, MEASUREMENT),
+    "mw": (SensorDeviceClass.POWER, MEASUREMENT),
+    "gw": (SensorDeviceClass.POWER, MEASUREMENT),
+    # Energy
+    "wh": (SensorDeviceClass.ENERGY, TOTAL_INCREASING),
+    "kwh": (SensorDeviceClass.ENERGY, TOTAL_INCREASING),
+    "mwh": (SensorDeviceClass.ENERGY, TOTAL_INCREASING),
+    "gwh": (SensorDeviceClass.ENERGY, TOTAL_INCREASING),
+    # Voltage
+    "v": (SensorDeviceClass.VOLTAGE, MEASUREMENT),
+    "mv": (SensorDeviceClass.VOLTAGE, MEASUREMENT),
+    "kv": (SensorDeviceClass.VOLTAGE, MEASUREMENT),
+    # Current
+    "a": (SensorDeviceClass.CURRENT, MEASUREMENT),
+    "ma": (SensorDeviceClass.CURRENT, MEASUREMENT),
+    # Frequency
+    "hz": (SensorDeviceClass.FREQUENCY, MEASUREMENT),
+    # Temperature
+    "°c": (SensorDeviceClass.TEMPERATURE, MEASUREMENT),
+    "℃": (SensorDeviceClass.TEMPERATURE, MEASUREMENT),
+    "c": (SensorDeviceClass.TEMPERATURE, MEASUREMENT),
+    "°f": (SensorDeviceClass.TEMPERATURE, MEASUREMENT),
+    # Reactive / apparent power
+    "var": (SensorDeviceClass.REACTIVE_POWER, MEASUREMENT),
+    "kvar": (SensorDeviceClass.REACTIVE_POWER, MEASUREMENT),
+    "va": (SensorDeviceClass.APPARENT_POWER, MEASUREMENT),
+    "kva": (SensorDeviceClass.APPARENT_POWER, MEASUREMENT),
+}
+
+# Units that need the entity code inspected to disambiguate the device class.
+_PERCENT_BATTERY_HINTS = ("soc", "battery", "capacity", "charge")
+
+
+def infer_device_class(unit: str | None, point_code: str) -> tuple[SensorDeviceClass | None, SensorStateClass | None]:
+    """Infer a device class and state class from a unit of measurement.
+
+    Returns ``(None, None)`` when the unit is unknown so the sensor is still created
+    as a plain numeric/text sensor.
+    """
+    if not unit:
+        return None, None
+
+    key = unit.strip().lower()
+
+    if key in _UNIT_CLASS_MAP:
+        return _UNIT_CLASS_MAP[key]
+
+    if key in ("%", "percent"):
+        code = point_code.lower()
+        if any(hint in code for hint in _PERCENT_BATTERY_HINTS):
+            return SensorDeviceClass.BATTERY, MEASUREMENT
+        # Generic percentage (e.g. efficiency) — measurement only.
+        return None, MEASUREMENT
+
+    return None, None
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry, async_add_entities: AddEntitiesCallback) -> None:
-    """Set up Sungrow sensor based on a config entry."""
+    """Set up Sungrow sensors from the coordinators created during entry setup."""
+    coordinators: list[SungrowPlantCoordinator] = hass.data[DOMAIN][entry.entry_id]
 
-    # helper to get gateway URL
-    gateway_key = entry.data[CONF_GATEWAY]
-    host = GATEWAYS.get(gateway_key, "https://gateway.isolarcloud.eu")  # Fallback to EU if mapping fails
-
-    # Reconstruct Auth
-    session = async_get_clientsession(hass)
-    auth = Auth(
-        host=host,
-        appkey=entry.data[CONF_APP_KEY],
-        access_key=entry.data[CONF_APP_SECRET],
-        app_id=entry.data[CONF_APP_ID],
-        websession=session,
-    )
-
-    # Restore tokens
-    if "tokens" in entry.data:
-        auth.tokens = entry.data["tokens"]
-    else:
-        _LOGGER.error("No tokens found in config entry")
-        return
-
-    plants_service = Plants(auth)
-
-    # Fetch plants
-    try:
-        plant_list = await plants_service.async_get_plants()
-    except Exception as err:
-        _LOGGER.error("Failed to fetch plants: %s", err)
-        return
-
-    entities = []
-
-    for plant_info in plant_list:
-        plant_id = str(plant_info["ps_id"])
-        plant_name = plant_info["ps_name"]
-
-        _LOGGER.debug(f"Setting up plant: {plant_name} ({plant_id})")
-
-        coordinator = SungrowPlantCoordinator(hass, entry, plants_service, plant_id, plant_name)
-
-        # Determine available sensors by doing a first refresh
-        await coordinator.async_config_entry_first_refresh()
-
+    entities: list[SungrowSensor] = []
+    for coordinator in coordinators:
         if not coordinator.data:
-            _LOGGER.warning(f"No data received for plant {plant_name}")
+            _LOGGER.warning("No data received for plant %s", coordinator.plant_name)
             continue
 
-        # Create a sensor for each data point returned by the API
-        # The data structure is { "P_CODE": { "code": "...", "value": ..., "unit": "...", "name": "..." } }
+        # The data structure is { "P_CODE": { "code": ..., "value": ..., "unit": ..., "name": ... } }
         for point_code, point_data in coordinator.data.items():
-            entities.append(SungrowSensor(coordinator, point_code, plant_id, plant_name, point_data, entry.entry_id))
+            entities.append(
+                SungrowSensor(coordinator, point_code, coordinator.plant_id, coordinator.plant_name, point_data)
+            )
 
     async_add_entities(entities)
-
-
-class SungrowPlantCoordinator(DataUpdateCoordinator):
-    """Coordinator to manage fetching data from single plant."""
-
-    def __init__(self, hass, config_entry, plants_service, plant_id, plant_name):
-        """Initialize."""
-        super().__init__(
-            hass,
-            _LOGGER,
-            name=f"Sungrow Plant {plant_name}",
-            update_interval=SCAN_INTERVAL,
-            config_entry=config_entry,
-        )
-        self.plants_service = plants_service
-        self.plant_id = plant_id
-
-    async def _async_update_data(self):
-        """Fetch data from API."""
-        try:
-            # async_get_realtime_data returns a dict of plants, keyed by plant_id
-            # { "123": { "code1": {...}, "code2": {...} } }
-            all_plants_data = await self.plants_service.async_get_realtime_data([self.plant_id])
-
-            if self.plant_id in all_plants_data:
-                return all_plants_data[self.plant_id]
-            return {}
-        except Exception as err:
-            raise UpdateFailed(f"Error communicating with API: {err}") from err
 
 
 class SungrowSensor(CoordinatorEntity, SensorEntity):
@@ -124,7 +105,7 @@ class SungrowSensor(CoordinatorEntity, SensorEntity):
 
     has_entity_name = True
 
-    def __init__(self, coordinator, point_code, plant_id, plant_name, init_data, entry_id):
+    def __init__(self, coordinator, point_code, plant_id, plant_name, init_data):
         """Initialize the sensor."""
         super().__init__(coordinator)
         self.point_code = point_code
@@ -141,7 +122,7 @@ class SungrowSensor(CoordinatorEntity, SensorEntity):
 
         # With has_entity_name = True, HA prefixes the device name automatically
         self._attr_name = sensor_name
-        _LOGGER.debug(f"Created sensor: {plant_name} {sensor_name} (code: {point_code})")
+        _LOGGER.debug("Created sensor: %s %s (code: %s)", plant_name, sensor_name, point_code)
         self._attr_unique_id = f"{plant_id}_{point_code}"
         self._attr_icon = "mdi:solar-power-variant"
 
@@ -160,16 +141,12 @@ class SungrowSensor(CoordinatorEntity, SensorEntity):
         if initial_value is None or str(initial_value).strip() == "" or str(initial_value).lower() == "unknown":
             self._attr_entity_registry_enabled_default = False
 
-        # Attempt to infer device class and unit
+        # Infer device class / state class / unit so the Energy dashboard and history
+        # graphs work out of the box (issue #19).
         self._attr_native_unit_of_measurement = init_data.get("unit")
-
-        # Simple inference for Power/Energy
-        if self._attr_native_unit_of_measurement in ["kW", "W"]:
-            self._attr_device_class = SensorDeviceClass.POWER
-            self._attr_state_class = SensorStateClass.MEASUREMENT
-        elif self._attr_native_unit_of_measurement in ["Wh", "kWh", "MWh"]:
-            self._attr_device_class = SensorDeviceClass.ENERGY
-            self._attr_state_class = SensorStateClass.TOTAL_INCREASING
+        device_class, state_class = infer_device_class(init_data.get("unit"), point_code)
+        self._attr_device_class = device_class
+        self._attr_state_class = state_class
 
     @property
     def native_value(self):

--- a/custom_components/sungrow/strings.json
+++ b/custom_components/sungrow/strings.json
@@ -32,7 +32,19 @@
       "unknown": "Unexpected error"
     },
     "abort": {
-      "already_configured": "Device is already configured"
+      "already_configured": "Device is already configured",
+      "reauth_successful": "Re-authentication was successful"
+    }
+  },
+  "options": {
+    "step": {
+      "init": {
+        "title": "Sungrow Options",
+        "description": "Adjust how often Home Assistant polls iSolarCloud. Lower values update more frequently but use more of your API quota.",
+        "data": {
+          "scan_interval": "Polling interval (minutes)"
+        }
+      }
     }
   }
 }

--- a/custom_components/sungrow/translations/en.json
+++ b/custom_components/sungrow/translations/en.json
@@ -32,7 +32,19 @@
       "unknown": "Unexpected error"
     },
     "abort": {
-      "already_configured": "Device is already configured"
+      "already_configured": "Device is already configured",
+      "reauth_successful": "Re-authentication was successful"
+    }
+  },
+  "options": {
+    "step": {
+      "init": {
+        "title": "Sungrow Options",
+        "description": "Adjust how often Home Assistant polls iSolarCloud. Lower values update more frequently but use more of your API quota.",
+        "data": {
+          "scan_interval": "Polling interval (minutes)"
+        }
+      }
     }
   }
 }

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -9,4 +9,4 @@ python-dotenv
 ruff
 
 # Component dependencies
-pysolarcloud
+pysolarcloud==0.4.0

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -180,8 +180,8 @@ def mock_auth_no_tokens(mock_auth):
 
 @pytest.fixture
 def mock_plants_service():
-    """Create a mock Plants service."""
-    with patch("custom_components.sungrow.sensor.Plants") as mock_plants_cls:
+    """Mock the Plants service used during entry setup (patches __init__ module)."""
+    with patch("custom_components.sungrow.Plants") as mock_plants_cls:
         plants_instance = MagicMock()
         plants_instance.async_get_plants = AsyncMock(return_value=MOCK_PLANT_LIST)
         plants_instance.async_get_realtime_data = AsyncMock(return_value=MOCK_REALTIME_DATA)
@@ -190,11 +190,14 @@ def mock_plants_service():
 
 
 @pytest.fixture
-def mock_sensor_auth():
-    """Create a mock Auth instance for sensor setup (patches sensor module)."""
-    with patch("custom_components.sungrow.sensor.Auth") as mock_auth_cls:
+def mock_setup_auth():
+    """Mock the SungrowAuth client used during entry setup, plus the HTTP session."""
+    with (
+        patch("custom_components.sungrow.SungrowAuth") as mock_auth_cls,
+        patch("custom_components.sungrow.async_get_clientsession", return_value=MagicMock()),
+    ):
         auth_instance = MagicMock()
-        auth_instance.tokens = MOCK_CONFIG_DATA["tokens"]
+        auth_instance.tokens = dict(MOCK_CONFIG_DATA["tokens"])
         mock_auth_cls.return_value = auth_instance
         yield auth_instance
 

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -1,0 +1,68 @@
+"""Tests for the token-persisting SungrowAuth wrapper."""
+
+from unittest.mock import MagicMock, patch
+
+import pysolarcloud
+
+from custom_components.sungrow.auth import SungrowAuth
+
+
+def _make_auth(token_updater=None) -> SungrowAuth:
+    """Create a SungrowAuth with a mocked websession (no real network)."""
+    return SungrowAuth(
+        host="https://gateway.isolarcloud.eu",
+        appkey="key",
+        access_key="secret",
+        app_id="1234",
+        websession=MagicMock(),
+        token_updater=token_updater,
+    )
+
+
+async def test_token_updater_called_when_tokens_rotate():
+    """When pysolarcloud refreshes (assigns a new tokens dict), the updater fires."""
+    saved = []
+    auth = _make_auth(token_updater=saved.append)
+    auth.tokens = {"access_token": "old", "refresh_token": "r1", "expires_at": 0}
+
+    new_tokens = {"access_token": "new", "refresh_token": "r2", "expires_at": 9999999999}
+
+    async def fake_parent(self):
+        self.tokens = new_tokens
+        return "new"
+
+    with patch.object(pysolarcloud.Auth, "async_get_access_token", fake_parent):
+        token = await auth.async_get_access_token()
+
+    assert token == "new"
+    assert saved == [new_tokens]
+
+
+async def test_token_updater_not_called_without_rotation():
+    """If the token is still valid (no new dict assigned), nothing is persisted."""
+    saved = []
+    auth = _make_auth(token_updater=saved.append)
+    auth.tokens = {"access_token": "tok", "refresh_token": "r1", "expires_at": 9999999999}
+
+    async def fake_parent(self):
+        # Token still valid — pysolarcloud returns it without reassigning self.tokens.
+        return self.tokens["access_token"]
+
+    with patch.object(pysolarcloud.Auth, "async_get_access_token", fake_parent):
+        token = await auth.async_get_access_token()
+
+    assert token == "tok"
+    assert saved == []
+
+
+async def test_no_updater_is_safe():
+    """A missing token_updater must not raise even when tokens rotate."""
+    auth = _make_auth(token_updater=None)
+    auth.tokens = {"access_token": "old", "expires_at": 0}
+
+    async def fake_parent(self):
+        self.tokens = {"access_token": "new", "expires_at": 9999999999}
+        return "new"
+
+    with patch.object(pysolarcloud.Auth, "async_get_access_token", fake_parent):
+        assert await auth.async_get_access_token() == "new"

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -6,14 +6,16 @@ import pytest
 from aiohttp import ClientError
 from homeassistant import config_entries, data_entry_flow
 from homeassistant.core import HomeAssistant
+from pytest_homeassistant_custom_component.common import MockConfigEntry
 
 from custom_components.sungrow.const import (
     CONF_APP_ID,
     CONF_APP_KEY,
+    CONF_SCAN_INTERVAL,
     DOMAIN,
 )
 
-from .conftest import MOCK_USER_INPUT
+from .conftest import MOCK_CONFIG_DATA, MOCK_USER_INPUT
 
 
 @pytest.fixture(autouse=True)
@@ -239,3 +241,71 @@ async def test_auth_step_url_without_code_anywhere(hass: HomeAssistant, mock_aut
 
     assert result3["type"] == data_entry_flow.FlowResultType.FORM
     assert result3["errors"]["base"] == "unknown"
+
+
+# ---------------------------------------------------------------------------
+# Duplicate prevention (unique_id)
+# ---------------------------------------------------------------------------
+
+
+async def test_user_step_aborts_if_already_configured(hass: HomeAssistant, mock_auth):
+    """Adding the same App ID twice aborts as already_configured."""
+    existing = MockConfigEntry(domain=DOMAIN, data=MOCK_CONFIG_DATA.copy(), unique_id="test_app_id")
+    existing.add_to_hass(hass)
+
+    result = await hass.config_entries.flow.async_init(DOMAIN, context={"source": config_entries.SOURCE_USER})
+    await hass.config_entries.flow.async_configure(result["flow_id"], user_input=MOCK_USER_INPUT)
+    result3 = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        user_input={"code": "auth_code_from_provider"},
+    )
+
+    assert result3["type"] == data_entry_flow.FlowResultType.ABORT
+    assert result3["reason"] == "already_configured"
+
+
+# ---------------------------------------------------------------------------
+# Reauth flow
+# ---------------------------------------------------------------------------
+
+
+async def test_reauth_flow_updates_entry(hass: HomeAssistant, mock_auth, mock_setup_auth, mock_plants_service):
+    """Reauth re-runs authorization and updates the existing entry in place (#14)."""
+    entry = MockConfigEntry(domain=DOMAIN, data=MOCK_CONFIG_DATA.copy(), unique_id="test_app_id")
+    entry.add_to_hass(hass)
+
+    result = await entry.start_reauth_flow(hass)
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
+    assert result["step_id"] == "auth"
+
+    # Provide a fresh authorization code.
+    mock_auth.tokens = {"access_token": "fresh_token", "refresh_token": "fresh_refresh", "expires_at": 9999999999}
+    result2 = await hass.config_entries.flow.async_configure(result["flow_id"], user_input={"code": "fresh_code"})
+    await hass.async_block_till_done()
+
+    assert result2["type"] == data_entry_flow.FlowResultType.ABORT
+    assert result2["reason"] == "reauth_successful"
+    assert entry.data["tokens"]["access_token"] == "fresh_token"
+
+
+# ---------------------------------------------------------------------------
+# Options flow
+# ---------------------------------------------------------------------------
+
+
+async def test_options_flow_sets_scan_interval(hass: HomeAssistant, mock_setup_auth, mock_plants_service):
+    """The options flow stores a custom polling interval (#21)."""
+    entry = MockConfigEntry(domain=DOMAIN, data=MOCK_CONFIG_DATA.copy(), unique_id="test_app_id")
+    entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+
+    result = await hass.config_entries.options.async_init(entry.entry_id)
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
+    assert result["step_id"] == "init"
+
+    result2 = await hass.config_entries.options.async_configure(result["flow_id"], user_input={CONF_SCAN_INTERVAL: 10})
+    await hass.async_block_till_done()
+
+    assert result2["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
+    assert entry.options[CONF_SCAN_INTERVAL] == 10

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -1,0 +1,105 @@
+"""Tests for the Sungrow data update coordinator."""
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import ConfigEntryAuthFailed
+from homeassistant.helpers.update_coordinator import UpdateFailed
+from pysolarcloud import PySolarCloudException
+
+from custom_components.sungrow.const import CONF_SCAN_INTERVAL
+from custom_components.sungrow.coordinator import SungrowPlantCoordinator, is_auth_error
+
+from .conftest import MOCK_REALTIME_DATA
+
+
+def _make_entry(options=None):
+    entry = MagicMock()
+    entry.options = options or {}
+    return entry
+
+
+# ---------------------------------------------------------------------------
+# is_auth_error
+# ---------------------------------------------------------------------------
+
+
+def test_is_auth_error_keyerror():
+    """A KeyError (failed refresh) is treated as an auth error."""
+    assert is_auth_error(KeyError("access_token")) is True
+
+
+def test_is_auth_error_known_pysolarcloud_error():
+    """Known pysolarcloud auth error codes are treated as auth errors."""
+    assert is_auth_error(PySolarCloudException({"error": "invalid_token"})) is True
+    assert is_auth_error(PySolarCloudException({"error": "auth_not_initialised"})) is True
+
+
+def test_is_auth_error_transient():
+    """Transient errors are not auth errors."""
+    assert is_auth_error(ConnectionError("boom")) is False
+    assert is_auth_error(PySolarCloudException({"error": "server_busy"})) is False
+
+
+# ---------------------------------------------------------------------------
+# _async_update_data
+# ---------------------------------------------------------------------------
+
+
+async def test_update_data_success(hass: HomeAssistant):
+    """Successful data fetch returns plant data."""
+    plants = MagicMock()
+    plants.async_get_realtime_data = AsyncMock(return_value=MOCK_REALTIME_DATA)
+
+    coordinator = SungrowPlantCoordinator(hass, _make_entry(), plants, "12345", "Test Plant")
+    data = await coordinator._async_update_data()
+
+    assert data["total_active_power"]["value"] == "5.23"
+
+
+async def test_update_data_missing_plant(hass: HomeAssistant):
+    """Returns empty dict when the plant_id is not in the response."""
+    plants = MagicMock()
+    plants.async_get_realtime_data = AsyncMock(return_value={"99999": {}})
+
+    coordinator = SungrowPlantCoordinator(hass, _make_entry(), plants, "12345", "Test Plant")
+    assert await coordinator._async_update_data() == {}
+
+
+async def test_update_data_transient_error_raises_update_failed(hass: HomeAssistant):
+    """A transient API error raises UpdateFailed (HA retries)."""
+    plants = MagicMock()
+    plants.async_get_realtime_data = AsyncMock(side_effect=ConnectionError("API down"))
+
+    coordinator = SungrowPlantCoordinator(hass, _make_entry(), plants, "12345", "Test Plant")
+    with pytest.raises(UpdateFailed):
+        await coordinator._async_update_data()
+
+
+async def test_update_data_auth_error_raises_config_entry_auth_failed(hass: HomeAssistant):
+    """A failed token refresh raises ConfigEntryAuthFailed (triggers reauth)."""
+    plants = MagicMock()
+    plants.async_get_realtime_data = AsyncMock(side_effect=KeyError("access_token"))
+
+    coordinator = SungrowPlantCoordinator(hass, _make_entry(), plants, "12345", "Test Plant")
+    with pytest.raises(ConfigEntryAuthFailed):
+        await coordinator._async_update_data()
+
+
+# ---------------------------------------------------------------------------
+# scan interval from options
+# ---------------------------------------------------------------------------
+
+
+async def test_scan_interval_uses_default(hass: HomeAssistant):
+    """Default scan interval is applied when no option is set."""
+    coordinator = SungrowPlantCoordinator(hass, _make_entry(), MagicMock(), "1", "P")
+    assert coordinator.update_interval.total_seconds() == 5 * 60
+
+
+async def test_scan_interval_from_options(hass: HomeAssistant):
+    """Scan interval option overrides the default."""
+    entry = _make_entry({CONF_SCAN_INTERVAL: 30})
+    coordinator = SungrowPlantCoordinator(hass, entry, MagicMock(), "1", "P")
+    assert coordinator.update_interval.total_seconds() == 30 * 60

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -3,6 +3,7 @@
 from unittest.mock import AsyncMock, patch
 
 from aiohttp.test_utils import make_mocked_request
+from homeassistant.config_entries import ConfigEntryState
 from homeassistant.core import HomeAssistant
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 
@@ -10,7 +11,7 @@ from custom_components.sungrow import (
     SungrowAuthCallbackView,
     async_setup,
 )
-from custom_components.sungrow.const import DOMAIN
+from custom_components.sungrow.const import CONF_SCAN_INTERVAL, DOMAIN
 
 from .conftest import MOCK_CONFIG_DATA
 
@@ -24,7 +25,6 @@ async def test_async_setup_registers_callback_view(hass: HomeAssistant):
     result = await async_setup(hass, {})
 
     assert result is True
-    # Verify register_view was called with a SungrowAuthCallbackView instance
     hass.http.register_view.assert_called_once()
     view_arg = hass.http.register_view.call_args[0][0]
     assert isinstance(view_arg, SungrowAuthCallbackView)
@@ -35,54 +35,90 @@ async def test_async_setup_registers_callback_view(hass: HomeAssistant):
 # ---------------------------------------------------------------------------
 
 
-async def test_async_setup_entry(hass: HomeAssistant, mock_sensor_auth, mock_plants_service):
-    """Test a successful setup entry stores data and forwards platforms."""
-    entry = MockConfigEntry(domain=DOMAIN, data=MOCK_CONFIG_DATA.copy())
+async def test_async_setup_entry_success(hass: HomeAssistant, mock_setup_auth, mock_plants_service):
+    """A successful setup stores coordinators and creates entities."""
+    entry = MockConfigEntry(domain=DOMAIN, data=MOCK_CONFIG_DATA.copy(), unique_id="test_app_id")
     entry.add_to_hass(hass)
 
-    with patch(
-        "custom_components.sungrow.sensor.async_setup_entry",
-        return_value=True,
-    ):
-        assert await hass.config_entries.async_setup(entry.entry_id)
-        await hass.async_block_till_done()
+    assert await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
 
-    assert DOMAIN in hass.data
-    assert entry.entry_id in hass.data[DOMAIN]
+    assert entry.state is ConfigEntryState.LOADED
+    coordinators = hass.data[DOMAIN][entry.entry_id]
+    # MOCK_PLANT_LIST has two plants.
+    assert len(coordinators) == 2
+    # Entities were created for the data points.
+    assert hass.states.async_all("sensor")
 
 
-async def test_async_unload_entry(hass: HomeAssistant, mock_sensor_auth, mock_plants_service):
-    """Test successful unload removes data."""
-    entry = MockConfigEntry(domain=DOMAIN, data=MOCK_CONFIG_DATA.copy())
+async def test_async_unload_entry(hass: HomeAssistant, mock_setup_auth, mock_plants_service):
+    """Test successful unload removes stored data."""
+    entry = MockConfigEntry(domain=DOMAIN, data=MOCK_CONFIG_DATA.copy(), unique_id="test_app_id")
     entry.add_to_hass(hass)
 
-    with patch(
-        "custom_components.sungrow.sensor.async_setup_entry",
-        return_value=True,
-    ):
-        await hass.config_entries.async_setup(entry.entry_id)
-        await hass.async_block_till_done()
+    await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
 
     assert await hass.config_entries.async_unload(entry.entry_id)
     await hass.async_block_till_done()
 
     assert entry.entry_id not in hass.data.get(DOMAIN, {})
+    assert entry.state is ConfigEntryState.NOT_LOADED
 
 
-async def test_async_setup_entry_stores_data(hass: HomeAssistant, mock_sensor_auth, mock_plants_service):
-    """Test that setup stores entry data under hass.data[DOMAIN][entry_id]."""
-    entry = MockConfigEntry(domain=DOMAIN, data=MOCK_CONFIG_DATA.copy())
+async def test_setup_entry_no_tokens_triggers_reauth(hass: HomeAssistant, mock_setup_auth, mock_plants_service):
+    """Missing tokens should raise ConfigEntryAuthFailed (reauth)."""
+    data = MOCK_CONFIG_DATA.copy()
+    del data["tokens"]
+    entry = MockConfigEntry(domain=DOMAIN, data=data, unique_id="test_app_id")
     entry.add_to_hass(hass)
 
-    with patch(
-        "custom_components.sungrow.sensor.async_setup_entry",
-        return_value=True,
-    ):
-        await hass.config_entries.async_setup(entry.entry_id)
-        await hass.async_block_till_done()
+    assert not await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
 
-    stored = hass.data[DOMAIN][entry.entry_id]
-    assert stored == MOCK_CONFIG_DATA
+    assert entry.state is ConfigEntryState.SETUP_ERROR
+
+
+async def test_setup_entry_connection_error_is_retried(hass: HomeAssistant, mock_setup_auth, mock_plants_service):
+    """A transient connection failure raises ConfigEntryNotReady (retry)."""
+    mock_plants_service.async_get_plants = AsyncMock(side_effect=ConnectionError("network down"))
+
+    entry = MockConfigEntry(domain=DOMAIN, data=MOCK_CONFIG_DATA.copy(), unique_id="test_app_id")
+    entry.add_to_hass(hass)
+
+    assert not await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert entry.state is ConfigEntryState.SETUP_RETRY
+
+
+async def test_setup_entry_auth_error_triggers_reauth(hass: HomeAssistant, mock_setup_auth, mock_plants_service):
+    """A failed token refresh (KeyError) raises ConfigEntryAuthFailed (reauth)."""
+    # pysolarcloud raises KeyError when the refresh response has no access_token.
+    mock_plants_service.async_get_plants = AsyncMock(side_effect=KeyError("access_token"))
+
+    entry = MockConfigEntry(domain=DOMAIN, data=MOCK_CONFIG_DATA.copy(), unique_id="test_app_id")
+    entry.add_to_hass(hass)
+
+    assert not await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert entry.state is ConfigEntryState.SETUP_ERROR
+
+
+async def test_options_change_reloads_entry(hass: HomeAssistant, mock_setup_auth, mock_plants_service):
+    """Updating options should reload the entry and apply the new scan interval."""
+    entry = MockConfigEntry(domain=DOMAIN, data=MOCK_CONFIG_DATA.copy(), unique_id="test_app_id")
+    entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+
+    hass.config_entries.async_update_entry(entry, options={CONF_SCAN_INTERVAL: 15})
+    await hass.async_block_till_done()
+
+    assert entry.state is ConfigEntryState.LOADED
+    coordinators = hass.data[DOMAIN][entry.entry_id]
+    assert coordinators[0].update_interval.total_seconds() == 15 * 60
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -1,32 +1,54 @@
 """Tests for the Sungrow sensor platform."""
 
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import MagicMock
 
 import pytest
 from homeassistant.components.sensor import SensorDeviceClass, SensorStateClass
-from homeassistant.config_entries import ConfigEntryState
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers.update_coordinator import UpdateFailed
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 
 from custom_components.sungrow.const import DOMAIN
 from custom_components.sungrow.sensor import (
-    SungrowPlantCoordinator,
     SungrowSensor,
     async_setup_entry,
+    infer_device_class,
 )
 
-from .conftest import MOCK_CONFIG_DATA, MOCK_REALTIME_DATA
+from .conftest import MOCK_CONFIG_DATA
+
+# ---------------------------------------------------------------------------
+# infer_device_class
+# ---------------------------------------------------------------------------
 
 
-@pytest.fixture(autouse=True)
-def mock_client_session():
-    """Mock async_get_clientsession to prevent background thread creation."""
-    with patch(
-        "custom_components.sungrow.sensor.async_get_clientsession",
-        return_value=MagicMock(),
-    ):
-        yield
+@pytest.mark.parametrize(
+    ("unit", "code", "device_class", "state_class"),
+    [
+        ("kW", "power", SensorDeviceClass.POWER, SensorStateClass.MEASUREMENT),
+        ("W", "power", SensorDeviceClass.POWER, SensorStateClass.MEASUREMENT),
+        ("kWh", "energy", SensorDeviceClass.ENERGY, SensorStateClass.TOTAL_INCREASING),
+        ("Wh", "energy", SensorDeviceClass.ENERGY, SensorStateClass.TOTAL_INCREASING),
+        ("MWh", "energy", SensorDeviceClass.ENERGY, SensorStateClass.TOTAL_INCREASING),
+        ("V", "voltage", SensorDeviceClass.VOLTAGE, SensorStateClass.MEASUREMENT),
+        ("A", "current", SensorDeviceClass.CURRENT, SensorStateClass.MEASUREMENT),
+        ("Hz", "freq", SensorDeviceClass.FREQUENCY, SensorStateClass.MEASUREMENT),
+        ("°C", "temp", SensorDeviceClass.TEMPERATURE, SensorStateClass.MEASUREMENT),
+        ("kvar", "reactive", SensorDeviceClass.REACTIVE_POWER, SensorStateClass.MEASUREMENT),
+        # Case-insensitive matching.
+        ("kwh", "energy", SensorDeviceClass.ENERGY, SensorStateClass.TOTAL_INCREASING),
+        # Battery percentage disambiguated by the code name.
+        ("%", "battery_soc", SensorDeviceClass.BATTERY, SensorStateClass.MEASUREMENT),
+        # Generic percentage gets a state class but no device class.
+        ("%", "efficiency", None, SensorStateClass.MEASUREMENT),
+        # Unknown / empty units.
+        ("", "status", None, None),
+        (None, "status", None, None),
+        ("widgets", "x", None, None),
+    ],
+)
+def test_infer_device_class(unit, code, device_class, state_class):
+    """Units map to the expected device and state classes (issue #19)."""
+    assert infer_device_class(unit, code) == (device_class, state_class)
 
 
 # ---------------------------------------------------------------------------
@@ -38,7 +60,6 @@ class TestSungrowSensor:
     """Unit tests for SungrowSensor entity."""
 
     def _make_coordinator(self, data=None):
-        """Create a minimal mock coordinator."""
         coordinator = MagicMock()
         coordinator.data = data or {}
         return coordinator
@@ -47,7 +68,7 @@ class TestSungrowSensor:
         """Test sensor name is derived from the point code."""
         coordinator = self._make_coordinator()
         init_data = {"code": "total_active_power", "value": "5.0", "unit": "kW", "name": "Total"}
-        sensor = SungrowSensor(coordinator, "total_active_power", "123", "My Plant", init_data, "test_entry")
+        sensor = SungrowSensor(coordinator, "total_active_power", "123", "My Plant", init_data)
 
         assert sensor._attr_name == "Total Active Power"
         assert sensor._attr_unique_id == "123_total_active_power"
@@ -56,68 +77,42 @@ class TestSungrowSensor:
         """Test sensor with a numeric code falls back to init_data name."""
         coordinator = self._make_coordinator()
         init_data = {"code": "12345", "value": "99", "unit": "W", "name": "Some Sensor"}
-        sensor = SungrowSensor(coordinator, "12345", "123", "My Plant", init_data, "test_entry")
+        sensor = SungrowSensor(coordinator, "12345", "123", "My Plant", init_data)
 
         assert sensor._attr_name == "Some Sensor"
 
-    def test_sensor_device_class_power_kw(self):
+    def test_sensor_device_class_power(self):
         """Test kW unit infers POWER device class."""
         coordinator = self._make_coordinator()
         init_data = {"code": "power", "value": "5.0", "unit": "kW", "name": "Power"}
-        sensor = SungrowSensor(coordinator, "power", "123", "Plant", init_data, "test_entry")
+        sensor = SungrowSensor(coordinator, "power", "123", "Plant", init_data)
 
         assert sensor._attr_device_class == SensorDeviceClass.POWER
         assert sensor._attr_state_class == SensorStateClass.MEASUREMENT
 
-    def test_sensor_device_class_power_w(self):
-        """Test W unit infers POWER device class."""
-        coordinator = self._make_coordinator()
-        init_data = {"code": "power", "value": "5000", "unit": "W", "name": "Power"}
-        sensor = SungrowSensor(coordinator, "power", "123", "Plant", init_data, "test_entry")
-
-        assert sensor._attr_device_class == SensorDeviceClass.POWER
-        assert sensor._attr_state_class == SensorStateClass.MEASUREMENT
-
-    def test_sensor_device_class_energy_kwh(self):
-        """Test kWh unit infers ENERGY device class."""
+    def test_sensor_device_class_energy(self):
+        """Test kWh unit infers ENERGY device class for the Energy dashboard."""
         coordinator = self._make_coordinator()
         init_data = {"code": "energy", "value": "12.0", "unit": "kWh", "name": "Energy"}
-        sensor = SungrowSensor(coordinator, "energy", "123", "Plant", init_data, "test_entry")
+        sensor = SungrowSensor(coordinator, "energy", "123", "Plant", init_data)
 
         assert sensor._attr_device_class == SensorDeviceClass.ENERGY
         assert sensor._attr_state_class == SensorStateClass.TOTAL_INCREASING
-
-    def test_sensor_device_class_energy_wh(self):
-        """Test Wh unit infers ENERGY device class."""
-        coordinator = self._make_coordinator()
-        init_data = {"code": "energy", "value": "12000", "unit": "Wh", "name": "Energy"}
-        sensor = SungrowSensor(coordinator, "energy", "123", "Plant", init_data, "test_entry")
-
-        assert sensor._attr_device_class == SensorDeviceClass.ENERGY
-        assert sensor._attr_state_class == SensorStateClass.TOTAL_INCREASING
-
-    def test_sensor_device_class_energy_mwh(self):
-        """Test MWh unit infers ENERGY device class."""
-        coordinator = self._make_coordinator()
-        init_data = {"code": "energy", "value": "0.012", "unit": "MWh", "name": "Energy"}
-        sensor = SungrowSensor(coordinator, "energy", "123", "Plant", init_data, "test_entry")
-
-        assert sensor._attr_device_class == SensorDeviceClass.ENERGY
-        assert sensor._attr_state_class == SensorStateClass.TOTAL_INCREASING
+        assert sensor._attr_native_unit_of_measurement == "kWh"
 
     def test_sensor_device_class_unknown_unit(self):
-        """Test unknown unit doesn't set device class."""
+        """Test unknown unit doesn't set a device class."""
         coordinator = self._make_coordinator()
         init_data = {"code": "status", "value": "OK", "unit": "", "name": "Status"}
-        sensor = SungrowSensor(coordinator, "status", "123", "Plant", init_data, "test_entry")
+        sensor = SungrowSensor(coordinator, "status", "123", "Plant", init_data)
 
-        assert not hasattr(sensor, "_attr_device_class") or sensor._attr_device_class is None
+        assert sensor._attr_device_class is None
 
     def test_sensor_icon(self):
         """Test all sensors use the solar icon."""
         coordinator = self._make_coordinator()
         init_data = {"code": "x", "value": "1", "unit": "", "name": "X"}
-        sensor = SungrowSensor(coordinator, "x", "123", "Plant", init_data, "test_entry")
+        sensor = SungrowSensor(coordinator, "x", "123", "Plant", init_data)
 
         assert sensor._attr_icon == "mdi:solar-power-variant"
 
@@ -125,7 +120,7 @@ class TestSungrowSensor:
         """Test sensor has device_info grouping it under its plant."""
         coordinator = self._make_coordinator()
         init_data = {"code": "power", "value": "5.0", "unit": "kW", "name": "Power"}
-        sensor = SungrowSensor(coordinator, "power", "456", "My Solar Plant", init_data, "test_entry")
+        sensor = SungrowSensor(coordinator, "power", "456", "My Solar Plant", init_data)
 
         assert sensor._attr_device_info is not None
         assert sensor._attr_device_info["identifiers"] == {("sungrow", "456")}
@@ -136,31 +131,23 @@ class TestSungrowSensor:
         """Test sensors with no value are disabled by default."""
         coordinator = self._make_coordinator()
 
-        # Test None
-        init_none = {"code": "x", "value": None, "unit": "", "name": "X"}
-        s1 = SungrowSensor(coordinator, "x", "123", "Plant", init_none, "entry")
+        s1 = SungrowSensor(coordinator, "x", "123", "Plant", {"value": None})
         assert s1.entity_registry_enabled_default is False
 
-        # Test empty string
-        init_empty = {"code": "y", "value": "  ", "unit": "", "name": "Y"}
-        s2 = SungrowSensor(coordinator, "y", "123", "Plant", init_empty, "entry")
+        s2 = SungrowSensor(coordinator, "y", "123", "Plant", {"value": "  "})
         assert s2.entity_registry_enabled_default is False
 
-        # Test "Unknown" literal
-        init_unk = {"code": "z", "value": "Unknown", "unit": "", "name": "Z"}
-        s3 = SungrowSensor(coordinator, "z", "123", "Plant", init_unk, "entry")
+        s3 = SungrowSensor(coordinator, "z", "123", "Plant", {"value": "Unknown"})
         assert s3.entity_registry_enabled_default is False
 
-        # Test valid value is NOT disabled
-        init_val = {"code": "v", "value": "1.2", "unit": "", "name": "V"}
-        s4 = SungrowSensor(coordinator, "v", "123", "Plant", init_val, "entry")
+        s4 = SungrowSensor(coordinator, "v", "123", "Plant", {"value": "1.2"})
         assert s4.entity_registry_enabled_default is True
 
     def test_native_value_float_conversion(self):
         """Test native_value converts string numbers to float."""
         data = {"power": {"code": "power", "value": "5.23", "unit": "kW", "name": "Power"}}
         coordinator = self._make_coordinator(data)
-        sensor = SungrowSensor(coordinator, "power", "123", "Plant", data["power"], "test_entry")
+        sensor = SungrowSensor(coordinator, "power", "123", "Plant", data["power"])
 
         assert sensor.native_value == 5.23
 
@@ -168,171 +155,88 @@ class TestSungrowSensor:
         """Test native_value returns raw string for non-numeric values."""
         data = {"status": {"code": "status", "value": "Running", "unit": "", "name": "Status"}}
         coordinator = self._make_coordinator(data)
-        sensor = SungrowSensor(coordinator, "status", "123", "Plant", data["status"], "test_entry")
+        sensor = SungrowSensor(coordinator, "status", "123", "Plant", data["status"])
 
         assert sensor.native_value == "Running"
 
     def test_native_value_none_when_missing(self):
         """Test native_value returns None when data is missing."""
         coordinator = self._make_coordinator({})
-        init_data = {"code": "missing", "value": "0", "unit": "", "name": "Missing"}
-        sensor = SungrowSensor(coordinator, "missing", "123", "Plant", init_data, "test_entry")
+        sensor = SungrowSensor(coordinator, "missing", "123", "Plant", {"value": "0"})
 
         assert sensor.native_value is None
 
     def test_native_value_none_when_coordinator_data_none(self):
         """Test native_value returns None when coordinator.data is None."""
         coordinator = self._make_coordinator(None)
-        init_data = {"code": "x", "value": "0", "unit": "", "name": "X"}
-        sensor = SungrowSensor(coordinator, "x", "123", "Plant", init_data, "test_entry")
+        sensor = SungrowSensor(coordinator, "x", "123", "Plant", {"value": "0"})
 
         assert sensor.native_value is None
 
     def test_extra_state_attributes(self):
         """Test extra_state_attributes returns the full data point dict."""
         point_data = {"code": "power", "value": "5.0", "unit": "kW", "name": "Power"}
-        data = {"power": point_data}
-        coordinator = self._make_coordinator(data)
-        sensor = SungrowSensor(coordinator, "power", "123", "Plant", point_data, "test_entry")
+        coordinator = self._make_coordinator({"power": point_data})
+        sensor = SungrowSensor(coordinator, "power", "123", "Plant", point_data)
 
         assert sensor.extra_state_attributes == point_data
 
     def test_extra_state_attributes_empty_when_missing(self):
         """Test extra_state_attributes returns {} when data is missing."""
         coordinator = self._make_coordinator({})
-        init_data = {"code": "x", "value": "0", "unit": "", "name": "X"}
-        sensor = SungrowSensor(coordinator, "x", "123", "Plant", init_data, "test_entry")
+        sensor = SungrowSensor(coordinator, "x", "123", "Plant", {"value": "0"})
 
         assert sensor.extra_state_attributes == {}
 
 
 # ---------------------------------------------------------------------------
-# SungrowPlantCoordinator unit tests
+# async_setup_entry (platform) — builds entities from stored coordinators
 # ---------------------------------------------------------------------------
 
 
-class TestSungrowPlantCoordinator:
-    """Unit tests for the data update coordinator."""
-
-    async def test_update_data_success(self, hass: HomeAssistant):
-        """Test successful data fetch returns plant data."""
-        mock_plants = MagicMock()
-        mock_plants.async_get_realtime_data = AsyncMock(return_value=MOCK_REALTIME_DATA)
-        mock_entry = MagicMock()
-
-        coordinator = SungrowPlantCoordinator(hass, mock_entry, mock_plants, "12345", "Test Plant")
-        data = await coordinator._async_update_data()
-
-        assert "total_active_power" in data
-        assert data["total_active_power"]["value"] == "5.23"
-
-    async def test_update_data_missing_plant(self, hass: HomeAssistant):
-        """Test returns empty dict when plant_id is not in response."""
-        mock_plants = MagicMock()
-        mock_plants.async_get_realtime_data = AsyncMock(return_value={"99999": {}})
-        mock_entry = MagicMock()
-
-        coordinator = SungrowPlantCoordinator(hass, mock_entry, mock_plants, "12345", "Test Plant")
-        data = await coordinator._async_update_data()
-
-        assert data == {}
-
-    async def test_update_data_api_error(self, hass: HomeAssistant):
-        """Test API error raises UpdateFailed."""
-        mock_plants = MagicMock()
-        mock_plants.async_get_realtime_data = AsyncMock(side_effect=Exception("API down"))
-        mock_entry = MagicMock()
-
-        coordinator = SungrowPlantCoordinator(hass, mock_entry, mock_plants, "12345", "Test Plant")
-
-        with pytest.raises(UpdateFailed, match="Error communicating with API"):
-            await coordinator._async_update_data()
+def _coordinator_with(plant_id, plant_name, data):
+    coordinator = MagicMock()
+    coordinator.plant_id = plant_id
+    coordinator.plant_name = plant_name
+    coordinator.data = data
+    return coordinator
 
 
-# ---------------------------------------------------------------------------
-# async_setup_entry integration test
-# ---------------------------------------------------------------------------
-
-
-async def test_sensor_setup_creates_entities(hass: HomeAssistant, mock_sensor_auth, mock_plants_service):
-    """Test async_setup_entry creates sensors for each data point."""
+async def test_sensor_setup_creates_entities(hass: HomeAssistant):
+    """The platform creates a sensor per data point across all coordinators."""
     entry = MockConfigEntry(domain=DOMAIN, data=MOCK_CONFIG_DATA.copy())
     entry.add_to_hass(hass)
-    # Set state to SETUP_IN_PROGRESS so the coordinator refresh is allowed
-    entry.mock_state(hass, ConfigEntryState.SETUP_IN_PROGRESS)
 
-    hass.data.setdefault(DOMAIN, {})
-    hass.data[DOMAIN][entry.entry_id] = entry.data
+    coordinators = [
+        _coordinator_with(
+            "12345",
+            "Plant A",
+            {
+                "total_active_power": {"value": "5.0", "unit": "kW", "name": "Total Active Power"},
+                "daily_energy": {"value": "12.0", "unit": "kWh", "name": "Daily Energy"},
+            },
+        ),
+        _coordinator_with("67890", "Plant B", {"total_active_power": {"value": "3.1", "unit": "kW"}}),
+    ]
+    hass.data.setdefault(DOMAIN, {})[entry.entry_id] = coordinators
 
-    added_entities = []
+    added = []
+    await async_setup_entry(hass, entry, lambda entities: added.extend(entities))
 
-    def capture_entities(entities):
-        added_entities.extend(entities)
-
-    await async_setup_entry(hass, entry, capture_entities)
-
-    # Plant 12345 has 3 data points, plant 67890 has 1
-    assert len(added_entities) == 4
-
-    # Check that we have the expected sensors
-    names = [e._attr_name for e in added_entities]
-    assert "Total Active Power" in names
-    assert "Daily Energy" in names
-    assert "Device Status" in names
-    # Second plant also has Total Active Power — check we have 2
+    assert len(added) == 3
+    names = [e._attr_name for e in added]
     assert names.count("Total Active Power") == 2
 
 
-async def test_sensor_setup_no_tokens(hass: HomeAssistant, mock_sensor_auth, mock_plants_service):
-    """Test async_setup_entry returns early when no tokens in config."""
-    data = MOCK_CONFIG_DATA.copy()
-    del data["tokens"]
-    entry = MockConfigEntry(domain=DOMAIN, data=data)
-    entry.add_to_hass(hass)
-    hass.data.setdefault(DOMAIN, {})
-    hass.data[DOMAIN][entry.entry_id] = entry.data
-
-    added_entities = []
-    await async_setup_entry(hass, entry, lambda entities: added_entities.extend(entities))
-
-    assert len(added_entities) == 0
-
-
-async def test_sensor_setup_plant_fetch_fails(hass: HomeAssistant, mock_sensor_auth, mock_plants_service):
-    """Test async_setup_entry handles plant fetch failure gracefully."""
-    mock_plants_service.async_get_plants = AsyncMock(side_effect=Exception("Network error"))
-
+async def test_sensor_setup_skips_plant_with_no_data(hass: HomeAssistant):
+    """Coordinators with no data don't produce entities."""
     entry = MockConfigEntry(domain=DOMAIN, data=MOCK_CONFIG_DATA.copy())
     entry.add_to_hass(hass)
-    hass.data.setdefault(DOMAIN, {})
-    hass.data[DOMAIN][entry.entry_id] = entry.data
 
-    added_entities = []
-    await async_setup_entry(hass, entry, lambda entities: added_entities.extend(entities))
+    coordinators = [_coordinator_with("12345", "Plant A", {}), _coordinator_with("67890", "Plant B", {})]
+    hass.data.setdefault(DOMAIN, {})[entry.entry_id] = coordinators
 
-    assert len(added_entities) == 0
+    added = []
+    await async_setup_entry(hass, entry, lambda entities: added.extend(entities))
 
-
-async def test_sensor_setup_skips_plant_with_no_data(hass: HomeAssistant, mock_sensor_auth, mock_plants_service):
-    """Test that plants returning empty data are skipped without creating entities."""
-    # Return empty data for all plants — covers the `if not coordinator.data: continue` branch
-    mock_plants_service.async_get_realtime_data = AsyncMock(
-        return_value={
-            "12345": {},
-            "67890": {},
-        }
-    )
-
-    entry = MockConfigEntry(domain=DOMAIN, data=MOCK_CONFIG_DATA.copy())
-    entry.add_to_hass(hass)
-    # Set state to SETUP_IN_PROGRESS so the coordinator refresh is allowed
-    entry.mock_state(hass, ConfigEntryState.SETUP_IN_PROGRESS)
-
-    hass.data.setdefault(DOMAIN, {})
-    hass.data[DOMAIN][entry.entry_id] = entry.data
-
-    added_entities = []
-    await async_setup_entry(hass, entry, lambda entities: added_entities.extend(entities))
-
-    # Both plants had empty data, so no sensors should be created
-    assert len(added_entities) == 0
+    assert added == []

--- a/tests/test_strings.py
+++ b/tests/test_strings.py
@@ -37,9 +37,9 @@ def test_strings_user_step_has_required_fields(strings_data):
     """Test the user step defines all form fields used by the config flow."""
     user_data = strings_data["config"]["step"]["user"]["data"]
     required_fields = {"gateway", "app_key", "app_secret", "app_id", "redirect_uri"}
-    assert required_fields.issubset(
-        set(user_data.keys())
-    ), f"Missing form fields: {required_fields - set(user_data.keys())}"
+    assert required_fields.issubset(set(user_data.keys())), (
+        f"Missing form fields: {required_fields - set(user_data.keys())}"
+    )
 
 
 def test_strings_auth_step_has_code_field(strings_data):


### PR DESCRIPTION
## Summary

Fixes the most-reported problems with the integration — **entities going unavailable after a reboot/update**, *"can't fetch token"*, and having to **delete & re-add** the integration (#14, #15, #20, #21) — plus the Energy dashboard `device_class` gap (#19).

### Root cause
`pysolarcloud.Auth.async_get_access_token()` refreshes the access token when it expires and **rotates the refresh token** (assigns a new in-memory `tokens` dict). The integration reconstructed `Auth` on every setup and restored tokens from the config entry, but **never wrote the rotated tokens back**. After a restart it reloaded an already-invalidated refresh token → refresh failed → all entities unavailable.

### Changes
- **`auth.py`** *(new)* — `SungrowAuth(pysolarcloud.Auth)` with a `token_updater` callback that persists rotated tokens to the config entry.
- **`__init__.py`** — builds auth + one coordinator per plant; classifies failures into `ConfigEntryNotReady` (transient → HA retries) vs `ConfigEntryAuthFailed` (→ reauth); reloads on options change.
- **`coordinator.py`** *(new)* — `SungrowPlantCoordinator`; reads scan interval from options; `is_auth_error()` maps a failed refresh to reauth.
- **`config_flow.py`** — **reauth flow** (re-authorize in place; no delete & re-add, history preserved) and an **options flow** for the polling interval (#21); unique ID prevents duplicate entries.
- **`sensor.py`** — broadened `infer_device_class()` so the **Energy dashboard** works (#19): power/energy/voltage/current/frequency/temperature/battery, case-insensitive.
- **`manifest.json`** — pin `pysolarcloud==0.4.0`; set codeowners.
- **CI** — lint `tests/` too and pin `ruff==0.15.16`; align `.pre-commit-config.yaml`.
- **Tests** — new `test_auth.py`, `test_coordinator.py`; updated the rest for the new architecture. **83 passing, ~98% coverage.**

### Notes for reviewers
- Companion docs/tooling PR: #22.
- `#16` (notification repeats) and `#7` (sensor mapping) are HA-automation/usage questions, not integration bugs. `#17` (dispatch control) and `#18` (EV charger) are feature requests needing hardware — out of scope here.

## Type of change
- [x] Bug fix
- [x] New feature (reauth flow, options flow, broader device classes)

## Checklist
- [x] `ruff check custom_components/ tests/` passes
- [x] `ruff format --check custom_components/ tests/` passes
- [x] `pytest` passes; new behaviour covered by tests

Closes #14
Closes #15
Closes #19
Closes #20
Closes #21