### PR TITLE
feat!: automatic OAuth callback handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,8 @@ Or manually:
 | **Redirect URI** | Pre-filled; leave as default unless you know what you're doing |
 
 4. Click **Submit** — you'll be shown an authorisation URL.
-5. Visit the URL, log in, and paste the returned **code** back into Home Assistant.
+5. Choose **Authorize automatically (recommended)**. A browser window opens for the iSolarCloud login; after you authorize, Home Assistant receives the code automatically via the `/api/sungrow_hass/callback` endpoint.
+6. If the automatic redirect doesn't work (for example, because iSolarCloud strips query parameters from your redirect URI), choose **Enter code manually** and paste the `code` from the URL.
 
 ### Obtaining Credentials
 

--- a/custom_components/sungrow/__init__.py
+++ b/custom_components/sungrow/__init__.py
@@ -177,7 +177,7 @@ class SungrowAuthCallbackView(HomeAssistantView):
     name = "api:sungrow_hass:callback"
 
     async def get(self, request: web.Request) -> web.Response:
-        """Handle callback."""
+        """Handle callback from iSolarCloud after user authorization."""
         hass: HomeAssistant = request.app["hass"]
         params = request.query
         code = params.get("code")
@@ -189,14 +189,18 @@ class SungrowAuthCallbackView(HomeAssistantView):
 
         _LOGGER.debug("Callback received with code: %s for flow_id: %s", code, flow_id)
 
-        # Retrieve the flow and update it
-        try:
-            await hass.config_entries.flow.async_configure(flow_id=flow_id, user_input={"code": code})
-        except Exception as err:
-            _LOGGER.error("Failed to pass code to config flow: %s", err)
-            return web.Response(text=f"Error occurred while resuming flow: {err}", status=500)
+        # Signal the waiting future so the config flow's background task can
+        # resume the flow cleanly.
+        future = hass.data.get(DOMAIN, {}).get("flows", {}).get(flow_id)
+        if future is not None and not future.done():
+            future.set_result(code)
+            return web.Response(
+                text="Authorization successful! You can close this window and return to Home Assistant.",
+                content_type="text/html",
+            )
 
+        _LOGGER.warning("OAuth callback received for flow %s but no pending future was found", flow_id)
         return web.Response(
-            text="Authorization successful! You can close this window and return to Home Assistant.",
-            content_type="text/html",
+            text="Authorization request not found or already completed. Please return to Home Assistant and try again.",
+            status=400,
         )

--- a/custom_components/sungrow/config_flow.py
+++ b/custom_components/sungrow/config_flow.py
@@ -1,5 +1,6 @@
 """Config flow for Sungrow iSolarCloud integration."""
 
+import asyncio
 import logging
 from typing import Any
 
@@ -106,29 +107,107 @@ class SungrowConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             errors=errors,
         )
 
+    def _ensure_auth_client(self) -> bool:
+        """Initialize the pysolarcloud Auth client if needed.
+
+        Returns True on success, False if the library is missing.
+        """
+        if self.auth_client:
+            return True
+
+        session = async_get_clientsession(self.hass)
+        gateway_url = GATEWAYS[self.init_info[CONF_GATEWAY]]
+
+        if Auth is None:
+            return False
+
+        self.auth_client = Auth(
+            host=gateway_url,
+            appkey=self.init_info[CONF_APP_KEY],
+            access_key=self.init_info[CONF_APP_SECRET],
+            app_id=self.init_info[CONF_APP_ID],
+            websession=session,
+        )
+        _LOGGER.info("Initialized Auth client for Sungrow iSolarCloud")
+        _LOGGER.debug("Auth client details: %s", self.auth_client)
+        return True
+
+    def _auth_url_with_flow_id(self) -> str:
+        """Build the iSolarCloud authorization URL including this flow's ID.
+
+        The flow_id lets the callback view resume the correct config flow when
+        iSolarCloud redirects back to /api/sungrow_hass/callback.
+        """
+        redirect_uri = self.init_info[CONF_REDIRECT_URI].rstrip("/")
+        # Preserve any existing query params on the configured redirect URI.
+        separator = "&" if "?" in redirect_uri else "?"
+        callback_redirect = f"{redirect_uri}{separator}flow_id={self.flow_id}"
+        return self.auth_client.auth_url(callback_redirect)
+
     async def async_step_auth(self, user_input: dict[str, Any] | None = None):
-        """Handle the authorization step."""
+        """Choose how to complete the OAuth authorization."""
+        if not self._ensure_auth_client():
+            return self.async_abort(reason="library_missing")
+
+        if user_input is not None:
+            # Menu selections arrive as {"next_step_id": "..."}
+            next_step = user_input.get("next_step_id")
+            method = "manual" if next_step == "auth_manual" else "callback"
+            self.context["method"] = method
+            if method == "manual":
+                return await self.async_step_auth_manual()
+            return await self.async_step_auth_callback()
+
+        auth_url = self._auth_url_with_flow_id()
+        return self.async_show_menu(
+            step_id="auth",
+            menu_options=["auth_callback", "auth_manual"],
+            description_placeholders={"auth_url": auth_url},
+        )
+
+    async def async_step_auth_callback(self, user_input: dict[str, Any] | None = None):
+        """Wait for iSolarCloud to redirect back to the callback endpoint.
+
+        The callback view extracts the authorization code and calls
+        async_configure, which re-enters this step with user_input={"code": ...}.
+        """
+        if user_input is not None and user_input.get("code"):
+            self.context["code"] = user_input["code"]
+            return self.async_show_progress_done(next_step_id="finish")
+
+        # Register this flow so the callback view can resume it.
+        flows = self.hass.data.setdefault(DOMAIN, {}).setdefault("flows", {})
+        future: asyncio.Future[str] = asyncio.Future()
+        flows[self.flow_id] = future
+
+        auth_url = self._auth_url_with_flow_id()
+
+        async def _wait_for_callback() -> None:
+            """Resume the flow once the OAuth callback delivers a code."""
+            try:
+                code = await future
+            except asyncio.CancelledError:
+                return
+            finally:
+                flows.pop(self.flow_id, None)
+            try:
+                await self.hass.config_entries.flow.async_configure(flow_id=self.flow_id, user_input={"code": code})
+            except Exception:  # pylint: disable=broad-except
+                _LOGGER.exception("Failed to resume config flow from OAuth callback")
+
+        task = self.hass.async_create_background_task(_wait_for_callback(), name="sungrow-oauth-callback")
+
+        return self.async_show_progress(
+            step_id="auth_callback",
+            progress_action="wait_for_callback",
+            progress_task=task,
+            description_placeholders={"auth_url": auth_url},
+        )
+
+    async def async_step_auth_manual(self, user_input: dict[str, Any] | None = None):
+        """Handle manual entry of the authorization code or full redirect URL."""
+        self.context["method"] = "manual"
         errors = {}
-
-        # Initialize Auth client
-        if not self.auth_client:
-            session = async_get_clientsession(self.hass)
-            gateway_url = GATEWAYS[self.init_info[CONF_GATEWAY]]
-
-            # Ensure Auth is available
-            if Auth is None:
-                # Fallback or error if library missing
-                return self.async_abort(reason="library_missing")
-
-            self.auth_client = Auth(
-                host=gateway_url,
-                appkey=self.init_info[CONF_APP_KEY],
-                access_key=self.init_info[CONF_APP_SECRET],
-                app_id=self.init_info[CONF_APP_ID],
-                websession=session,
-            )
-            _LOGGER.info("Initialized Auth client for Sungrow iSolarCloud")
-            _LOGGER.debug(f"Auth client details: {self.auth_client}")
 
         if user_input is not None and user_input.get("code"):
             try:
@@ -141,7 +220,6 @@ class SungrowConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                     if "code" in query:
                         code = query["code"][0]
                     else:
-                        # Fallback if maybe it's in the fragment?
                         query = parse_qs(parsed.fragment.split("?")[-1] if "?" in parsed.fragment else "")
                         if "code" in query:
                             code = query["code"][0]
@@ -151,60 +229,77 @@ class SungrowConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 else:
                     code = code_input
 
-                # We need the base redirect URI without the flow_id param for the token exchange
-                # The code we get implies the user was redirected to: URI?flow_id=123&code=ABC
-                # For exchange, we must send the exact SAME redirect_uri sent in auth request.
+                self.context["code"] = code
+                return self.async_show_progress_done(next_step_id="finish")
 
-                # Use the clean redirect URI without flow_id for the token exchange
-                # This ensures it matches exactly what was sent in the auth request
-                # (and prevents issues if the provider strips query params)
-                redirect_uri_clean = self.init_info[CONF_REDIRECT_URI]
-
-                _LOGGER.info("Authorizing with code: %s and redirect_uri: %s", code, redirect_uri_clean)
-                await self.auth_client.async_authorize(code, redirect_uri_clean)
-
-                # Get the tokens
-                tokens = self.auth_client.tokens
-                _LOGGER.debug(f"Received tokens: {tokens}")
-
-                if not tokens or not tokens.get("access_token"):
-                    _LOGGER.error("Failed to retrieve tokens")
-                    errors["base"] = "invalid_auth"
-                else:
-                    # We can store tokens in the config entry data
-                    data = {**self.init_info, "tokens": tokens}
-
-                    if self._reauth_entry is not None:
-                        # Update the existing entry in place and reload it, so the user
-                        # never has to delete and re-add the integration (issue #14).
-                        return self.async_update_reload_and_abort(self._reauth_entry, data=data)
-
-                    await self.async_set_unique_id(str(self.init_info[CONF_APP_ID]))
-                    self._abort_if_unique_id_configured()
-                    return self.async_create_entry(title=f"Sungrow {self.init_info[CONF_APP_ID]}", data=data)
-
-            except data_entry_flow.AbortFlow:
-                # Let HA handle flow aborts (e.g. already_configured) normally.
-                raise
-            except ClientError as e:
-                _LOGGER.warning("Client connection error in async_step_auth: %s", e)
-                errors["base"] = "cannot_connect"
             except Exception as e:  # pylint: disable=broad-except
-                _LOGGER.exception("Unexpected exception in async_step_auth: %s", e)
+                _LOGGER.exception("Unexpected exception in async_step_auth_manual: %s", e)
                 errors["base"] = "unknown"
 
-        # Generate auth URL
-        redirect_uri_clean = self.init_info[CONF_REDIRECT_URI]
-
-        # We use the clean URI (no flow_id) to potentially avoid provider issues with query params
-        auth_url = self.auth_client.auth_url(redirect_uri_clean)
-
+        auth_url = self._auth_url_with_flow_id()
         return self.async_show_form(
-            step_id="auth",
+            step_id="auth_manual",
             description_placeholders={"auth_url": auth_url},
             data_schema=vol.Schema({vol.Optional("code"): str}),
             errors=errors,
         )
+
+    def _finish_error_result(self, error_key: str):
+        """Return a user-facing result for an authorization failure.
+
+        Manual-entry users are sent back to the code form so they can retry;
+        automatic-callback users get an abort because there is no form to return to.
+        """
+        if self.context.get("method") == "manual":
+            auth_url = self._auth_url_with_flow_id()
+            return self.async_show_form(
+                step_id="auth_manual",
+                description_placeholders={"auth_url": auth_url},
+                data_schema=vol.Schema({vol.Optional("code"): str}),
+                errors={"base": error_key},
+            )
+        return self.async_abort(reason=error_key)
+
+    async def async_step_finish(self, user_input: dict[str, Any] | None = None):
+        """Exchange the authorization code for tokens and create the config entry."""
+
+        if not self._ensure_auth_client():
+            return self.async_abort(reason="library_missing")
+
+        code = self.context.get("code")
+        if not code:
+            _LOGGER.error("Finish step reached without an authorization code")
+            return self.async_abort(reason="missing_code")
+
+        try:
+            redirect_uri_clean = self.init_info[CONF_REDIRECT_URI]
+            _LOGGER.info("Authorizing with code: %s and redirect_uri: %s", code, redirect_uri_clean)
+            await self.auth_client.async_authorize(code, redirect_uri_clean)
+
+            tokens = self.auth_client.tokens
+            _LOGGER.debug("Received tokens: %s", tokens)
+
+            if not tokens or not tokens.get("access_token"):
+                _LOGGER.error("Failed to retrieve tokens")
+                return self._finish_error_result("invalid_auth")
+
+            data = {**self.init_info, "tokens": tokens}
+
+            if self._reauth_entry is not None:
+                return self.async_update_reload_and_abort(self._reauth_entry, data=data)
+
+            await self.async_set_unique_id(str(self.init_info[CONF_APP_ID]))
+            self._abort_if_unique_id_configured()
+            return self.async_create_entry(title=f"Sungrow {self.init_info[CONF_APP_ID]}", data=data)
+
+        except data_entry_flow.AbortFlow:
+            raise
+        except ClientError as e:
+            _LOGGER.warning("Client connection error in async_step_finish: %s", e)
+            return self._finish_error_result("cannot_connect")
+        except Exception as e:  # pylint: disable=broad-except
+            _LOGGER.exception("Unexpected exception in async_step_finish: %s", e)
+            return self._finish_error_result("unknown")
 
 
 def _parse_extra_measure_points(raw: str | None) -> dict[str, str]:

--- a/custom_components/sungrow/strings.json
+++ b/custom_components/sungrow/strings.json
@@ -19,9 +19,21 @@
       },
       "auth": {
         "title": "Authorize App",
+        "description": "Please visit the URL below to authorize the application:\n\n{auth_url}\n\n**Instructions:**\n1. Visit the link above and log in.\n2. You will be redirected back to Home Assistant automatically.\n3. If the redirect does not work, choose **Enter code manually** and paste the code from the URL.",
+        "menu_options": {
+          "auth_callback": "Authorize automatically (recommended)",
+          "auth_manual": "Enter code manually"
+        }
+      },
+      "auth_callback": {
+        "title": "Waiting for authorization",
+        "description": "A new window should have opened for:\n\n{auth_url}\n\nAfter you log in and authorize the app, this screen will update automatically."
+      },
+      "auth_manual": {
+        "title": "Enter Authorization Code",
         "description": "Please visit the URL below to authorize the application:\n\n{auth_url}\n\n**Instructions:**\n1. Visit the link above and log in.\n2. You will be redirected (page may show an error).\n3. Copy the **code** parameter from the URL address bar.\n4. Paste it below.",
         "data": {
-          "code": "Authorization Code"
+          "code": "Authorization Code or full redirect URL"
         }
       }
     },
@@ -34,6 +46,7 @@
     },
     "abort": {
       "already_configured": "Device is already configured",
+      "missing_code": "Authorization code was not received. Please try again.",
       "reauth_successful": "Re-authentication was successful"
     }
   },

--- a/custom_components/sungrow/translations/en.json
+++ b/custom_components/sungrow/translations/en.json
@@ -19,9 +19,21 @@
       },
       "auth": {
         "title": "Authorize App",
+        "description": "Please visit the URL below to authorize the application:\n\n{auth_url}\n\n**Instructions:**\n1. Visit the link above and log in.\n2. You will be redirected back to Home Assistant automatically.\n3. If the redirect does not work, choose **Enter code manually** and paste the code from the URL.",
+        "menu_options": {
+          "auth_callback": "Authorize automatically (recommended)",
+          "auth_manual": "Enter code manually"
+        }
+      },
+      "auth_callback": {
+        "title": "Waiting for authorization",
+        "description": "A new window should have opened for:\n\n{auth_url}\n\nAfter you log in and authorize the app, this screen will update automatically."
+      },
+      "auth_manual": {
+        "title": "Enter Authorization Code",
         "description": "Please visit the URL below to authorize the application:\n\n{auth_url}\n\n**Instructions:**\n1. Visit the link above and log in.\n2. You will be redirected (page may show an error).\n3. Copy the **code** parameter from the URL address bar.\n4. Paste it below.",
         "data": {
-          "code": "Authorization Code"
+          "code": "Authorization Code or full redirect URL"
         }
       }
     },
@@ -34,6 +46,7 @@
     },
     "abort": {
       "already_configured": "Device is already configured",
+      "missing_code": "Authorization code was not received. Please try again.",
       "reauth_successful": "Re-authentication was successful"
     }
   },

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -37,9 +37,15 @@ by the integration itself.
    exchange. Scheme (`http`/`https`), host/IP, and path must all match.
    - Local: `http://homeassistant.local:8123/api/sungrow_hass/callback`
    - Nabu Casa: `https://<your-id>.ui.nabu.casa/api/sungrow_hass/callback`
-5. After agreeing to authorize you may land on a **404 page** — that's expected.
-   Copy the `code` value from the URL bar (or paste the whole URL; the integration
-   extracts the code for you).
+5. **Try automatic authorization first.** The config flow can capture the
+   authorization code automatically when iSolarCloud redirects back to
+   `/api/sungrow_hass/callback`. If this does not complete, use **Enter code
+   manually** and paste the `code` value from the URL bar (or paste the whole URL;
+   the integration extracts the code for you).
+6. If automatic authorization never completes, iSolarCloud may be stripping the
+   `flow_id` query parameter from the redirect URI. In that case rely on the
+   **Enter code manually** option and make sure the base redirect URI still
+   matches the developer portal exactly.
 
 ---
 

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -1,5 +1,6 @@
 """Tests for the Sungrow iSolarCloud config flow."""
 
+import asyncio
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -46,7 +47,7 @@ async def test_user_step_shows_form(hass: HomeAssistant):
 
 
 async def test_user_step_advances_to_auth(hass: HomeAssistant, mock_auth):
-    """Test submitting user form advances to the auth step."""
+    """Test submitting user form advances to the auth menu."""
     result = await hass.config_entries.flow.async_init(DOMAIN, context={"source": config_entries.SOURCE_USER})
 
     result2 = await hass.config_entries.flow.async_configure(
@@ -54,7 +55,7 @@ async def test_user_step_advances_to_auth(hass: HomeAssistant, mock_auth):
         user_input=MOCK_USER_INPUT,
     )
 
-    assert result2["type"] == data_entry_flow.FlowResultType.FORM
+    assert result2["type"] == data_entry_flow.FlowResultType.MENU
     assert result2["step_id"] == "auth"
     # The auth URL should be present in description placeholders
     assert "auth_url" in result2["description_placeholders"]
@@ -66,29 +67,36 @@ async def test_user_step_advances_to_auth(hass: HomeAssistant, mock_auth):
 
 
 async def test_auth_step_success(hass: HomeAssistant, mock_auth):
-    """Test a full successful flow: user → auth → entry created."""
+    """Test a full successful flow: user -> auth menu -> manual -> entry created."""
     # Step 1: init
     result = await hass.config_entries.flow.async_init(DOMAIN, context={"source": config_entries.SOURCE_USER})
 
-    # Step 2: submit user info
+    # Step 2: submit user info -> auth menu
     result2 = await hass.config_entries.flow.async_configure(
         result["flow_id"],
         user_input=MOCK_USER_INPUT,
     )
     assert result2["step_id"] == "auth"
 
-    # Step 3: submit the auth code
+    # Step 3: choose manual entry
+    result3 = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        user_input={"next_step_id": "auth_manual"},
+    )
+    assert result3["step_id"] == "auth_manual"
+
+    # Step 4: submit the auth code
     with patch("custom_components.sungrow.async_setup_entry", return_value=True):
-        result3 = await hass.config_entries.flow.async_configure(
+        result4 = await hass.config_entries.flow.async_configure(
             result["flow_id"],
             user_input={"code": "auth_code_from_provider"},
         )
         await hass.async_block_till_done()
 
-    assert result3["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
-    assert result3["title"] == f"Sungrow {MOCK_USER_INPUT[CONF_APP_ID]}"
-    assert result3["data"]["tokens"]["access_token"] == "test_access_token"
-    assert result3["data"][CONF_APP_KEY] == MOCK_USER_INPUT[CONF_APP_KEY]
+    assert result4["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
+    assert result4["title"] == f"Sungrow {MOCK_USER_INPUT[CONF_APP_ID]}"
+    assert result4["data"]["tokens"]["access_token"] == "test_access_token"
+    assert result4["data"][CONF_APP_KEY] == MOCK_USER_INPUT[CONF_APP_KEY]
 
 
 # ---------------------------------------------------------------------------
@@ -99,20 +107,18 @@ async def test_auth_step_success(hass: HomeAssistant, mock_auth):
 async def test_auth_step_extracts_code_from_url(hass: HomeAssistant, mock_auth):
     """Test that pasting a full callback URL extracts the code automatically."""
     result = await hass.config_entries.flow.async_init(DOMAIN, context={"source": config_entries.SOURCE_USER})
-    await hass.config_entries.flow.async_configure(
-        result["flow_id"],
-        user_input=MOCK_USER_INPUT,
-    )
+    await hass.config_entries.flow.async_configure(result["flow_id"], user_input=MOCK_USER_INPUT)
+    await hass.config_entries.flow.async_configure(result["flow_id"], user_input={"next_step_id": "auth_manual"})
 
     callback_url = "http://homeassistant.local:8123/api/sungrow_hass/callback?code=extracted_code&flow_id=123"
     with patch("custom_components.sungrow.async_setup_entry", return_value=True):
-        result3 = await hass.config_entries.flow.async_configure(
+        result4 = await hass.config_entries.flow.async_configure(
             result["flow_id"],
             user_input={"code": callback_url},
         )
         await hass.async_block_till_done()
 
-    assert result3["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
+    assert result4["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
     # Verify Auth.async_authorize was called with the extracted code
     mock_auth.async_authorize.assert_called_once()
     call_args = mock_auth.async_authorize.call_args
@@ -124,21 +130,24 @@ async def test_auth_step_extracts_code_from_url(hass: HomeAssistant, mock_auth):
 # ---------------------------------------------------------------------------
 
 
+async def _navigate_to_auth_manual(hass: HomeAssistant, flow_id: str):
+    """Helper: move from the auth menu to the manual code entry step."""
+    await hass.config_entries.flow.async_configure(flow_id, user_input=MOCK_USER_INPUT)
+    await hass.config_entries.flow.async_configure(flow_id, user_input={"next_step_id": "auth_manual"})
+
+
 async def test_auth_step_no_tokens(hass: HomeAssistant, mock_auth_no_tokens):
     """Test auth step when tokens are empty/missing."""
     result = await hass.config_entries.flow.async_init(DOMAIN, context={"source": config_entries.SOURCE_USER})
-    await hass.config_entries.flow.async_configure(
-        result["flow_id"],
-        user_input=MOCK_USER_INPUT,
-    )
+    await _navigate_to_auth_manual(hass, result["flow_id"])
 
-    result3 = await hass.config_entries.flow.async_configure(
+    result4 = await hass.config_entries.flow.async_configure(
         result["flow_id"],
         user_input={"code": "some_code"},
     )
 
-    assert result3["type"] == data_entry_flow.FlowResultType.FORM
-    assert result3["errors"]["base"] == "invalid_auth"
+    assert result4["type"] == data_entry_flow.FlowResultType.FORM
+    assert result4["errors"]["base"] == "invalid_auth"
 
 
 async def test_auth_step_connection_error(hass: HomeAssistant, mock_auth):
@@ -146,18 +155,15 @@ async def test_auth_step_connection_error(hass: HomeAssistant, mock_auth):
     mock_auth.async_authorize = AsyncMock(side_effect=ClientError("Connection failed"))
 
     result = await hass.config_entries.flow.async_init(DOMAIN, context={"source": config_entries.SOURCE_USER})
-    await hass.config_entries.flow.async_configure(
-        result["flow_id"],
-        user_input=MOCK_USER_INPUT,
-    )
+    await _navigate_to_auth_manual(hass, result["flow_id"])
 
-    result3 = await hass.config_entries.flow.async_configure(
+    result4 = await hass.config_entries.flow.async_configure(
         result["flow_id"],
         user_input={"code": "some_code"},
     )
 
-    assert result3["type"] == data_entry_flow.FlowResultType.FORM
-    assert result3["errors"]["base"] == "cannot_connect"
+    assert result4["type"] == data_entry_flow.FlowResultType.FORM
+    assert result4["errors"]["base"] == "cannot_connect"
 
 
 async def test_auth_step_unexpected_error(hass: HomeAssistant, mock_auth):
@@ -165,18 +171,15 @@ async def test_auth_step_unexpected_error(hass: HomeAssistant, mock_auth):
     mock_auth.async_authorize = AsyncMock(side_effect=RuntimeError("Boom"))
 
     result = await hass.config_entries.flow.async_init(DOMAIN, context={"source": config_entries.SOURCE_USER})
-    await hass.config_entries.flow.async_configure(
-        result["flow_id"],
-        user_input=MOCK_USER_INPUT,
-    )
+    await _navigate_to_auth_manual(hass, result["flow_id"])
 
-    result3 = await hass.config_entries.flow.async_configure(
+    result4 = await hass.config_entries.flow.async_configure(
         result["flow_id"],
         user_input={"code": "some_code"},
     )
 
-    assert result3["type"] == data_entry_flow.FlowResultType.FORM
-    assert result3["errors"]["base"] == "unknown"
+    assert result4["type"] == data_entry_flow.FlowResultType.FORM
+    assert result4["errors"]["base"] == "unknown"
 
 
 # ---------------------------------------------------------------------------
@@ -205,21 +208,18 @@ async def test_auth_step_library_missing(hass: HomeAssistant):
 async def test_auth_step_code_in_url_without_code_param(hass: HomeAssistant, mock_auth):
     """Test that pasting a URL without a 'code' query param falls back to fragment parsing."""
     result = await hass.config_entries.flow.async_init(DOMAIN, context={"source": config_entries.SOURCE_USER})
-    await hass.config_entries.flow.async_configure(
-        result["flow_id"],
-        user_input=MOCK_USER_INPUT,
-    )
+    await _navigate_to_auth_manual(hass, result["flow_id"])
 
     # URL with code in the fragment (SPA-style redirect)
     fragment_url = "http://homeassistant.local:8123/callback#state=abc?code=frag_code"
     with patch("custom_components.sungrow.async_setup_entry", return_value=True):
-        result3 = await hass.config_entries.flow.async_configure(
+        result4 = await hass.config_entries.flow.async_configure(
             result["flow_id"],
             user_input={"code": fragment_url},
         )
         await hass.async_block_till_done()
 
-    assert result3["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
+    assert result4["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
     mock_auth.async_authorize.assert_called_once()
     call_args = mock_auth.async_authorize.call_args
     assert call_args[0][0] == "frag_code"
@@ -228,20 +228,17 @@ async def test_auth_step_code_in_url_without_code_param(hass: HomeAssistant, moc
 async def test_auth_step_url_without_code_anywhere(hass: HomeAssistant, mock_auth):
     """Test that a URL with no code param in query OR fragment returns invalid_auth."""
     result = await hass.config_entries.flow.async_init(DOMAIN, context={"source": config_entries.SOURCE_USER})
-    await hass.config_entries.flow.async_configure(
-        result["flow_id"],
-        user_input=MOCK_USER_INPUT,
-    )
+    await _navigate_to_auth_manual(hass, result["flow_id"])
 
     # URL that starts with http but has no 'code' anywhere
     bad_url = "http://example.com/callback?state=abc&other=value"
-    result3 = await hass.config_entries.flow.async_configure(
+    result4 = await hass.config_entries.flow.async_configure(
         result["flow_id"],
         user_input={"code": bad_url},
     )
 
-    assert result3["type"] == data_entry_flow.FlowResultType.FORM
-    assert result3["errors"]["base"] == "unknown"
+    assert result4["type"] == data_entry_flow.FlowResultType.FORM
+    assert result4["errors"]["base"] == "unknown"
 
 
 # ---------------------------------------------------------------------------
@@ -256,18 +253,84 @@ async def test_user_step_aborts_if_already_configured(hass: HomeAssistant, mock_
 
     result = await hass.config_entries.flow.async_init(DOMAIN, context={"source": config_entries.SOURCE_USER})
     await hass.config_entries.flow.async_configure(result["flow_id"], user_input=MOCK_USER_INPUT)
-    result3 = await hass.config_entries.flow.async_configure(
+    await hass.config_entries.flow.async_configure(result["flow_id"], user_input={"next_step_id": "auth_manual"})
+    result4 = await hass.config_entries.flow.async_configure(
         result["flow_id"],
         user_input={"code": "auth_code_from_provider"},
     )
 
-    assert result3["type"] == data_entry_flow.FlowResultType.ABORT
-    assert result3["reason"] == "already_configured"
+    assert result4["type"] == data_entry_flow.FlowResultType.ABORT
+    assert result4["reason"] == "already_configured"
 
 
 # ---------------------------------------------------------------------------
 # Reauth flow
 # ---------------------------------------------------------------------------
+
+
+async def test_auth_url_includes_flow_id(hass: HomeAssistant, mock_auth):
+    """Test the authorization URL embeds the current config flow ID."""
+    result = await hass.config_entries.flow.async_init(DOMAIN, context={"source": config_entries.SOURCE_USER})
+    await hass.config_entries.flow.async_configure(result["flow_id"], user_input=MOCK_USER_INPUT)
+
+    mock_auth.auth_url.assert_called_once()
+    redirect_uri = mock_auth.auth_url.call_args[0][0]
+    assert f"flow_id={result['flow_id']}" in redirect_uri
+
+
+async def test_auth_callback_step_registers_future(hass: HomeAssistant, mock_auth):
+    """Test choosing automatic authorization registers a callback future."""
+    result = await hass.config_entries.flow.async_init(DOMAIN, context={"source": config_entries.SOURCE_USER})
+    await hass.config_entries.flow.async_configure(result["flow_id"], user_input=MOCK_USER_INPUT)
+
+    result3 = await hass.config_entries.flow.async_configure(
+        result["flow_id"], user_input={"next_step_id": "auth_callback"}
+    )
+    assert result3["step_id"] == "auth_callback"
+    assert result3["type"] == data_entry_flow.FlowResultType.SHOW_PROGRESS
+
+    flows = hass.data[DOMAIN]["flows"]
+    assert result["flow_id"] in flows
+    assert isinstance(flows[result["flow_id"]], asyncio.Future)
+
+
+async def test_callback_view_resumes_flow(hass: HomeAssistant, mock_auth):
+    """Test the HTTP callback view delivers the code and completes the flow."""
+    from custom_components.sungrow import SungrowAuthCallbackView
+
+    result = await hass.config_entries.flow.async_init(DOMAIN, context={"source": config_entries.SOURCE_USER})
+    await hass.config_entries.flow.async_configure(result["flow_id"], user_input=MOCK_USER_INPUT)
+    result3 = await hass.config_entries.flow.async_configure(
+        result["flow_id"], user_input={"next_step_id": "auth_callback"}
+    )
+    assert result3["type"] == data_entry_flow.FlowResultType.SHOW_PROGRESS
+
+    request = MagicMock()
+    request.app = {"hass": hass}
+    request.query = {"code": "callback_code", "flow_id": result["flow_id"]}
+    view = SungrowAuthCallbackView()
+
+    with patch("custom_components.sungrow.async_setup_entry", return_value=True):
+        response = await view.get(request)
+        # Wait for the progress task to resume and finish the flow.
+        await hass.async_block_till_done()
+        await hass.async_block_till_done()
+
+    assert response.status == 200
+    mock_auth.async_authorize.assert_called_once_with("callback_code", MOCK_USER_INPUT["redirect_uri"])
+
+
+async def test_callback_view_rejects_unknown_flow(hass: HomeAssistant, mock_auth):
+    """Test the HTTP callback view rejects callbacks for unknown flows."""
+    from custom_components.sungrow import SungrowAuthCallbackView
+
+    request = MagicMock()
+    request.app = {"hass": hass}
+    request.query = {"code": "callback_code", "flow_id": "unknown-flow"}
+    view = SungrowAuthCallbackView()
+
+    response = await view.get(request)
+    assert response.status == 400
 
 
 async def test_reauth_flow_updates_entry(hass: HomeAssistant, mock_auth, mock_setup_auth, mock_plants_service):
@@ -276,16 +339,21 @@ async def test_reauth_flow_updates_entry(hass: HomeAssistant, mock_auth, mock_se
     entry.add_to_hass(hass)
 
     result = await entry.start_reauth_flow(hass)
-    assert result["type"] == data_entry_flow.FlowResultType.FORM
+    assert result["type"] == data_entry_flow.FlowResultType.MENU
     assert result["step_id"] == "auth"
 
-    # Provide a fresh authorization code.
+    # Choose manual entry and provide a fresh authorization code.
+    result2 = await hass.config_entries.flow.async_configure(
+        result["flow_id"], user_input={"next_step_id": "auth_manual"}
+    )
+    assert result2["step_id"] == "auth_manual"
+
     mock_auth.tokens = {"access_token": "fresh_token", "refresh_token": "fresh_refresh", "expires_at": 9999999999}
-    result2 = await hass.config_entries.flow.async_configure(result["flow_id"], user_input={"code": "fresh_code"})
+    result3 = await hass.config_entries.flow.async_configure(result["flow_id"], user_input={"code": "fresh_code"})
     await hass.async_block_till_done()
 
-    assert result2["type"] == data_entry_flow.FlowResultType.ABORT
-    assert result2["reason"] == "reauth_successful"
+    assert result3["type"] == data_entry_flow.FlowResultType.ABORT
+    assert result3["reason"] == "reauth_successful"
     assert entry.data["tokens"]["access_token"] == "fresh_token"
 
 

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -1,6 +1,6 @@
 """Tests for Sungrow component setup and the auth callback view."""
 
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock
 
 from aiohttp.test_utils import make_mocked_request
 from homeassistant.config_entries import ConfigEntryState
@@ -170,34 +170,28 @@ class TestSungrowAuthCallbackView:
         assert response.status == 400
 
     async def test_callback_success(self, hass: HomeAssistant):
-        """Test a successful callback configures the flow."""
+        """Test a successful callback signals the waiting flow future."""
+        import asyncio
+
+        future: asyncio.Future[str] = asyncio.Future()
+        hass.data.setdefault("sungrow", {})["flows"] = {"flow_abc": future}
+
         mock_request = make_mocked_request("GET", "/api/sungrow_hass/callback?code=auth_code_123&flow_id=flow_abc")
         mock_request.app["hass"] = hass
 
-        with patch.object(
-            hass.config_entries.flow,
-            "async_configure",
-            new_callable=AsyncMock,
-            return_value={"type": "create_entry"},
-        ) as mock_configure:
-            response = await self.view.get(mock_request)
+        response = await self.view.get(mock_request)
 
         assert response.status == 200
         assert "Authorization successful" in response.text
-        mock_configure.assert_called_once_with(flow_id="flow_abc", user_input={"code": "auth_code_123"})
+        assert future.done()
+        assert future.result() == "auth_code_123"
 
-    async def test_callback_flow_error(self, hass: HomeAssistant):
-        """Test callback returns 500 when flow configuration fails."""
+    async def test_callback_flow_not_found(self, hass: HomeAssistant):
+        """Test callback returns 400 when no pending flow future exists."""
         mock_request = make_mocked_request("GET", "/api/sungrow_hass/callback?code=auth_code&flow_id=bad_flow")
         mock_request.app["hass"] = hass
 
-        with patch.object(
-            hass.config_entries.flow,
-            "async_configure",
-            new_callable=AsyncMock,
-            side_effect=Exception("Flow not found"),
-        ):
-            response = await self.view.get(mock_request)
+        response = await self.view.get(mock_request)
 
-        assert response.status == 500
-        assert "Error occurred" in response.text
+        assert response.status == 400
+        assert "not found" in response.text.lower()

--- a/tests/test_strings.py
+++ b/tests/test_strings.py
@@ -31,6 +31,8 @@ def test_strings_has_required_steps(strings_data):
     steps = strings_data["config"]["step"]
     assert "user" in steps, "Missing 'user' step"
     assert "auth" in steps, "Missing 'auth' step"
+    assert "auth_manual" in steps, "Missing 'auth_manual' step"
+    assert "auth_callback" in steps, "Missing 'auth_callback' step"
 
 
 def test_strings_user_step_has_required_fields(strings_data):
@@ -42,9 +44,9 @@ def test_strings_user_step_has_required_fields(strings_data):
     )
 
 
-def test_strings_auth_step_has_code_field(strings_data):
-    """Test the auth step defines the 'code' field."""
-    auth_data = strings_data["config"]["step"]["auth"]["data"]
+def test_strings_auth_manual_step_has_code_field(strings_data):
+    """Test the auth_manual step defines the 'code' field."""
+    auth_data = strings_data["config"]["step"]["auth_manual"]["data"]
     assert "code" in auth_data
 
 


### PR DESCRIPTION
## Summary

This PR implements automatic OAuth callback handling for the iSolarCloud config flow, removing the need to manually copy and paste the authorization code when the redirect works.

Closes #34.

## What changed

- Split the auth step into a menu with two options:
  - **Authorize automatically (recommended)** — opens the iSolarCloud URL with the config `flow_id` embedded in the redirect URI. When iSolarCloud redirects back to `/api/sungrow_hass/callback`, the callback view signals a waiting future and the flow completes automatically.
  - **Enter code manually** — the existing copy/paste fallback, now on its own step.
- `SungrowAuthCallbackView` now signals the per-flow future instead of calling `async_configure` directly.
- Token-exchange errors during manual entry are shown on the code form so users can retry; errors during automatic callback abort the flow.
- Updated `strings.json`, `translations/en.json`, and `README.md`.

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] Documentation / chore

## Checklist

- [x] `ruff check custom_components/ tests/` passes
- [x] `ruff format --check custom_components/ tests/` passes
- [x] `pytest` passes and new/changed behaviour is covered by tests
- [x] Documentation updated (`README.md`)
