### PR TITLE
fix: correct icon and alias for battery SoC sensor

### DIFF
--- a/custom_components/sungrow/sensor.py
+++ b/custom_components/sungrow/sensor.py
@@ -27,6 +27,7 @@ SENSOR_ALIASES: dict[str, str] = {
     "daily_field_discharge_capacity": "Battery Daily Discharge Capacity",
     "energy_storage_active_power_ems": "EMS Battery Power",
     "energy_storage_soc_ems": "EMS Battery SOC",
+    "battery_level_soc": "Battery State of Charge",
 }
 
 # Per-issue custom codes that users commonly request. If the point_id is configured
@@ -155,7 +156,6 @@ class SungrowSensor(CoordinatorEntity, SensorEntity):
         self._attr_name = sensor_name
         _LOGGER.debug("Created sensor: %s %s (code: %s)", plant_name, sensor_name, point_code)
         self._attr_unique_id = f"{plant_id}_{point_code}"
-        self._attr_icon = "mdi:solar-power-variant"
 
         # Group sensors under a device per plant
         self._attr_device_info = DeviceInfo(
@@ -179,6 +179,11 @@ class SungrowSensor(CoordinatorEntity, SensorEntity):
         device_class, state_class = infer_device_class(init_data.get("unit"), point_code)
         self._attr_device_class = device_class
         self._attr_state_class = state_class
+
+        # Let HA choose the icon automatically for sensors with a known device class
+        # (e.g. mdi:battery for BATTERY, mdi:lightning-bolt for POWER/ENERGY).
+        # Fall back to the solar panel icon only for unclassified sensors.
+        self._attr_icon = None if device_class else "mdi:solar-power-variant"
 
     @property
     def native_value(self):

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -124,13 +124,31 @@ class TestSungrowSensor:
 
         assert sensor._attr_device_class is None
 
-    def test_sensor_icon(self):
-        """Test all sensors use the solar icon."""
+    def test_sensor_icon_fallback_for_unclassified(self):
+        """Sensors with no recognised device class fall back to the solar icon."""
         coordinator = self._make_coordinator()
         init_data = {"code": "x", "value": "1", "unit": "", "name": "X"}
         sensor = SungrowSensor(coordinator, "x", "123", "Plant", init_data)
 
         assert sensor._attr_icon == "mdi:solar-power-variant"
+
+    def test_sensor_icon_none_for_classified(self):
+        """Sensors with a known device class use None so HA picks the right icon."""
+        coordinator = self._make_coordinator()
+        # Battery SoC — device_class: BATTERY → should show mdi:battery automatically
+        init_data = {"code": "battery_level_soc", "value": "80", "unit": "%"}
+        sensor = SungrowSensor(coordinator, "battery_level_soc", "123", "Plant", init_data)
+
+        assert sensor._attr_icon is None
+        assert sensor._attr_device_class == SensorDeviceClass.BATTERY
+
+    def test_sensor_alias_battery_soc(self):
+        """battery_level_soc gets a friendly human-readable alias."""
+        coordinator = self._make_coordinator()
+        init_data = {"code": "battery_level_soc", "value": "80", "unit": "%"}
+        sensor = SungrowSensor(coordinator, "battery_level_soc", "123", "Plant", init_data)
+
+        assert sensor._attr_name == "Battery State of Charge"
 
     def test_sensor_device_info(self):
         """Test sensor has device_info grouping it under its plant."""


### PR DESCRIPTION
Closes #39

## Summary

The battery SoC sensor (`battery_level_soc`) had two cosmetic issues:

- **Wrong icon**: all sensors were hardcoded to `mdi:solar-power-variant`, overriding HA's automatic device-class icons. SoC sensors have `device_class: battery` so HA would normally show `mdi:battery` — but the override prevented this. Sensors with a known device class now set `_attr_icon = None` so HA picks the right icon automatically.
- **Ugly auto-name**: the point code generated "Battery Level Soc" (title-case of underscores). Now aliased to "Battery State of Charge".

> **Note for the reporter:** Battery SoC (%) is not an energy entity and cannot be added to the energy dashboard — that's expected HA behaviour. For the energy dashboard, use the battery charge/discharge energy sensors (kWh), e.g. *Battery Daily Charge Capacity* / *Battery Daily Discharge Capacity*.

## Test plan

- [ ] `battery_level_soc` sensor shows as "Battery State of Charge" in HA UI
- [ ] SoC sensor shows battery icon (not solar panel)
- [ ] Power/energy sensors show lightning-bolt icon
- [ ] Sensors with no device class still show `mdi:solar-power-variant`

🤖 Generated with [Claude Code](https://claude.com/claude-code)