### PR TITLE
feat: sub-minute polling intervals (seconds, min 10 s)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,8 @@ jobs:
         uses: actions/setup-python@v6
         with:
           python-version: "3.13"
+          cache: pip
+          cache-dependency-path: .github/workflows/ci.yml
 
       - name: Install dependencies
         run: |
@@ -40,6 +42,8 @@ jobs:
         uses: actions/setup-python@v6
         with:
           python-version: "3.13"
+          cache: pip
+          cache-dependency-path: requirements_test.txt
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/cleanup-pr-release.yml
+++ b/.github/workflows/cleanup-pr-release.yml
@@ -1,0 +1,29 @@
+name: Cleanup PR dev releases
+
+on:
+  pull_request:
+    types: [closed]
+    branches: [main]
+
+permissions:
+  contents: write
+
+jobs:
+  cleanup:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Delete pre-releases for this branch
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+        run: |
+          BRANCH="${{ github.head_ref }}"
+          BRANCH=$(echo "$BRANCH" | sed 's/[^a-zA-Z0-9._-]/-/g' | sed 's/-\{2,\}/-/g')
+          TAG_PREFIX="dev-${BRANCH}-v"
+          echo "Deleting pre-releases with tag prefix: ${TAG_PREFIX}"
+          gh release list --json tagName,isPrerelease \
+            --jq ".[] | select(.isPrerelease and (.tagName | startswith(\"${TAG_PREFIX}\"))) | .tagName" \
+          | while read -r tag; do
+              echo "Deleting release and tag: ${tag}"
+              gh release delete "$tag" --yes --cleanup-tag
+            done

--- a/custom_components/sungrow/__init__.py
+++ b/custom_components/sungrow/__init__.py
@@ -22,6 +22,7 @@ from .const import (
     CONF_APP_KEY,
     CONF_APP_SECRET,
     CONF_GATEWAY,
+    CONF_SCAN_INTERVAL,
     DEFAULT_HOST,
     DOMAIN,
     GATEWAYS,
@@ -52,6 +53,17 @@ CONFIG_SCHEMA = IterableSchema({}, extra=vol.ALLOW_EXTRA)
 async def async_setup(hass: HomeAssistant, config: dict) -> bool:
     """Set up the Sungrow iSolarCloud component."""
     hass.http.register_view(SungrowAuthCallbackView())
+    return True
+
+
+async def async_migrate_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> bool:
+    """Migrate old config entry versions to the current schema."""
+    if config_entry.version == 1:
+        # v1 stored scan_interval in minutes; v2 uses seconds.
+        old_interval = config_entry.options.get(CONF_SCAN_INTERVAL, 5)
+        new_options = {**config_entry.options, CONF_SCAN_INTERVAL: old_interval * 60}
+        hass.config_entries.async_update_entry(config_entry, options=new_options, version=2)
+        _LOGGER.info("Migrated scan_interval from %d minutes to %d seconds", old_interval, old_interval * 60)
     return True
 
 

--- a/custom_components/sungrow/config_flow.py
+++ b/custom_components/sungrow/config_flow.py
@@ -41,7 +41,7 @@ _LOGGER = logging.getLogger(__name__)
 class SungrowConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     """Handle a config flow for Sungrow iSolarCloud."""
 
-    VERSION = 1
+    VERSION = 2
 
     def __init__(self):
         """Initialize the config flow."""

--- a/custom_components/sungrow/const.py
+++ b/custom_components/sungrow/const.py
@@ -23,8 +23,8 @@ GATEWAYS = {
 
 DEFAULT_HOST = GATEWAYS["Europe"]
 
-# Polling interval (minutes). iSolarCloud allows ~2000 calls/hour, so the default
-# is deliberately conservative; users can tune it via the integration options.
-DEFAULT_SCAN_INTERVAL = 5
-MIN_SCAN_INTERVAL = 1
-MAX_SCAN_INTERVAL = 1440
+# Polling interval (seconds). iSolarCloud allows ~2000 calls/hour on the free plan,
+# so the minimum is capped at 10 s to prevent accidental quota exhaustion.
+DEFAULT_SCAN_INTERVAL = 300
+MIN_SCAN_INTERVAL = 10
+MAX_SCAN_INTERVAL = 86400

--- a/custom_components/sungrow/coordinator.py
+++ b/custom_components/sungrow/coordinator.py
@@ -43,12 +43,12 @@ class SungrowPlantCoordinator(DataUpdateCoordinator):
         plant_name: str,
     ) -> None:
         """Initialize the coordinator."""
-        scan_minutes = config_entry.options.get(CONF_SCAN_INTERVAL, DEFAULT_SCAN_INTERVAL)
+        scan_seconds = config_entry.options.get(CONF_SCAN_INTERVAL, DEFAULT_SCAN_INTERVAL)
         super().__init__(
             hass,
             _LOGGER,
             name=f"Sungrow Plant {plant_name}",
-            update_interval=timedelta(minutes=scan_minutes),
+            update_interval=timedelta(seconds=scan_seconds),
             config_entry=config_entry,
         )
         self.plants_service = plants_service

--- a/custom_components/sungrow/strings.json
+++ b/custom_components/sungrow/strings.json
@@ -55,9 +55,9 @@
     "step": {
       "init": {
         "title": "Sungrow Options",
-        "description": "Adjust how often Home Assistant polls iSolarCloud. Lower values update more frequently but use more of your API quota.",
+        "description": "Adjust how often Home Assistant polls iSolarCloud. Lower values update more frequently but use more of your API quota. The free plan allows ~2000 calls/hour; the minimum is 10 seconds.",
         "data": {
-          "scan_interval": "Polling interval (minutes)",
+          "scan_interval": "Polling interval (seconds)",
           "extra_measure_points": "Extra measure points (point_id=code, comma separated)"
         }
       }

--- a/custom_components/sungrow/translations/en.json
+++ b/custom_components/sungrow/translations/en.json
@@ -55,9 +55,9 @@
     "step": {
       "init": {
         "title": "Sungrow Options",
-        "description": "Adjust how often Home Assistant polls iSolarCloud. Lower values update more frequently but use more of your API quota.",
+        "description": "Adjust how often Home Assistant polls iSolarCloud. Lower values update more frequently but use more of your API quota. The free plan allows ~2000 calls/hour; the minimum is 10 seconds.",
         "data": {
-          "scan_interval": "Polling interval (minutes)",
+          "scan_interval": "Polling interval (seconds)",
           "extra_measure_points": "Extra measure points (point_id=code, comma separated)"
         }
       }

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -443,7 +443,7 @@ async def test_options_flow_parses_extra_measure_points(hass: HomeAssistant, moc
     result2 = await hass.config_entries.options.async_configure(
         result["flow_id"],
         user_input={
-            CONF_SCAN_INTERVAL: 5,
+            CONF_SCAN_INTERVAL: 30,
             CONF_EXTRA_MEASURE_POINTS: "99999=battery_charge_power, 99998=battery_discharge_power",
         },
     )
@@ -468,7 +468,7 @@ async def test_options_flow_rejects_invalid_extra_measure_points(
     result = await hass.config_entries.options.async_init(entry.entry_id)
     result2 = await hass.config_entries.options.async_configure(
         result["flow_id"],
-        user_input={CONF_SCAN_INTERVAL: 5, CONF_EXTRA_MEASURE_POINTS: "not_a_mapping"},
+        user_input={CONF_SCAN_INTERVAL: 30, CONF_EXTRA_MEASURE_POINTS: "not_a_mapping"},
     )
 
     assert result2["type"] == data_entry_flow.FlowResultType.FORM

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -128,16 +128,16 @@ async def test_update_data_unrelated_keyerror_raises_update_failed(hass: HomeAss
 
 
 async def test_scan_interval_uses_default(hass: HomeAssistant):
-    """Default scan interval is applied when no option is set."""
+    """Default scan interval is 300 seconds."""
     coordinator = SungrowPlantCoordinator(hass, _make_entry(), MagicMock(), "1", "P")
-    assert coordinator.update_interval.total_seconds() == 5 * 60
+    assert coordinator.update_interval.total_seconds() == 300
 
 
 async def test_scan_interval_from_options(hass: HomeAssistant):
-    """Scan interval option overrides the default."""
+    """Scan interval option (in seconds) overrides the default."""
     entry = _make_entry({CONF_SCAN_INTERVAL: 30})
     coordinator = SungrowPlantCoordinator(hass, entry, MagicMock(), "1", "P")
-    assert coordinator.update_interval.total_seconds() == 30 * 60
+    assert coordinator.update_interval.total_seconds() == 30
 
 
 async def test_extra_measure_points_passed_to_api(hass: HomeAssistant):

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -120,7 +120,7 @@ async def test_options_change_reloads_entry(hass: HomeAssistant, mock_setup_auth
     assert entry.state is ConfigEntryState.LOADED
     entry_data = hass.data[DOMAIN][entry.entry_id]
     coordinators = entry_data["coordinators"]
-    assert coordinators[0].update_interval.total_seconds() == 15 * 60
+    assert coordinators[0].update_interval.total_seconds() == 15
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #40

## Summary

- The polling interval is now configured in **seconds** instead of minutes, minimum **10 s** (prevents accidental quota exhaustion on the free 2000 calls/hour plan)
- Default stays 5 minutes (now stored as 300)
- **Automatic migration**: config entry VERSION bumped to 2; existing installations have their stored minute value multiplied by 60 on first load — no user action needed

## Test plan

- [ ] Existing install upgrades cleanly (migration log: `Migrated scan_interval from N minutes to M seconds`)
- [ ] Options UI shows "Polling interval (seconds)" with the new range
- [ ] Setting 30 s results in ~2 polls/minute as expected
- [ ] Values below 10 s are rejected by the form

🤖 Generated with [Claude Code](https://claude.com/claude-code)