### PR TITLE
feat: auto-start OAuth redirect with manual code/URL fallback

### DIFF
--- a/custom_components/sungrow/config_flow.py
+++ b/custom_components/sungrow/config_flow.py
@@ -145,36 +145,29 @@ class SungrowConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         return self.auth_client.auth_url(callback_redirect)
 
     async def async_step_auth(self, user_input: dict[str, Any] | None = None):
-        """Choose how to complete the OAuth authorization."""
+        """Begin authorization by automatically waiting for the OAuth redirect.
+
+        No menu is shown: the callback listener starts immediately so the user
+        only has to approve the app in their browser. If the redirect never
+        arrives (e.g. the callback endpoint is unreachable), the flow falls back
+        to manual entry so the user can paste the code or full redirect URL.
+        """
         if not self._ensure_auth_client():
             return self.async_abort(reason="library_missing")
-
-        if user_input is not None:
-            # Menu selections arrive as {"next_step_id": "..."}
-            next_step = user_input.get("next_step_id")
-            method = "manual" if next_step == "auth_manual" else "callback"
-            self.context["method"] = method
-            if method == "manual":
-                return await self.async_step_auth_manual()
-            return await self.async_step_auth_callback()
-
-        auth_url = self._auth_url_with_flow_id()
-        return self.async_show_menu(
-            step_id="auth",
-            menu_options=["auth_callback", "auth_manual"],
-            description_placeholders={"auth_url": auth_url},
-        )
+        return await self.async_step_auth_callback()
 
     async def async_step_auth_callback(self, user_input: dict[str, Any] | None = None):
         """Wait for iSolarCloud to redirect back to the callback endpoint.
 
         The callback view extracts the authorization code and calls
         async_configure, which re-enters this step with user_input={"code": ...}.
-        If the callback does not arrive within five minutes, the flow aborts so
-        the user can restart and choose the manual code entry option.
+        If the callback does not arrive within the timeout, the flow falls back
+        to the manual code-entry form instead of aborting.
         """
         if self.context.get("callback_timeout"):
-            return self.async_abort(reason="callback_timeout")
+            # The redirect never arrived — hand off to manual code entry so the
+            # user can paste the authorization code or full redirect URL.
+            return self.async_show_progress_done(next_step_id="auth_manual")
         if user_input is not None and user_input.get("code"):
             self.context["code"] = user_input["code"]
             return self.async_show_progress_done(next_step_id="finish")
@@ -189,7 +182,7 @@ class SungrowConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         async def _wait_for_callback() -> None:
             """Resume the flow once the OAuth callback delivers a code."""
             try:
-                code = await asyncio.wait_for(future, timeout=300)
+                code = await asyncio.wait_for(future, timeout=120)
             except TimeoutError:
                 _LOGGER.warning("OAuth callback not received within timeout for flow %s", self.flow_id)
                 self.context["callback_timeout"] = True
@@ -217,8 +210,11 @@ class SungrowConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         )
 
     async def async_step_auth_manual(self, user_input: dict[str, Any] | None = None):
-        """Handle manual entry of the authorization code or full redirect URL."""
-        self.context["method"] = "manual"
+        """Handle manual entry of the authorization code or full redirect URL.
+
+        Reached as a fallback when the automatic redirect does not complete, or
+        when the user wants to paste the code themselves.
+        """
         errors = {}
 
         if user_input is not None and user_input.get("code"):
@@ -257,20 +253,18 @@ class SungrowConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         )
 
     def _finish_error_result(self, error_key: str):
-        """Return a user-facing result for an authorization failure.
+        """Return the manual code-entry form with an error so the user can retry.
 
-        Manual-entry users are sent back to the code form so they can retry;
-        automatic-callback users get an abort because there is no form to return to.
+        Both the automatic and manual paths land here on failure; showing the
+        manual form lets the user paste a fresh code or full redirect URL.
         """
-        if self.context.get("method") == "manual":
-            auth_url = self._auth_url_with_flow_id()
-            return self.async_show_form(
-                step_id="auth_manual",
-                description_placeholders={"auth_url": auth_url},
-                data_schema=vol.Schema({vol.Optional("code"): str}),
-                errors={"base": error_key},
-            )
-        return self.async_abort(reason=error_key)
+        auth_url = self._auth_url_with_flow_id()
+        return self.async_show_form(
+            step_id="auth_manual",
+            description_placeholders={"auth_url": auth_url},
+            data_schema=vol.Schema({vol.Optional("code"): str}),
+            errors={"base": error_key},
+        )
 
     async def async_step_finish(self, user_input: dict[str, Any] | None = None):
         """Exchange the authorization code for tokens and create the config entry."""

--- a/custom_components/sungrow/strings.json
+++ b/custom_components/sungrow/strings.json
@@ -17,21 +17,13 @@
           "app_id": "App ID from iSolarCloud Developer Platform. To find this, go to your application and look for 'id' within the URL like so: {app_id_url}."
         }
       },
-      "auth": {
-        "title": "Authorize App",
-        "description": "Please visit the URL below to authorize the application:\n\n{auth_url}\n\n**Instructions:**\n1. Visit the link above and log in.\n2. You will be redirected back to Home Assistant automatically.\n3. If the redirect does not work, choose **Enter code manually** and paste the code from the URL.",
-        "menu_options": {
-          "auth_callback": "Authorize automatically (recommended)",
-          "auth_manual": "Enter code manually"
-        }
-      },
       "auth_callback": {
         "title": "Waiting for authorization",
-        "description": "A new window should have opened for:\n\n{auth_url}\n\nAfter you log in and authorize the app, this screen will update automatically."
+        "description": "Open the link below to authorize the application:\n\n{auth_url}\n\nAfter you log in and approve the app, you will be redirected back and this screen will update automatically.\n\nIf the redirect does not complete (for example the page shows an error), wait a moment and you will be able to paste the code manually."
       },
       "auth_manual": {
         "title": "Enter Authorization Code",
-        "description": "Please visit the URL below to authorize the application:\n\n{auth_url}\n\n**Instructions:**\n1. Visit the link above and log in.\n2. You will be redirected (page may show an error).\n3. Copy the **code** parameter from the URL address bar.\n4. Paste it below.",
+        "description": "The automatic redirect did not complete. Finish authorizing manually:\n\n{auth_url}\n\n**Instructions:**\n1. Visit the link above and log in (skip if you already did).\n2. You will be redirected (the page may show an error).\n3. Copy the **code** parameter from the URL address bar.\n4. Paste the code — or the full redirect URL — below.",
         "data": {
           "code": "Authorization Code or full redirect URL"
         }
@@ -46,7 +38,6 @@
     },
     "abort": {
       "already_configured": "Device is already configured",
-      "callback_timeout": "Authorization callback was not received in time. Please try again and choose Enter code manually if the redirect does not complete.",
       "missing_code": "Authorization code was not received. Please try again.",
       "reauth_successful": "Re-authentication was successful"
     }

--- a/custom_components/sungrow/translations/en.json
+++ b/custom_components/sungrow/translations/en.json
@@ -17,21 +17,13 @@
           "app_id": "App ID from iSolarCloud Developer Platform. To find this, go to your application and look for 'id' within the URL like so: {app_id_url}."
         }
       },
-      "auth": {
-        "title": "Authorize App",
-        "description": "Please visit the URL below to authorize the application:\n\n{auth_url}\n\n**Instructions:**\n1. Visit the link above and log in.\n2. You will be redirected back to Home Assistant automatically.\n3. If the redirect does not work, choose **Enter code manually** and paste the code from the URL.",
-        "menu_options": {
-          "auth_callback": "Authorize automatically (recommended)",
-          "auth_manual": "Enter code manually"
-        }
-      },
       "auth_callback": {
         "title": "Waiting for authorization",
-        "description": "A new window should have opened for:\n\n{auth_url}\n\nAfter you log in and authorize the app, this screen will update automatically."
+        "description": "Open the link below to authorize the application:\n\n{auth_url}\n\nAfter you log in and approve the app, you will be redirected back and this screen will update automatically.\n\nIf the redirect does not complete (for example the page shows an error), wait a moment and you will be able to paste the code manually."
       },
       "auth_manual": {
         "title": "Enter Authorization Code",
-        "description": "Please visit the URL below to authorize the application:\n\n{auth_url}\n\n**Instructions:**\n1. Visit the link above and log in.\n2. You will be redirected (page may show an error).\n3. Copy the **code** parameter from the URL address bar.\n4. Paste it below.",
+        "description": "The automatic redirect did not complete. Finish authorizing manually:\n\n{auth_url}\n\n**Instructions:**\n1. Visit the link above and log in (skip if you already did).\n2. You will be redirected (the page may show an error).\n3. Copy the **code** parameter from the URL address bar.\n4. Paste the code — or the full redirect URL — below.",
         "data": {
           "code": "Authorization Code or full redirect URL"
         }
@@ -46,7 +38,6 @@
     },
     "abort": {
       "already_configured": "Device is already configured",
-      "callback_timeout": "Authorization callback was not received in time. Please try again and choose Enter code manually if the redirect does not complete.",
       "missing_code": "Authorization code was not received. Please try again.",
       "reauth_successful": "Re-authentication was successful"
     }

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -37,15 +37,17 @@ by the integration itself.
    exchange. Scheme (`http`/`https`), host/IP, and path must all match.
    - Local: `http://homeassistant.local:8123/api/sungrow_hass/callback`
    - Nabu Casa: `https://<your-id>.ui.nabu.casa/api/sungrow_hass/callback`
-5. **Try automatic authorization first.** The config flow can capture the
-   authorization code automatically when iSolarCloud redirects back to
-   `/api/sungrow_hass/callback`. If this does not complete, use **Enter code
-   manually** and paste the `code` value from the URL bar (or paste the whole URL;
-   the integration extracts the code for you).
-6. If automatic authorization never completes, iSolarCloud may be stripping the
-   `flow_id` query parameter from the redirect URI. In that case rely on the
-   **Enter code manually** option and make sure the base redirect URI still
-   matches the developer portal exactly.
+5. **Automatic authorization runs first.** After you submit your credentials the
+   config flow shows a *Waiting for authorization* screen and captures the code
+   automatically when iSolarCloud redirects back to `/api/sungrow_hass/callback`.
+   You only need to log in and approve the app in the browser.
+6. **Manual entry is the fallback.** If the redirect does not complete (for
+   example the callback endpoint returns an error, or iSolarCloud strips the
+   `flow_id` query parameter), the flow automatically switches to an *Enter
+   Authorization Code* form after a short wait. Paste the `code` value from the
+   URL bar there — or paste the whole redirect URL and the integration extracts
+   the code for you. Make sure the base redirect URI still matches the developer
+   portal exactly.
 
 ---
 

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -47,7 +47,7 @@ async def test_user_step_shows_form(hass: HomeAssistant):
 
 
 async def test_user_step_advances_to_auth(hass: HomeAssistant, mock_auth):
-    """Test submitting user form advances to the auth menu."""
+    """Test submitting the user form starts the automatic callback wait."""
     result = await hass.config_entries.flow.async_init(DOMAIN, context={"source": config_entries.SOURCE_USER})
 
     result2 = await hass.config_entries.flow.async_configure(
@@ -55,8 +55,9 @@ async def test_user_step_advances_to_auth(hass: HomeAssistant, mock_auth):
         user_input=MOCK_USER_INPUT,
     )
 
-    assert result2["type"] == data_entry_flow.FlowResultType.MENU
-    assert result2["step_id"] == "auth"
+    # No menu: the flow automatically waits for the OAuth redirect.
+    assert result2["type"] == data_entry_flow.FlowResultType.SHOW_PROGRESS
+    assert result2["step_id"] == "auth_callback"
     # The auth URL should be present in description placeholders
     assert "auth_url" in result2["description_placeholders"]
 
@@ -67,25 +68,14 @@ async def test_user_step_advances_to_auth(hass: HomeAssistant, mock_auth):
 
 
 async def test_auth_step_success(hass: HomeAssistant, mock_auth):
-    """Test a full successful flow: user -> auth menu -> manual -> entry created."""
+    """Test a full successful flow via the manual fallback: user -> manual -> entry created."""
     # Step 1: init
     result = await hass.config_entries.flow.async_init(DOMAIN, context={"source": config_entries.SOURCE_USER})
 
-    # Step 2: submit user info -> auth menu
-    result2 = await hass.config_entries.flow.async_configure(
-        result["flow_id"],
-        user_input=MOCK_USER_INPUT,
-    )
-    assert result2["step_id"] == "auth"
+    # Step 2: submit user info; the automatic wait times out and drops to manual entry.
+    await _navigate_to_auth_manual(hass, result["flow_id"])
 
-    # Step 3: choose manual entry
-    result3 = await hass.config_entries.flow.async_configure(
-        result["flow_id"],
-        user_input={"next_step_id": "auth_manual"},
-    )
-    assert result3["step_id"] == "auth_manual"
-
-    # Step 4: submit the auth code
+    # Step 3: submit the auth code
     with patch("custom_components.sungrow.async_setup_entry", return_value=True):
         result4 = await hass.config_entries.flow.async_configure(
             result["flow_id"],
@@ -107,8 +97,7 @@ async def test_auth_step_success(hass: HomeAssistant, mock_auth):
 async def test_auth_step_extracts_code_from_url(hass: HomeAssistant, mock_auth):
     """Test that pasting a full callback URL extracts the code automatically."""
     result = await hass.config_entries.flow.async_init(DOMAIN, context={"source": config_entries.SOURCE_USER})
-    await hass.config_entries.flow.async_configure(result["flow_id"], user_input=MOCK_USER_INPUT)
-    await hass.config_entries.flow.async_configure(result["flow_id"], user_input={"next_step_id": "auth_manual"})
+    await _navigate_to_auth_manual(hass, result["flow_id"])
 
     callback_url = "http://homeassistant.local:8123/api/sungrow_hass/callback?code=extracted_code&flow_id=123"
     with patch("custom_components.sungrow.async_setup_entry", return_value=True):
@@ -131,9 +120,20 @@ async def test_auth_step_extracts_code_from_url(hass: HomeAssistant, mock_auth):
 
 
 async def _navigate_to_auth_manual(hass: HomeAssistant, flow_id: str):
-    """Helper: move from the auth menu to the manual code entry step."""
-    await hass.config_entries.flow.async_configure(flow_id, user_input=MOCK_USER_INPUT)
-    await hass.config_entries.flow.async_configure(flow_id, user_input={"next_step_id": "auth_manual"})
+    """Helper: drive the flow to the manual code-entry step via a callback timeout.
+
+    Submitting the user form starts the automatic callback wait; forcing that
+    wait to time out drops the flow to the manual code-entry form.
+    """
+
+    async def _timeout(*args, **kwargs):
+        await asyncio.sleep(0)
+        raise TimeoutError
+
+    with patch("custom_components.sungrow.config_flow.asyncio.wait_for", side_effect=_timeout):
+        await hass.config_entries.flow.async_configure(flow_id, user_input=MOCK_USER_INPUT)
+        await hass.async_block_till_done()
+        await hass.async_block_till_done()
 
 
 async def test_auth_step_no_tokens(hass: HomeAssistant, mock_auth_no_tokens):
@@ -252,8 +252,7 @@ async def test_user_step_aborts_if_already_configured(hass: HomeAssistant, mock_
     existing.add_to_hass(hass)
 
     result = await hass.config_entries.flow.async_init(DOMAIN, context={"source": config_entries.SOURCE_USER})
-    await hass.config_entries.flow.async_configure(result["flow_id"], user_input=MOCK_USER_INPUT)
-    await hass.config_entries.flow.async_configure(result["flow_id"], user_input={"next_step_id": "auth_manual"})
+    await _navigate_to_auth_manual(hass, result["flow_id"])
     result4 = await hass.config_entries.flow.async_configure(
         result["flow_id"],
         user_input={"code": "auth_code_from_provider"},
@@ -279,13 +278,10 @@ async def test_auth_url_includes_flow_id(hass: HomeAssistant, mock_auth):
 
 
 async def test_auth_callback_step_registers_future(hass: HomeAssistant, mock_auth):
-    """Test choosing automatic authorization registers a callback future."""
+    """Test the automatic auth step registers a callback future."""
     result = await hass.config_entries.flow.async_init(DOMAIN, context={"source": config_entries.SOURCE_USER})
-    await hass.config_entries.flow.async_configure(result["flow_id"], user_input=MOCK_USER_INPUT)
+    result3 = await hass.config_entries.flow.async_configure(result["flow_id"], user_input=MOCK_USER_INPUT)
 
-    result3 = await hass.config_entries.flow.async_configure(
-        result["flow_id"], user_input={"next_step_id": "auth_callback"}
-    )
     assert result3["step_id"] == "auth_callback"
     assert result3["type"] == data_entry_flow.FlowResultType.SHOW_PROGRESS
 
@@ -299,10 +295,7 @@ async def test_callback_view_resumes_flow(hass: HomeAssistant, mock_auth):
     from custom_components.sungrow import SungrowAuthCallbackView
 
     result = await hass.config_entries.flow.async_init(DOMAIN, context={"source": config_entries.SOURCE_USER})
-    await hass.config_entries.flow.async_configure(result["flow_id"], user_input=MOCK_USER_INPUT)
-    result3 = await hass.config_entries.flow.async_configure(
-        result["flow_id"], user_input={"next_step_id": "auth_callback"}
-    )
+    result3 = await hass.config_entries.flow.async_configure(result["flow_id"], user_input=MOCK_USER_INPUT)
     assert result3["type"] == data_entry_flow.FlowResultType.SHOW_PROGRESS
 
     request = MagicMock()
@@ -325,10 +318,7 @@ async def test_callback_view_resumes_flow_without_flow_id(hass: HomeAssistant, m
     from custom_components.sungrow import SungrowAuthCallbackView
 
     result = await hass.config_entries.flow.async_init(DOMAIN, context={"source": config_entries.SOURCE_USER})
-    await hass.config_entries.flow.async_configure(result["flow_id"], user_input=MOCK_USER_INPUT)
-    result3 = await hass.config_entries.flow.async_configure(
-        result["flow_id"], user_input={"next_step_id": "auth_callback"}
-    )
+    result3 = await hass.config_entries.flow.async_configure(result["flow_id"], user_input=MOCK_USER_INPUT)
     assert result3["type"] == data_entry_flow.FlowResultType.SHOW_PROGRESS
 
     request = MagicMock()
@@ -359,9 +349,8 @@ async def test_callback_view_rejects_unknown_flow(hass: HomeAssistant, mock_auth
     assert response.status == 400
 
 
-async def test_auth_callback_timeout_aborts_flow(hass: HomeAssistant, mock_auth):
-    """Test that a missing callback within the timeout aborts the flow."""
-    from unittest.mock import patch
+async def test_auth_callback_timeout_falls_back_to_manual(hass: HomeAssistant, mock_auth):
+    """Test that a missing callback within the timeout drops to manual code entry."""
 
     async def _fake_wait_for(*args, **kwargs):
         """Yield control so the progress step is returned, then time out."""
@@ -369,20 +358,17 @@ async def test_auth_callback_timeout_aborts_flow(hass: HomeAssistant, mock_auth)
         raise TimeoutError
 
     result = await hass.config_entries.flow.async_init(DOMAIN, context={"source": config_entries.SOURCE_USER})
-    await hass.config_entries.flow.async_configure(result["flow_id"], user_input=MOCK_USER_INPUT)
 
     with patch("custom_components.sungrow.config_flow.asyncio.wait_for", side_effect=_fake_wait_for):
-        result3 = await hass.config_entries.flow.async_configure(
-            result["flow_id"], user_input={"next_step_id": "auth_callback"}
-        )
-        assert result3["type"] == data_entry_flow.FlowResultType.SHOW_PROGRESS
+        result2 = await hass.config_entries.flow.async_configure(result["flow_id"], user_input=MOCK_USER_INPUT)
+        assert result2["type"] == data_entry_flow.FlowResultType.SHOW_PROGRESS
         # Wait for the background task to process the timeout.
         await hass.async_block_till_done()
         await hass.async_block_till_done()
 
-    # The flow should have been aborted by the timeout handler.
-    with pytest.raises(data_entry_flow.UnknownFlow):
-        hass.config_entries.flow.async_get(result["flow_id"])
+    # The flow should have fallen back to the manual code-entry form.
+    flow = hass.config_entries.flow.async_get(result["flow_id"])
+    assert flow["step_id"] == "auth_manual"
 
 
 async def test_reauth_flow_updates_entry(hass: HomeAssistant, mock_auth, mock_setup_auth, mock_plants_service):
@@ -390,16 +376,21 @@ async def test_reauth_flow_updates_entry(hass: HomeAssistant, mock_auth, mock_se
     entry = MockConfigEntry(domain=DOMAIN, data=MOCK_CONFIG_DATA.copy(), unique_id="test_app_id")
     entry.add_to_hass(hass)
 
-    result = await entry.start_reauth_flow(hass)
-    assert result["type"] == data_entry_flow.FlowResultType.MENU
-    assert result["step_id"] == "auth"
+    async def _timeout(*args, **kwargs):
+        await asyncio.sleep(0)
+        raise TimeoutError
 
-    # Choose manual entry and provide a fresh authorization code.
-    result2 = await hass.config_entries.flow.async_configure(
-        result["flow_id"], user_input={"next_step_id": "auth_manual"}
-    )
-    assert result2["step_id"] == "auth_manual"
+    # Reauth starts the automatic wait; force it to time out so we land on manual entry.
+    with patch("custom_components.sungrow.config_flow.asyncio.wait_for", side_effect=_timeout):
+        result = await entry.start_reauth_flow(hass)
+        assert result["type"] == data_entry_flow.FlowResultType.SHOW_PROGRESS
+        await hass.async_block_till_done()
+        await hass.async_block_till_done()
 
+    flow = hass.config_entries.flow.async_get(result["flow_id"])
+    assert flow["step_id"] == "auth_manual"
+
+    # Provide a fresh authorization code via manual entry.
     mock_auth.tokens = {"access_token": "fresh_token", "refresh_token": "fresh_refresh", "expires_at": 9999999999}
     result3 = await hass.config_entries.flow.async_configure(result["flow_id"], user_input={"code": "fresh_code"})
     await hass.async_block_till_done()

--- a/tests/test_strings.py
+++ b/tests/test_strings.py
@@ -30,7 +30,6 @@ def test_strings_has_required_steps(strings_data):
     """Test config flow steps match what the code defines."""
     steps = strings_data["config"]["step"]
     assert "user" in steps, "Missing 'user' step"
-    assert "auth" in steps, "Missing 'auth' step"
     assert "auth_manual" in steps, "Missing 'auth_manual' step"
     assert "auth_callback" in steps, "Missing 'auth_callback' step"
 


### PR DESCRIPTION
## What & why

The auth setup previously showed a menu forcing the user to choose **Authorize automatically** vs **Enter code manually** before anything happened. This changes the flow to **start the redirect/callback listener automatically**, while keeping manual entry available as a **fallback** — matching the requested behaviour and directly helping users whose callback endpoint returns an error.

## Behaviour

1. Submit credentials → the flow immediately shows *Waiting for authorization* and listens for the iSolarCloud redirect to `/api/sungrow_hass/callback`. The user only logs in and approves.
2. If the redirect doesn't complete within the timeout (callback unreachable / `flow_id` stripped / any error), the flow **automatically switches to the manual code-entry form** instead of aborting. The user pastes the `code` or the full redirect URL.
3. Finish failures also return to the manual form so users can retry with a fresh code.

This makes a 404 / broken callback **non-blocking**: the user always has a way to complete setup.

## Changes

- `async_step_auth` delegates straight to the callback wait (no menu)
- Callback timeout → `auth_manual` form (was: abort with `callback_timeout`)
- `_finish_error_result` always returns the manual form
- Callback timeout shortened 300s → 120s so the fallback surfaces sooner
- Removed the unused `auth` menu step and `callback_timeout` strings (both `strings.json` and `translations/en.json`)
- Updated `docs/TROUBLESHOOTING.md`
- Updated tests to drive the manual step via the timeout fallback

## Testing

`ruff check` + `ruff format --check` clean; full suite green (112 passed, 2 live deselected).

🤖 Generated with [Claude Code](https://claude.com/claude-code)