### PR TITLE
ci: trigger release PR automatically on main pushes

### DIFF
--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -1,6 +1,9 @@
 name: Release PR
 
 on:
+    push:
+        branches:
+            - main
     workflow_dispatch: {}
 
 permissions:
@@ -14,6 +17,9 @@ concurrency:
 
 jobs:
     release-pr:
+        if: |
+            !contains(github.event.head_commit.message, 'chore: release') &&
+            !contains(github.event.head_commit.message, '[skip ci]')
         runs-on: ubuntu-latest
         steps:
             - name: Checkout
@@ -23,6 +29,11 @@ jobs:
 
             - name: Conventional Changelog (no tag/release)
               id: changelog
+              # Version bump rules with the conventionalcommits preset:
+              #   feat! / fix! / BREAKING CHANGE -> major
+              #   feat                             -> minor
+              #   fix                              -> patch
+              #   chore / docs / style / refactor / test / ci / build -> no release
               uses: TriPSs/conventional-changelog-action@v6
               with:
                   github-token: ${{ github.token }}


### PR DESCRIPTION
## Summary

Trigger `release-pr.yml` automatically on every push to `main`, so a release PR is opened/updated as soon as a conventional commit lands that bumps the prospective version number.

## Behaviour

- Runs on `push` to `main` (and keeps `workflow_dispatch`).
- Skips pushes whose head commit is a release commit (`chore: release ...`) or contains `[skip ci]`.
- Uses the `conventionalcommits` preset with these bump rules:
  - `feat!` / `fix!` / `BREAKING CHANGE` → **major**
  - `feat` → **minor**
  - `fix` → **patch**
  - `chore` / `docs` / `style` / `refactor` / `test` / `ci` / `build` → **no release** (`skip-on-empty: true`)

## Type of change

- [x] CI/CD change

## Checklist

- [x] Workflow syntax validated locally
- [x] Existing tests still pass
