### PR TITLE
ci: add Codecov coverage reporting

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,7 +53,7 @@ jobs:
         run: pip install -r requirements_test.txt
 
       - name: Run tests with coverage
-        run: pytest tests/ --cov=custom_components/sungrow --cov-report=xml --cov-report=term-missing -v
+        run: pytest tests/ --cov=custom_components/sungrow --cov-branch --cov-report=xml --cov-report=term-missing -v
 
       - name: Upload coverage report
         if: always()
@@ -61,6 +61,14 @@ jobs:
         with:
           name: coverage-report
           path: coverage.xml
+
+      - name: Upload coverage to Codecov
+        if: always()
+        uses: codecov/codecov-action@v5
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: coverage.xml
+          fail_ci_if_error: false
 
   hacs_validate:
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 [![HACS][hacs-badge]][hacs-url]
 [![CI][ci-badge]][ci-url]
+[![codecov][codecov-badge]][codecov-url]
 [![GitHub Release][release-badge]][release-url]
 
 Custom component that integrates Sungrow inverters via the iSolarCloud API into Home Assistant using the [`sungrow-isolarcloud`](https://github.com/KRoperUK/pysolarcloud) library (a maintained fork of `pysolarcloud`).
@@ -120,6 +121,8 @@ Found a bug or have a feature request? [Open an issue][issues-url].
 [hacs-url]: https://hacs.xyz
 [ci-badge]: https://github.com/KRoperUK/sungrow-hass/actions/workflows/ci.yml/badge.svg
 [ci-url]: https://github.com/KRoperUK/sungrow-hass/actions/workflows/ci.yml
+[codecov-badge]: https://codecov.io/gh/KRoperUK/sungrow-hass/branch/main/graph/badge.svg
+[codecov-url]: https://codecov.io/gh/KRoperUK/sungrow-hass
 [release-badge]: https://img.shields.io/github/v/release/KRoperUK/sungrow-hass
 [release-url]: https://github.com/KRoperUK/sungrow-hass/releases/latest
 [hacs-my-badge]: https://my.home-assistant.io/badges/hacs_repository.svg

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,19 @@
+# Codecov configuration — https://docs.codecov.com/docs/codecov-yaml
+coverage:
+  status:
+    project:
+      default:
+        target: auto        # compare against the base commit
+        threshold: 1%        # allow a 1% drop without failing
+        informational: true  # report only — do not fail CI (relax once coverage stabilises)
+    patch:
+      default:
+        target: 80%          # new/changed lines should be well covered
+        informational: true
+
+comment:
+  layout: "reach, diff, flags, files"
+  require_changes: true       # only comment on PRs that change coverage
+
+ignore:
+  - "tests/**"


### PR DESCRIPTION
Adds [Codecov](https://codecov.io) coverage reporting to CI.

## Changes
- **`ci.yml`**: the `test` job now emits branch coverage (`--cov-branch`) and uploads `coverage.xml` to Codecov via `codecov/codecov-action@v5` after the existing artifact upload. The step is `if: always()` and `fail_ci_if_error: false`, so a Codecov hiccup never fails CI.
- **`codecov.yml`**: project + patch status are `informational: true` for now — Codecov will **comment on PRs** with coverage deltas but won't block merges while coverage stabilises. `tests/` is ignored. Flip `informational` off later to enforce a floor.
- **README**: added a `codecov` badge.

## Setup
The `CODECOV_TOKEN` repository secret has been added (Settings → Secrets and variables → Actions). For this public repo Codecov also supports tokenless uploads, but the token makes uploads reliable.

Current coverage is ~90% (line) / ~81% (branch), so the dashboard starts healthy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)