### PR TITLE
feat: dispatch control, extra measure points, sensor aliases, forked API client

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,13 +4,15 @@
 [![CI][ci-badge]][ci-url]
 [![GitHub Release][release-badge]][release-url]
 
-Custom component that integrates Sungrow inverters via the iSolarCloud API into Home Assistant using the [`pysolarcloud`](https://pypi.org/project/pysolarcloud/) library.
+Custom component that integrates Sungrow inverters via the iSolarCloud API into Home Assistant using the [`sungrow-isolarcloud`](https://github.com/KRoperUK/pysolarcloud) library (a maintained fork of `pysolarcloud`).
 
 ## Features
 
 - **Cloud Polling** — fetches real-time data from the iSolarCloud API.
 - **Auto-Discovery** — automatically finds all plants linked to your account.
 - **Sensors** — creates sensors for every available data point (power, energy, battery SOC, etc.) with correct device/state classes for the Energy dashboard.
+- **Custom measure points** — request additional iSolarCloud point IDs (e.g. battery charge/discharge power or EV charger values) via the options flow.
+- **Dispatch / control entities** — number and select entities for charge/discharge command, power, SOC limits, and forced charging, with automatic EMS heartbeat when dispatching.
 - **Config Flow** — set up entirely through the Home Assistant UI.
 - **Token persistence & re-auth** — refreshed tokens are saved automatically, so entities stay available across restarts; if credentials expire you're prompted to re-authorize in place (no delete & re-add).
 - **Configurable polling interval** — tune how often data is fetched via the integration options.
@@ -60,7 +62,14 @@ Register an application on the [iSolarCloud Developer Platform](https://develope
 
 ### Options
 
-After setup, go to **Settings → Devices & Services → Sungrow → Configure** to change the **polling interval** (default 5 minutes).
+After setup, go to **Settings → Devices & Services → Sungrow → Configure** to change:
+
+- **Polling interval** (default 5 minutes)
+- **Extra measure points** — add custom `point_id=code` pairs to request additional data points from iSolarCloud
+
+### Sensor mapping
+
+Not sure which sensor corresponds to which value in the iSolarCloud app? See [docs/SENSORS.md](docs/SENSORS.md).
 
 ## Troubleshooting
 

--- a/custom_components/sungrow/__init__.py
+++ b/custom_components/sungrow/__init__.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import logging
 
 import voluptuous as vol
@@ -12,7 +13,8 @@ from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryAuthFailed, ConfigEntryNotReady
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
-from pysolarcloud.plants import Plants
+from pysolarcloud.control import Control
+from pysolarcloud.plants import DeviceType, Plants
 
 from .auth import SungrowAuth
 from .const import (
@@ -26,7 +28,7 @@ from .const import (
 )
 from .coordinator import SungrowPlantCoordinator, is_auth_error
 
-PLATFORMS: list[Platform] = [Platform.SENSOR]
+PLATFORMS: list[Platform] = [Platform.NUMBER, Platform.SELECT, Platform.SENSOR]
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -78,6 +80,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     auth.tokens = dict(entry.data["tokens"])
 
     plants_service = Plants(auth)
+    control_service = Control(auth)
 
     try:
         plant_list = await plants_service.async_get_plants()
@@ -87,6 +90,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         raise ConfigEntryNotReady(f"Unable to fetch plants from iSolarCloud: {err}") from err
 
     coordinators: list[SungrowPlantCoordinator] = []
+    devices_by_plant: dict[str, list[dict]] = {}
     for plant_info in plant_list:
         plant_id = str(plant_info["ps_id"])
         plant_name = plant_info["ps_name"]
@@ -95,7 +99,24 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         await coordinator.async_config_entry_first_refresh()
         coordinators.append(coordinator)
 
-    hass.data.setdefault(DOMAIN, {})[entry.entry_id] = coordinators
+        # Discover dispatch-capable devices (inverters / ESS) for this plant. Failures here are
+        # non-fatal — dispatch entities simply won't be created for this plant.
+        try:
+            devices = await plants_service.async_get_plant_devices(
+                plant_id,
+                device_types=[DeviceType.INVERTER, DeviceType.ENERGY_STORAGE_SYSTEM],
+            )
+            devices_by_plant[plant_id] = devices
+        except Exception as err:
+            _LOGGER.warning("Could not fetch devices for plant %s: %s", plant_name, err)
+            devices_by_plant[plant_id] = []
+
+    hass.data.setdefault(DOMAIN, {})[entry.entry_id] = {
+        "coordinators": coordinators,
+        "control": control_service,
+        "devices": devices_by_plant,
+        "heartbeat_stop": {},
+    }
 
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
 
@@ -107,6 +128,10 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
 async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Unload a config entry."""
+    entry_data = hass.data[DOMAIN].get(entry.entry_id, {})
+    for stop_event in entry_data.get("heartbeat_stop", {}).values():
+        stop_event.set()
+
     if unload_ok := await hass.config_entries.async_unload_platforms(entry, PLATFORMS):
         hass.data[DOMAIN].pop(entry.entry_id)
 
@@ -116,6 +141,32 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 async def async_reload_entry(hass: HomeAssistant, entry: ConfigEntry) -> None:
     """Reload the config entry when its options change."""
     await hass.config_entries.async_reload(entry.entry_id)
+
+
+async def async_start_heartbeat(
+    hass: HomeAssistant, entry: ConfigEntry, plant_id: str, device_uuid: str, interval: int
+) -> None:
+    """Start (or restart) the EMS heartbeat loop for a plant/device."""
+    entry_data = hass.data[DOMAIN][entry.entry_id]
+    stops = entry_data["heartbeat_stop"]
+
+    # Stop any existing loop for this plant before starting a new one.
+    if plant_id in stops:
+        stops[plant_id].set()
+        await asyncio.sleep(0)
+
+    stop_event = asyncio.Event()
+    stops[plant_id] = stop_event
+    control: Control = entry_data["control"]
+    asyncio.create_task(control.heartbeat_loop(device_uuid, interval, stop_event))
+
+
+async def async_stop_heartbeat(hass: HomeAssistant, entry: ConfigEntry, plant_id: str) -> None:
+    """Stop the EMS heartbeat loop for a plant."""
+    entry_data = hass.data[DOMAIN].get(entry.entry_id, {})
+    stops = entry_data.get("heartbeat_stop", {})
+    if plant_id in stops:
+        stops[plant_id].set()
 
 
 class SungrowAuthCallbackView(HomeAssistantView):

--- a/custom_components/sungrow/config_flow.py
+++ b/custom_components/sungrow/config_flow.py
@@ -15,6 +15,7 @@ from .const import (
     CONF_APP_ID,
     CONF_APP_KEY,
     CONF_APP_SECRET,
+    CONF_EXTRA_MEASURE_POINTS,
     CONF_GATEWAY,
     CONF_REDIRECT_URI,
     CONF_SCAN_INTERVAL,
@@ -206,23 +207,65 @@ class SungrowConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         )
 
 
+def _parse_extra_measure_points(raw: str | None) -> dict[str, str]:
+    """Parse a comma-separated 'point_id=code' list into a mapping.
+
+    Whitespace around entries is ignored; duplicate point_ids keep the last value.
+    """
+    out: dict[str, str] = {}
+    if not raw:
+        return out
+    for entry in raw.split(","):
+        entry = entry.strip()
+        if not entry:
+            continue
+        if "=" not in entry:
+            raise vol.Invalid(f"Extra measure point '{entry}' must be in the form point_id=code")
+        point_id, code = entry.split("=", 1)
+        point_id = point_id.strip()
+        code = code.strip()
+        if not point_id or not code:
+            raise vol.Invalid("point_id and code must not be empty")
+        if not point_id.isdigit():
+            raise vol.Invalid(f"point_id must be numeric, got '{point_id}'")
+        out[point_id] = code
+    return out
+
+
 class SungrowOptionsFlow(config_entries.OptionsFlow):
     """Handle Sungrow integration options (e.g. polling interval)."""
 
     async def async_step_init(self, user_input: dict[str, Any] | None = None):
         """Manage the integration options."""
+        errors: dict[str, str] = {}
         if user_input is not None:
-            return self.async_create_entry(title="", data=user_input)
+            # Normalise the free-text mapping into a dict before storing.
+            try:
+                extras = _parse_extra_measure_points(user_input.get(CONF_EXTRA_MEASURE_POINTS))
+            except vol.Invalid as exc:
+                errors["base"] = "invalid_extra_measure_points"
+                _LOGGER.warning("Invalid extra measure points input: %s", exc)
+            else:
+                data = {**user_input, CONF_EXTRA_MEASURE_POINTS: extras}
+                return self.async_create_entry(title="", data=data)
 
-        current = self.config_entry.options.get(CONF_SCAN_INTERVAL, DEFAULT_SCAN_INTERVAL)
+        current_interval = self.config_entry.options.get(CONF_SCAN_INTERVAL, DEFAULT_SCAN_INTERVAL)
+        current_extras = self.config_entry.options.get(CONF_EXTRA_MEASURE_POINTS, {})
+        extras_str = ",".join(f"{pid}={code}" for pid, code in current_extras.items())
         return self.async_show_form(
             step_id="init",
             data_schema=vol.Schema(
                 {
-                    vol.Required(CONF_SCAN_INTERVAL, default=current): vol.All(
+                    vol.Required(CONF_SCAN_INTERVAL, default=current_interval): vol.All(
                         vol.Coerce(int),
                         vol.Range(min=MIN_SCAN_INTERVAL, max=MAX_SCAN_INTERVAL),
-                    )
+                    ),
+                    vol.Optional(
+                        CONF_EXTRA_MEASURE_POINTS,
+                        default=extras_str,
+                        description={"suggested_value": extras_str},
+                    ): str,
                 }
             ),
+            errors=errors,
         )

--- a/custom_components/sungrow/const.py
+++ b/custom_components/sungrow/const.py
@@ -12,6 +12,7 @@ CONF_PASSWORD = "password"
 
 # Options
 CONF_SCAN_INTERVAL = "scan_interval"
+CONF_EXTRA_MEASURE_POINTS = "extra_measure_points"
 
 GATEWAYS = {
     "Europe": "https://gateway.isolarcloud.eu",

--- a/custom_components/sungrow/coordinator.py
+++ b/custom_components/sungrow/coordinator.py
@@ -13,7 +13,7 @@ from pysolarcloud import PySolarCloudException
 from pysolarcloud.plants import Plants
 
 from .auth import AUTH_ERRORS
-from .const import CONF_SCAN_INTERVAL, DEFAULT_SCAN_INTERVAL
+from .const import CONF_EXTRA_MEASURE_POINTS, CONF_SCAN_INTERVAL, DEFAULT_SCAN_INTERVAL
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -54,13 +54,16 @@ class SungrowPlantCoordinator(DataUpdateCoordinator):
         self.plants_service = plants_service
         self.plant_id = plant_id
         self.plant_name = plant_name
+        self.extra_measure_points: dict[str, str] = dict(config_entry.options.get(CONF_EXTRA_MEASURE_POINTS, {}))
 
     async def _async_update_data(self):
         """Fetch data from the API for this plant."""
         try:
             # async_get_realtime_data returns a dict of plants keyed by plant_id:
             # { "123": { "code1": {...}, "code2": {...} } }
-            all_plants_data = await self.plants_service.async_get_realtime_data([self.plant_id])
+            all_plants_data = await self.plants_service.async_get_realtime_data(
+                [self.plant_id], extra_measure_points=self.extra_measure_points or None
+            )
         except Exception as err:
             if is_auth_error(err):
                 raise ConfigEntryAuthFailed(f"Authentication with iSolarCloud failed: {err}") from err

--- a/custom_components/sungrow/manifest.json
+++ b/custom_components/sungrow/manifest.json
@@ -12,7 +12,7 @@
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/KRoperUK/sungrow-hass/issues",
   "requirements": [
-    "pysolarcloud==0.4.0"
+    "sungrow-isolarcloud==0.5.0"
   ],
   "version": "0.2.3"
 }

--- a/custom_components/sungrow/number.py
+++ b/custom_components/sungrow/number.py
@@ -1,0 +1,159 @@
+"""Number entities for Sungrow iSolarCloud dispatch control."""
+
+from __future__ import annotations
+
+import logging
+
+from homeassistant.components.number import NumberDeviceClass, NumberEntity, NumberMode
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity import DeviceInfo
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
+from pysolarcloud.control import Control
+
+from . import async_start_heartbeat, async_stop_heartbeat
+from .const import DOMAIN
+from .coordinator import SungrowPlantCoordinator
+
+_LOGGER = logging.getLogger(__name__)
+
+# Number parameters exposed as HA Number entities.
+# Keys are canonical Control parameter names; values describe the HA entity.
+DISPATCH_NUMBERS: dict[str, dict] = {
+    "charge_discharge_power": {
+        "name": "Charge/Discharge Power",
+        "device_class": NumberDeviceClass.POWER,
+        "native_unit_of_measurement": "W",
+        "native_min_value": 0,
+        "native_max_value": 5000,
+        "native_step": 100,
+        "mode": NumberMode.SLIDER,
+    },
+    "soc_upper_limit": {
+        "name": "SOC Upper Limit",
+        "device_class": NumberDeviceClass.BATTERY,
+        "native_unit_of_measurement": "%",
+        "native_min_value": 70,
+        "native_max_value": 100,
+        "native_step": 1,
+        "mode": NumberMode.SLIDER,
+    },
+    "soc_lower_limit": {
+        "name": "SOC Lower Limit",
+        "device_class": NumberDeviceClass.BATTERY,
+        "native_unit_of_measurement": "%",
+        "native_min_value": 0,
+        "native_max_value": 50,
+        "native_step": 1,
+        "mode": NumberMode.SLIDER,
+    },
+    "forced_charging_target_soc_1": {
+        "name": "Forced Charge Target SOC",
+        "device_class": NumberDeviceClass.BATTERY,
+        "native_unit_of_measurement": "%",
+        "native_min_value": 0,
+        "native_max_value": 100,
+        "native_step": 1,
+        "mode": NumberMode.SLIDER,
+    },
+}
+
+
+async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry, async_add_entities: AddEntitiesCallback) -> None:
+    """Set up Sungrow dispatch number entities."""
+    entry_data = hass.data[DOMAIN][entry.entry_id]
+    control: Control = entry_data["control"]
+    devices_by_plant: dict[str, list[dict]] = entry_data["devices"]
+    coordinators: list[SungrowPlantCoordinator] = entry_data["coordinators"]
+
+    entities: list[NumberEntity] = []
+    for coordinator in coordinators:
+        plant_id = coordinator.plant_id
+        devices = devices_by_plant.get(plant_id, [])
+        if not devices:
+            continue
+        # Prefer the ESS device if present, otherwise fall back to the first inverter.
+        ess_devices = [d for d in devices if d.get("device_type") == "ENERGY_STORAGE_SYSTEM"]
+        target = ess_devices[0] if ess_devices else devices[0]
+        device_uuid = target.get("uuid")
+        if not device_uuid:
+            continue
+        device_name = target.get("device_name") or coordinator.plant_name
+        for param, meta in DISPATCH_NUMBERS.items():
+            entities.append(
+                SungrowDispatchNumber(
+                    coordinator,
+                    control,
+                    device_uuid,
+                    device_name,
+                    param,
+                    meta,
+                )
+            )
+
+    async_add_entities(entities)
+
+
+class SungrowDispatchNumber(CoordinatorEntity, NumberEntity):
+    """Number entity for a Sungrow dispatch parameter."""
+
+    _attr_has_entity_name = True
+    _attr_available = False
+
+    def __init__(
+        self,
+        coordinator: SungrowPlantCoordinator,
+        control: Control,
+        device_uuid: str,
+        device_name: str,
+        param: str,
+        meta: dict,
+    ) -> None:
+        """Initialize the dispatch number."""
+        super().__init__(coordinator)
+        self.control = control
+        self.device_uuid = device_uuid
+        self.param = param
+        self._attr_name = meta["name"]
+        self._attr_unique_id = f"{coordinator.plant_id}_{device_uuid}_{param}"
+        self._attr_device_info = DeviceInfo(
+            identifiers={(DOMAIN, device_uuid)},
+            name=device_name,
+            manufacturer="Sungrow",
+        )
+        self._attr_device_class = meta.get("device_class")
+        self._attr_native_unit_of_measurement = meta.get("native_unit_of_measurement")
+        self._attr_native_min_value = meta["native_min_value"]
+        self._attr_native_max_value = meta["native_max_value"]
+        self._attr_native_step = meta["native_step"]
+        self._attr_mode = meta["mode"]
+
+    @property
+    def native_value(self) -> float | None:
+        """Return the current parameter value if known."""
+        # Parameters are not polled continuously; they are read once at setup if desired.
+        # For now we keep the entity available once the coordinator is running.
+        if self.coordinator.last_update_success:
+            self._attr_available = True
+        return None
+
+    async def async_set_native_value(self, value: float) -> None:
+        """Update the dispatch parameter on the inverter."""
+        _LOGGER.debug("Setting %s to %s for %s", self.param, value, self.device_uuid)
+        await self.control.async_update_parameters(self.device_uuid, {self.param: str(int(value))})
+        # If the user is actively dispatching, ensure a heartbeat is running so the
+        # inverter stays in External EMS mode.
+        if self.param == "charge_discharge_power":
+            await async_start_heartbeat(
+                self.hass,
+                self.coordinator.config_entry,
+                self.coordinator.plant_id,
+                self.device_uuid,
+                interval=60,
+            )
+
+    async def async_will_remove_from_hass(self) -> None:
+        """Stop the heartbeat when the entity is removed."""
+        await async_stop_heartbeat(self.hass, self.coordinator.config_entry, self.coordinator.plant_id)
+        await super().async_will_remove_from_hass()

--- a/custom_components/sungrow/select.py
+++ b/custom_components/sungrow/select.py
@@ -1,0 +1,135 @@
+"""Select entities for Sungrow iSolarCloud dispatch control."""
+
+from __future__ import annotations
+
+import logging
+
+from homeassistant.components.select import SelectEntity
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity import DeviceInfo
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
+from pysolarcloud.control import Control
+
+from . import async_start_heartbeat, async_stop_heartbeat
+from .const import DOMAIN
+from .coordinator import SungrowPlantCoordinator
+
+_LOGGER = logging.getLogger(__name__)
+
+# Select parameters exposed as HA Select entities.
+DISPATCH_SELECTS: dict[str, dict] = {
+    "charge_discharge_command": {
+        "name": "Charge/Discharge Command",
+        "options_map": {
+            "Stop": Control.CHARGE_DISCHARGE_COMMANDS["stop"],
+            "Charge": Control.CHARGE_DISCHARGE_COMMANDS["charge"],
+            "Discharge": Control.CHARGE_DISCHARGE_COMMANDS["discharge"],
+        },
+    },
+    "forced_charging": {
+        "name": "Forced Charging",
+        "options_map": {
+            "Disable": Control.FORCED_CHARGING["disable"],
+            "Enable": Control.FORCED_CHARGING["enable"],
+        },
+    },
+}
+
+
+async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry, async_add_entities: AddEntitiesCallback) -> None:
+    """Set up Sungrow dispatch select entities."""
+    entry_data = hass.data[DOMAIN][entry.entry_id]
+    control: Control = entry_data["control"]
+    devices_by_plant: dict[str, list[dict]] = entry_data["devices"]
+    coordinators: list[SungrowPlantCoordinator] = entry_data["coordinators"]
+
+    entities: list[SelectEntity] = []
+    for coordinator in coordinators:
+        plant_id = coordinator.plant_id
+        devices = devices_by_plant.get(plant_id, [])
+        if not devices:
+            continue
+        ess_devices = [d for d in devices if d.get("device_type") == "ENERGY_STORAGE_SYSTEM"]
+        target = ess_devices[0] if ess_devices else devices[0]
+        device_uuid = target.get("uuid")
+        if not device_uuid:
+            continue
+        device_name = target.get("device_name") or coordinator.plant_name
+        for param, meta in DISPATCH_SELECTS.items():
+            entities.append(
+                SungrowDispatchSelect(
+                    coordinator,
+                    control,
+                    device_uuid,
+                    device_name,
+                    param,
+                    meta,
+                )
+            )
+
+    async_add_entities(entities)
+
+
+class SungrowDispatchSelect(CoordinatorEntity, SelectEntity):
+    """Select entity for a Sungrow dispatch parameter."""
+
+    _attr_has_entity_name = True
+    _attr_available = False
+
+    def __init__(
+        self,
+        coordinator: SungrowPlantCoordinator,
+        control: Control,
+        device_uuid: str,
+        device_name: str,
+        param: str,
+        meta: dict,
+    ) -> None:
+        """Initialize the dispatch select."""
+        super().__init__(coordinator)
+        self.control = control
+        self.device_uuid = device_uuid
+        self.param = param
+        self.options_map = dict(meta["options_map"])
+        reverse_map = {v: k for k, v in self.options_map.items()}
+        self._reverse_map = reverse_map
+        self._attr_name = meta["name"]
+        self._attr_unique_id = f"{coordinator.plant_id}_{device_uuid}_{param}"
+        self._attr_device_info = DeviceInfo(
+            identifiers={(DOMAIN, device_uuid)},
+            name=device_name,
+            manufacturer="Sungrow",
+        )
+        self._attr_options = list(self.options_map.keys())
+
+    @property
+    def current_option(self) -> str | None:
+        """Return the current option (unknown until the user sets it)."""
+        if self.coordinator.last_update_success:
+            self._attr_available = True
+        return None
+
+    async def async_select_option(self, option: str) -> None:
+        """Update the dispatch parameter on the inverter."""
+        value = self.options_map[option]
+        _LOGGER.debug("Setting %s to %s (%s) for %s", self.param, option, value, self.device_uuid)
+        await self.control.async_update_parameters(self.device_uuid, {self.param: value})
+
+        # Keep the inverter in dispatch mode while actively charging/discharging.
+        if self.param == "charge_discharge_command" and option in {"Charge", "Discharge"}:
+            await async_start_heartbeat(
+                self.hass,
+                self.coordinator.config_entry,
+                self.coordinator.plant_id,
+                self.device_uuid,
+                interval=60,
+            )
+        elif self.param == "charge_discharge_command" and option == "Stop":
+            await async_stop_heartbeat(self.hass, self.coordinator.config_entry, self.coordinator.plant_id)
+
+    async def async_will_remove_from_hass(self) -> None:
+        """Stop the heartbeat when the entity is removed."""
+        await async_stop_heartbeat(self.hass, self.coordinator.config_entry, self.coordinator.plant_id)
+        await super().async_will_remove_from_hass()

--- a/custom_components/sungrow/sensor.py
+++ b/custom_components/sungrow/sensor.py
@@ -13,6 +13,32 @@ from homeassistant.helpers.update_coordinator import CoordinatorEntity
 from .const import DOMAIN
 from .coordinator import SungrowPlantCoordinator
 
+# Friendly names for point codes that are otherwise opaque or overly generic.
+# These are applied in addition to the code-based naming, so existing entities
+# keep their unique_id while users see a clearer label.
+SENSOR_ALIASES: dict[str, str] = {
+    "total_field_energy_storage_active_power": "Battery Power",
+    "total_field_energy_storage_maximum_reactive_power": "Battery Max Reactive Power",
+    "total_field_chargeable_energy": "Battery Chargeable Energy",
+    "total_field_dischargeable_energy": "Battery Dischargeable Energy",
+    "total_field_maximum_rechargeable_power": "Battery Max Charge Power",
+    "total_field_maximum_dischargeable_power": "Battery Max Discharge Power",
+    "daily_field_charge_capacity": "Battery Daily Charge Capacity",
+    "daily_field_discharge_capacity": "Battery Daily Discharge Capacity",
+    "energy_storage_active_power_ems": "EMS Battery Power",
+    "energy_storage_soc_ems": "EMS Battery SOC",
+}
+
+# Per-issue custom codes that users commonly request. If the point_id is configured
+# via the options flow, the code is used as-is; we also supply a friendly alias here
+# so the UI label is meaningful.
+EXTRA_CODE_ALIASES: dict[str, str] = {
+    "battery_charge_power": "Battery Charge Power",
+    "battery_discharge_power": "Battery Discharge Power",
+    "ev_charger_power": "EV Charger Power",
+    "ev_charger_energy": "EV Charger Energy",
+}
+
 _LOGGER = logging.getLogger(__name__)
 
 # Map a (lower-cased) unit of measurement to the appropriate device and state class.
@@ -83,7 +109,8 @@ def infer_device_class(unit: str | None, point_code: str) -> tuple[SensorDeviceC
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry, async_add_entities: AddEntitiesCallback) -> None:
     """Set up Sungrow sensors from the coordinators created during entry setup."""
-    coordinators: list[SungrowPlantCoordinator] = hass.data[DOMAIN][entry.entry_id]
+    entry_data = hass.data[DOMAIN][entry.entry_id]
+    coordinators: list[SungrowPlantCoordinator] = entry_data["coordinators"]
 
     entities: list[SungrowSensor] = []
     for coordinator in coordinators:
@@ -120,6 +147,10 @@ class SungrowSensor(CoordinatorEntity, SensorEntity):
         else:
             sensor_name = point_code.replace("_", " ").title()
 
+        # Apply friendly aliases for known opaque codes, including user-configured
+        # extra measure points that have a documented alias.
+        sensor_name = EXTRA_CODE_ALIASES.get(point_code, SENSOR_ALIASES.get(point_code, sensor_name))
+
         # With has_entity_name = True, HA prefixes the device name automatically
         self._attr_name = sensor_name
         _LOGGER.debug("Created sensor: %s %s (code: %s)", plant_name, sensor_name, point_code)
@@ -143,7 +174,8 @@ class SungrowSensor(CoordinatorEntity, SensorEntity):
 
         # Infer device class / state class / unit so the Energy dashboard and history
         # graphs work out of the box (issue #19).
-        self._attr_native_unit_of_measurement = init_data.get("unit")
+        unit = init_data.get("unit")
+        self._attr_native_unit_of_measurement = unit if unit else None
         device_class, state_class = infer_device_class(init_data.get("unit"), point_code)
         self._attr_device_class = device_class
         self._attr_state_class = state_class

--- a/custom_components/sungrow/strings.json
+++ b/custom_components/sungrow/strings.json
@@ -29,6 +29,7 @@
       "cannot_connect": "Failed to connect",
       "invalid_auth": "Invalid authentication",
       "invalid_auth_url": "Could not find 'applicationId' in the provided URL.",
+      "invalid_extra_measure_points": "Extra measure points must be in the form point_id=code, comma separated",
       "unknown": "Unexpected error"
     },
     "abort": {
@@ -42,7 +43,8 @@
         "title": "Sungrow Options",
         "description": "Adjust how often Home Assistant polls iSolarCloud. Lower values update more frequently but use more of your API quota.",
         "data": {
-          "scan_interval": "Polling interval (minutes)"
+          "scan_interval": "Polling interval (minutes)",
+          "extra_measure_points": "Extra measure points (point_id=code, comma separated)"
         }
       }
     }

--- a/custom_components/sungrow/translations/en.json
+++ b/custom_components/sungrow/translations/en.json
@@ -29,6 +29,7 @@
       "cannot_connect": "Failed to connect",
       "invalid_auth": "Invalid authentication",
       "invalid_auth_url": "Could not find 'applicationId' in the provided URL.",
+      "invalid_extra_measure_points": "Extra measure points must be in the form point_id=code, comma separated",
       "unknown": "Unexpected error"
     },
     "abort": {
@@ -42,7 +43,8 @@
         "title": "Sungrow Options",
         "description": "Adjust how often Home Assistant polls iSolarCloud. Lower values update more frequently but use more of your API quota.",
         "data": {
-          "scan_interval": "Polling interval (minutes)"
+          "scan_interval": "Polling interval (minutes)",
+          "extra_measure_points": "Extra measure points (point_id=code, comma separated)"
         }
       }
     }

--- a/docs/SENSORS.md
+++ b/docs/SENSORS.md
@@ -1,0 +1,82 @@
+# Sungrow iSolarCloud sensor mapping
+
+The integration creates one Home Assistant device per iSolarCloud plant, then adds a sensor for every realtime measure point that the plant returns. The point codes come from the iSolarCloud API; this guide maps the most common ones to the values shown in the iSolarCloud app.
+
+> Not every inverter / battery / meter returns every point. The available set depends on your model, firmware, and region. If a value you expect is missing, see [Adding extra measure points](#adding-extra-measure-points) below.
+
+## Common dashboard values
+
+| iSolarCloud app / diagram | Likely sensor (code) | Notes |
+|---|---|---|
+| Solar Production | `total_active_power` or `inverter_ac_power` | Total AC power from the inverter(s). |
+| Battery Usage | `total_field_energy_storage_active_power` (aliased as **Battery Power**) | Positive = charging, negative = discharging. |
+| Battery Charge % | `battery_level_soc`, `battery_soc`, `total_field_soc`, or `energy_storage_soc_ems` | Depends on your system topology. |
+| Load | `load_power` or `total_load_active_power` | Household consumption. |
+| Usage from Grid | `grid_active_power` or `grid_active_power_ems` | Positive = importing, negative = exporting. |
+| Daily Solar Yield | `daily_yield` / `inverter_daily_yield` / `daily_pv_yield_ems` | Resets at midnight local time. |
+| Daily Feed-in | `feed_in_energy_today` / `daily_feed_in_energy_pv` | Energy exported to the grid today. |
+| Daily Import | `energy_purchased_today` / `total_purchased_energy` | Energy imported from the grid today. |
+
+## Battery-specific points
+
+The following codes are surfaced for many hybrid inverters / battery systems:
+
+- `total_field_energy_storage_active_power` → **Battery Power** (kW)
+- `total_field_maximum_rechargeable_power` → **Battery Max Charge Power**
+- `total_field_maximum_dischargeable_power` → **Battery Max Discharge Power**
+- `total_field_chargeable_energy` → **Battery Chargeable Energy**
+- `total_field_dischargeable_energy` → **Battery Dischargeable Energy**
+- `daily_field_charge_capacity` → **Battery Daily Charge Capacity**
+- `daily_field_discharge_capacity` → **Battery Daily Discharge Capacity**
+
+If you need separate **Battery Charge Power** and **Battery Discharge Power** sensors (rather than a single signed value), you can request the additional point IDs via the integration options once you know them for your hardware. See the next section.
+
+## Adding extra measure points
+
+Some point IDs are not included in the default request because they vary by inverter model or firmware. The integration can request any point ID you provide:
+
+1. Open **Settings → Devices & services → Sungrow iSolarCloud → Configure**.
+2. In **Extra measure points**, enter a comma-separated list of `point_id=code` pairs, for example:
+   ```
+   99999=battery_charge_power, 99998=battery_discharge_power
+   ```
+3. The point IDs must be numeric; the codes can be any descriptive name you like.
+4. Save — the integration will reload and create sensors for those codes.
+
+You can find the actual point IDs for your hardware by:
+
+- Checking the **Common Measuring Point Enumeration** in the iSolarCloud Developer Portal.
+- Running a diagnostics dump from the device page in Home Assistant.
+- Using community tools such as [GoSungrow](https://github.com/MickMake/GoSungrow) to list points for your plant.
+
+## Dispatch / control entities
+
+If your inverter / ESS supports parameter configuration, the integration also creates **Number** and **Select** entities per plant for dispatch control:
+
+| Entity | Parameter | Range / options |
+|---|---|---|
+| Charge/Discharge Command | `charge_discharge_command` | Stop / Charge / Discharge |
+| Charge/Discharge Power | `charge_discharge_power` | 0–5000 W |
+| SOC Upper Limit | `soc_upper_limit` | 70–100 % |
+| SOC Lower Limit | `soc_lower_limit` | 0–50 % |
+| Forced Charging | `forced_charging` | Disable / Enable |
+| Forced Charge Target SOC | `forced_charging_target_soc_1` | 0–100 % |
+
+When you set **Charge/Discharge Command** to *Charge* or *Discharge*, the integration automatically starts sending the External EMS heartbeat (param `10017`) every 60 seconds so the inverter stays in dispatch mode. Selecting **Stop** turns the heartbeat off. If you remove the dispatch entities, the heartbeat is also stopped.
+
+> Dispatch support requires the correct iSolarCloud API plan and firmware. The integration will only create dispatch entities if it can discover a compatible inverter or ESS device for the plant.
+
+## EV charger support
+
+If your EV charger appears as a separate device in iSolarCloud, its point IDs can be requested via the **Extra measure points** option once identified. The integration does not yet auto-discover EV charger devices because the available codes are not consistent across charger models; community contributions of verified point ID lists are welcome.
+
+## Still missing a sensor?
+
+1. Enable debug logging for the integration:
+   ```yaml
+   logger:
+     logs:
+       custom_components.sungrow: debug
+   ```
+2. Reload the integration and look for the raw realtime data in the logs.
+3. Find the point ID / code for the value you want and add it via the options, or open an issue with the redacted raw data.

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -9,4 +9,4 @@ python-dotenv
 ruff
 
 # Component dependencies
-pysolarcloud==0.4.0
+sungrow-isolarcloud==0.5.0

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -71,6 +71,12 @@ MOCK_REALTIME_DATA = {
             "unit": "",
             "name": "Device Status",
         },
+        "total_field_energy_storage_active_power": {
+            "code": "total_field_energy_storage_active_power",
+            "value": "-1.4",
+            "unit": "kW",
+            "name": "Total Field Energy Storage Active Power",
+        },
     },
     "67890": {
         "total_active_power": {
@@ -180,12 +186,23 @@ def mock_auth_no_tokens(mock_auth):
 
 @pytest.fixture
 def mock_plants_service():
-    """Mock the Plants service used during entry setup (patches __init__ module)."""
-    with patch("custom_components.sungrow.Plants") as mock_plants_cls:
+    """Mock the Plants and Control services used during entry setup."""
+    with (
+        patch("custom_components.sungrow.Plants") as mock_plants_cls,
+        patch("custom_components.sungrow.Control") as mock_control_cls,
+    ):
         plants_instance = MagicMock()
         plants_instance.async_get_plants = AsyncMock(return_value=MOCK_PLANT_LIST)
         plants_instance.async_get_realtime_data = AsyncMock(return_value=MOCK_REALTIME_DATA)
+        plants_instance.async_get_plant_devices = AsyncMock(return_value=[])
         mock_plants_cls.return_value = plants_instance
+
+        control_instance = MagicMock()
+        control_instance.async_update_parameters = AsyncMock(return_value=[])
+        control_instance.async_heartbeat = AsyncMock()
+        control_instance.heartbeat_loop = AsyncMock()
+        mock_control_cls.return_value = control_instance
+
         yield plants_instance
 
 

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -11,6 +11,7 @@ from pytest_homeassistant_custom_component.common import MockConfigEntry
 from custom_components.sungrow.const import (
     CONF_APP_ID,
     CONF_APP_KEY,
+    CONF_EXTRA_MEASURE_POINTS,
     CONF_SCAN_INTERVAL,
     DOMAIN,
 )
@@ -309,3 +310,46 @@ async def test_options_flow_sets_scan_interval(hass: HomeAssistant, mock_setup_a
 
     assert result2["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
     assert entry.options[CONF_SCAN_INTERVAL] == 10
+
+
+async def test_options_flow_parses_extra_measure_points(hass: HomeAssistant, mock_setup_auth, mock_plants_service):
+    """The options flow parses the free-text extra measure point mapping."""
+    entry = MockConfigEntry(domain=DOMAIN, data=MOCK_CONFIG_DATA.copy(), unique_id="test_app_id")
+    entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+
+    result = await hass.config_entries.options.async_init(entry.entry_id)
+    result2 = await hass.config_entries.options.async_configure(
+        result["flow_id"],
+        user_input={
+            CONF_SCAN_INTERVAL: 5,
+            CONF_EXTRA_MEASURE_POINTS: "99999=battery_charge_power, 99998=battery_discharge_power",
+        },
+    )
+    await hass.async_block_till_done()
+
+    assert result2["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
+    assert entry.options[CONF_EXTRA_MEASURE_POINTS] == {
+        "99999": "battery_charge_power",
+        "99998": "battery_discharge_power",
+    }
+
+
+async def test_options_flow_rejects_invalid_extra_measure_points(
+    hass: HomeAssistant, mock_setup_auth, mock_plants_service
+):
+    """The options flow rejects malformed extra measure point input."""
+    entry = MockConfigEntry(domain=DOMAIN, data=MOCK_CONFIG_DATA.copy(), unique_id="test_app_id")
+    entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+
+    result = await hass.config_entries.options.async_init(entry.entry_id)
+    result2 = await hass.config_entries.options.async_configure(
+        result["flow_id"],
+        user_input={CONF_SCAN_INTERVAL: 5, CONF_EXTRA_MEASURE_POINTS: "not_a_mapping"},
+    )
+
+    assert result2["type"] == data_entry_flow.FlowResultType.FORM
+    assert result2["errors"] is not None

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -8,7 +8,7 @@ from homeassistant.exceptions import ConfigEntryAuthFailed
 from homeassistant.helpers.update_coordinator import UpdateFailed
 from pysolarcloud import PySolarCloudException
 
-from custom_components.sungrow.const import CONF_SCAN_INTERVAL
+from custom_components.sungrow.const import CONF_EXTRA_MEASURE_POINTS, CONF_SCAN_INTERVAL
 from custom_components.sungrow.coordinator import SungrowPlantCoordinator, is_auth_error
 
 from .conftest import MOCK_REALTIME_DATA
@@ -103,3 +103,28 @@ async def test_scan_interval_from_options(hass: HomeAssistant):
     entry = _make_entry({CONF_SCAN_INTERVAL: 30})
     coordinator = SungrowPlantCoordinator(hass, entry, MagicMock(), "1", "P")
     assert coordinator.update_interval.total_seconds() == 30 * 60
+
+
+async def test_extra_measure_points_passed_to_api(hass: HomeAssistant):
+    """Extra measure points from options are forwarded to pysolarcloud."""
+    plants = MagicMock()
+    plants.async_get_realtime_data = AsyncMock(return_value={"12345": {}})
+
+    entry = _make_entry({CONF_EXTRA_MEASURE_POINTS: {"99999": "battery_charge_power"}})
+    coordinator = SungrowPlantCoordinator(hass, entry, plants, "12345", "Test Plant")
+    await coordinator._async_update_data()
+
+    plants.async_get_realtime_data.assert_awaited_once_with(
+        ["12345"], extra_measure_points={"99999": "battery_charge_power"}
+    )
+
+
+async def test_extra_measure_points_empty_passes_none(hass: HomeAssistant):
+    """When no extra measure points are configured, None is passed to the API."""
+    plants = MagicMock()
+    plants.async_get_realtime_data = AsyncMock(return_value={"12345": {}})
+
+    coordinator = SungrowPlantCoordinator(hass, _make_entry(), plants, "12345", "Test Plant")
+    await coordinator._async_update_data()
+
+    plants.async_get_realtime_data.assert_awaited_once_with(["12345"], extra_measure_points=None)

--- a/tests/test_dispatch.py
+++ b/tests/test_dispatch.py
@@ -1,0 +1,192 @@
+"""Tests for the Sungrow dispatch (number/select) platforms."""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from homeassistant.components.number import NumberDeviceClass
+from homeassistant.components.select import SelectEntity
+from homeassistant.core import HomeAssistant
+from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+from custom_components.sungrow.const import DOMAIN
+from custom_components.sungrow.number import DISPATCH_NUMBERS
+from custom_components.sungrow.number import async_setup_entry as number_setup_entry
+from custom_components.sungrow.select import DISPATCH_SELECTS
+from custom_components.sungrow.select import async_setup_entry as select_setup_entry
+
+from .conftest import MOCK_CONFIG_DATA
+
+
+def _coordinator_with(plant_id, plant_name):
+    coordinator = MagicMock()
+    coordinator.plant_id = plant_id
+    coordinator.plant_name = plant_name
+    coordinator.config_entry = MagicMock()
+    coordinator.last_update_success = True
+    return coordinator
+
+
+def _entry_data_for(devices):
+    control = MagicMock()
+    control.async_update_parameters = AsyncMock(return_value=[])
+    control.async_heartbeat = AsyncMock()
+    control.heartbeat_loop = AsyncMock()
+    return {
+        "coordinators": [_coordinator_with("12345", "Test Plant")],
+        "control": control,
+        "devices": {"12345": devices},
+        "heartbeat_stop": {},
+    }
+
+
+async def test_number_setup_creates_entities_for_ess_device(hass: HomeAssistant):
+    """Dispatch numbers are created when an ESS device is discovered."""
+    entry = MockConfigEntry(domain=DOMAIN, data=MOCK_CONFIG_DATA.copy())
+    entry.add_to_hass(hass)
+    devices = [{"uuid": "dev-uuid-1", "device_type": "ENERGY_STORAGE_SYSTEM", "device_name": "Inverter 1"}]
+    hass.data.setdefault(DOMAIN, {})[entry.entry_id] = _entry_data_for(devices)
+
+    added = []
+    await number_setup_entry(hass, entry, lambda entities: added.extend(entities))
+
+    assert len(added) == len(DISPATCH_NUMBERS)
+    power = next(e for e in added if e.param == "charge_discharge_power")
+    assert power._attr_device_class == NumberDeviceClass.POWER
+    assert power._attr_native_unit_of_measurement == "W"
+
+
+async def test_number_setup_falls_back_to_inverter(hass: HomeAssistant):
+    """Dispatch numbers fall back to an inverter device if no ESS device exists."""
+    entry = MockConfigEntry(domain=DOMAIN, data=MOCK_CONFIG_DATA.copy())
+    entry.add_to_hass(hass)
+    devices = [{"uuid": "dev-uuid-2", "device_type": "INVERTER"}]
+    hass.data.setdefault(DOMAIN, {})[entry.entry_id] = _entry_data_for(devices)
+
+    added = []
+    await number_setup_entry(hass, entry, lambda entities: added.extend(entities))
+
+    assert len(added) == len(DISPATCH_NUMBERS)
+
+
+async def test_number_setup_no_devices(hass: HomeAssistant):
+    """No dispatch numbers are created when no dispatchable devices are found."""
+    entry = MockConfigEntry(domain=DOMAIN, data=MOCK_CONFIG_DATA.copy())
+    entry.add_to_hass(hass)
+    hass.data.setdefault(DOMAIN, {})[entry.entry_id] = _entry_data_for([])
+
+    added = []
+    await number_setup_entry(hass, entry, lambda entities: added.extend(entities))
+
+    assert added == []
+
+
+async def test_number_set_value_calls_control(hass: HomeAssistant):
+    """Setting a number entity writes the parameter via Control."""
+    entry = MockConfigEntry(domain=DOMAIN, data=MOCK_CONFIG_DATA.copy())
+    entry.add_to_hass(hass)
+    devices = [{"uuid": "dev-uuid-1", "device_type": "ENERGY_STORAGE_SYSTEM"}]
+    entry_data = _entry_data_for(devices)
+    hass.data.setdefault(DOMAIN, {})[entry.entry_id] = entry_data
+
+    added = []
+    await number_setup_entry(hass, entry, lambda entities: added.extend(entities))
+    power = next(e for e in added if e.param == "charge_discharge_power")
+
+    with patch("custom_components.sungrow.number.async_start_heartbeat", new=AsyncMock()):
+        await power.async_set_native_value(2500)
+
+    entry_data["control"].async_update_parameters.assert_awaited_once_with(
+        "dev-uuid-1", {"charge_discharge_power": "2500"}
+    )
+
+
+async def test_number_starts_heartbeat_for_power_changes(hass: HomeAssistant):
+    """Changing charge/discharge power starts the EMS heartbeat loop."""
+    entry = MockConfigEntry(domain=DOMAIN, data=MOCK_CONFIG_DATA.copy())
+    entry.add_to_hass(hass)
+    devices = [{"uuid": "dev-uuid-1", "device_type": "ENERGY_STORAGE_SYSTEM"}]
+    entry_data = _entry_data_for(devices)
+    hass.data.setdefault(DOMAIN, {})[entry.entry_id] = entry_data
+
+    added = []
+    await number_setup_entry(hass, entry, lambda entities: added.extend(entities))
+    power = next(e for e in added if e.param == "charge_discharge_power")
+
+    with patch("custom_components.sungrow.number.async_start_heartbeat", new=AsyncMock()) as mock_start:
+        await power.async_set_native_value(1500)
+
+    mock_start.assert_awaited_once()
+    assert mock_start.call_args.args[3] == "dev-uuid-1"
+
+
+async def test_select_setup_creates_entities_for_ess_device(hass: HomeAssistant):
+    """Dispatch selects are created when an ESS device is discovered."""
+    entry = MockConfigEntry(domain=DOMAIN, data=MOCK_CONFIG_DATA.copy())
+    entry.add_to_hass(hass)
+    devices = [{"uuid": "dev-uuid-1", "device_type": "ENERGY_STORAGE_SYSTEM"}]
+    hass.data.setdefault(DOMAIN, {})[entry.entry_id] = _entry_data_for(devices)
+
+    added = []
+    await select_setup_entry(hass, entry, lambda entities: added.extend(entities))
+
+    assert len(added) == len(DISPATCH_SELECTS)
+    command = next(e for e in added if e.param == "charge_discharge_command")
+    assert isinstance(command, SelectEntity)
+    assert set(command.options_map.keys()) == {"Stop", "Charge", "Discharge"}
+
+
+async def test_select_option_calls_control(hass: HomeAssistant):
+    """Selecting an option writes the parameter via Control."""
+    entry = MockConfigEntry(domain=DOMAIN, data=MOCK_CONFIG_DATA.copy())
+    entry.add_to_hass(hass)
+    devices = [{"uuid": "dev-uuid-1", "device_type": "ENERGY_STORAGE_SYSTEM"}]
+    entry_data = _entry_data_for(devices)
+    hass.data.setdefault(DOMAIN, {})[entry.entry_id] = entry_data
+
+    added = []
+    await select_setup_entry(hass, entry, lambda entities: added.extend(entities))
+    command = next(e for e in added if e.param == "charge_discharge_command")
+
+    with patch("custom_components.sungrow.select.async_start_heartbeat", new=AsyncMock()):
+        await command.async_select_option("Charge")
+
+    entry_data["control"].async_update_parameters.assert_awaited_once_with(
+        "dev-uuid-1", {"charge_discharge_command": "170"}
+    )
+
+
+async def test_select_stop_stops_heartbeat(hass: HomeAssistant):
+    """Selecting 'Stop' stops the EMS heartbeat loop."""
+    entry = MockConfigEntry(domain=DOMAIN, data=MOCK_CONFIG_DATA.copy())
+    entry.add_to_hass(hass)
+    devices = [{"uuid": "dev-uuid-1", "device_type": "ENERGY_STORAGE_SYSTEM"}]
+    entry_data = _entry_data_for(devices)
+    hass.data.setdefault(DOMAIN, {})[entry.entry_id] = entry_data
+
+    added = []
+    await select_setup_entry(hass, entry, lambda entities: added.extend(entities))
+    command = next(e for e in added if e.param == "charge_discharge_command")
+
+    command.hass = hass
+    with patch("custom_components.sungrow.select.async_stop_heartbeat", new=AsyncMock()) as mock_stop:
+        await command.async_select_option("Stop")
+
+    mock_stop.assert_awaited_once_with(hass, command.coordinator.config_entry, "12345")
+
+
+async def test_entity_removal_stops_heartbeat(hass: HomeAssistant):
+    """Removing a dispatch entity stops the heartbeat for the plant."""
+    entry = MockConfigEntry(domain=DOMAIN, data=MOCK_CONFIG_DATA.copy())
+    entry.add_to_hass(hass)
+    devices = [{"uuid": "dev-uuid-1", "device_type": "ENERGY_STORAGE_SYSTEM"}]
+    entry_data = _entry_data_for(devices)
+    hass.data.setdefault(DOMAIN, {})[entry.entry_id] = entry_data
+
+    added = []
+    await number_setup_entry(hass, entry, lambda entities: added.extend(entities))
+    number = added[0]
+
+    number.hass = hass
+    with patch("custom_components.sungrow.number.async_stop_heartbeat", new=AsyncMock()) as mock_stop:
+        await number.async_will_remove_from_hass()
+
+    mock_stop.assert_awaited_once_with(hass, number.coordinator.config_entry, "12345")

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -44,7 +44,8 @@ async def test_async_setup_entry_success(hass: HomeAssistant, mock_setup_auth, m
     await hass.async_block_till_done()
 
     assert entry.state is ConfigEntryState.LOADED
-    coordinators = hass.data[DOMAIN][entry.entry_id]
+    entry_data = hass.data[DOMAIN][entry.entry_id]
+    coordinators = entry_data["coordinators"]
     # MOCK_PLANT_LIST has two plants.
     assert len(coordinators) == 2
     # Entities were created for the data points.
@@ -117,7 +118,8 @@ async def test_options_change_reloads_entry(hass: HomeAssistant, mock_setup_auth
     await hass.async_block_till_done()
 
     assert entry.state is ConfigEntryState.LOADED
-    coordinators = hass.data[DOMAIN][entry.entry_id]
+    entry_data = hass.data[DOMAIN][entry.entry_id]
+    coordinators = entry_data["coordinators"]
     assert coordinators[0].update_interval.total_seconds() == 15 * 60
 
 

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -73,6 +73,22 @@ class TestSungrowSensor:
         assert sensor._attr_name == "Total Active Power"
         assert sensor._attr_unique_id == "123_total_active_power"
 
+    def test_sensor_alias_for_battery_power(self):
+        """Known opaque battery codes get a friendly alias."""
+        coordinator = self._make_coordinator()
+        init_data = {"code": "total_field_energy_storage_active_power", "value": "-1.4", "unit": "kW"}
+        sensor = SungrowSensor(coordinator, "total_field_energy_storage_active_power", "123", "My Plant", init_data)
+
+        assert sensor._attr_name == "Battery Power"
+
+    def test_sensor_alias_for_extra_measure_point(self):
+        """User-configured extra measure points use documented aliases when available."""
+        coordinator = self._make_coordinator()
+        init_data = {"code": "battery_charge_power", "value": "1500", "unit": "W"}
+        sensor = SungrowSensor(coordinator, "battery_charge_power", "123", "My Plant", init_data)
+
+        assert sensor._attr_name == "Battery Charge Power"
+
     def test_sensor_name_numeric_code_fallback(self):
         """Test sensor with a numeric code falls back to init_data name."""
         coordinator = self._make_coordinator()
@@ -218,7 +234,12 @@ async def test_sensor_setup_creates_entities(hass: HomeAssistant):
         ),
         _coordinator_with("67890", "Plant B", {"total_active_power": {"value": "3.1", "unit": "kW"}}),
     ]
-    hass.data.setdefault(DOMAIN, {})[entry.entry_id] = coordinators
+    hass.data.setdefault(DOMAIN, {})[entry.entry_id] = {
+        "coordinators": coordinators,
+        "control": MagicMock(),
+        "devices": {},
+        "heartbeat_stop": {},
+    }
 
     added = []
     await async_setup_entry(hass, entry, lambda entities: added.extend(entities))
@@ -234,7 +255,12 @@ async def test_sensor_setup_skips_plant_with_no_data(hass: HomeAssistant):
     entry.add_to_hass(hass)
 
     coordinators = [_coordinator_with("12345", "Plant A", {}), _coordinator_with("67890", "Plant B", {})]
-    hass.data.setdefault(DOMAIN, {})[entry.entry_id] = coordinators
+    hass.data.setdefault(DOMAIN, {})[entry.entry_id] = {
+        "coordinators": coordinators,
+        "control": MagicMock(),
+        "devices": {},
+        "heartbeat_stop": {},
+    }
 
     added = []
     await async_setup_entry(hass, entry, lambda entities: added.extend(entities))


### PR DESCRIPTION
## Summary

This PR closes the open feature requests by switching to a maintained fork of the upstream API client and adding the missing integration capabilities:

- Closes #7 — adds a sensor mapping guide at `docs/SENSORS.md`.
- Closes #17 — adds dispatch Number/Select entities (charge/discharge command & power, SOC limits, forced charging) with automatic EMS heartbeat.
- Closes #31 — adds friendly battery aliases and a configurable **Extra measure points** option so users can request battery charge/discharge power point IDs for their specific inverter.
- Lays groundwork for #18 — the forked client includes a best-effort `async_get_device_realtime` helper for EV chargers and other device types.

It also changes the release automation so `release-pr.yml` runs automatically on every push to `main`, creating/updating a release PR with the prospective new version:

- `feat!` / `fix!` / `BREAKING CHANGE` → major
- `feat` → minor
- `fix` → patch
- `chore` / `docs` / `style` / `refactor` / `test` / `ci` / `build` → no release

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] Documentation / chore
- [x] CI/CD change

## Checklist

- [x] `ruff check custom_components/ tests/` passes
- [x] `ruff format --check custom_components/ tests/` passes
- [x] `pytest` passes and new/changed behaviour is covered by tests
- [x] Documentation updated (`docs/SENSORS.md`, `README.md`)

## Notes

The `sungrow-isolarcloud` package (the KRoperUK/pysolarcloud fork) is published on PyPI at v0.5.0, and the manifest pins it directly: `sungrow-isolarcloud==0.5.0`.
