### PR TITLE
fix: harden heartbeat lifecycle, entity availability & secret logging

### DIFF
--- a/custom_components/sungrow/__init__.py
+++ b/custom_components/sungrow/__init__.py
@@ -31,6 +31,10 @@ from .coordinator import SungrowPlantCoordinator, is_auth_error
 
 PLATFORMS: list[Platform] = [Platform.NUMBER, Platform.SELECT, Platform.SENSOR]
 
+# How long to wait for a heartbeat loop to observe its stop event and exit
+# before force-cancelling it.
+HEARTBEAT_STOP_TIMEOUT = 10
+
 _LOGGER = logging.getLogger(__name__)
 
 
@@ -127,7 +131,8 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         "coordinators": coordinators,
         "control": control_service,
         "devices": devices_by_plant,
-        "heartbeat_stop": {},
+        # plant_id -> (stop_event, task) for the running EMS heartbeat loops.
+        "heartbeats": {},
     }
 
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
@@ -141,8 +146,10 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Unload a config entry."""
     entry_data = hass.data[DOMAIN].get(entry.entry_id, {})
-    for stop_event in entry_data.get("heartbeat_stop", {}).values():
-        stop_event.set()
+    heartbeats = entry_data.get("heartbeats", {})
+    for heartbeat in list(heartbeats.values()):
+        await _stop_heartbeat(heartbeat)
+    heartbeats.clear()
 
     if unload_ok := await hass.config_entries.async_unload_platforms(entry, PLATFORMS):
         hass.data[DOMAIN].pop(entry.entry_id)
@@ -155,30 +162,53 @@ async def async_reload_entry(hass: HomeAssistant, entry: ConfigEntry) -> None:
     await hass.config_entries.async_reload(entry.entry_id)
 
 
+async def _stop_heartbeat(heartbeat: tuple[asyncio.Event, asyncio.Task]) -> None:
+    """Signal a heartbeat loop to stop and wait for it to actually exit."""
+    stop_event, task = heartbeat
+    stop_event.set()
+    try:
+        async with asyncio.timeout(HEARTBEAT_STOP_TIMEOUT):
+            await task
+    except TimeoutError:
+        _LOGGER.warning("Heartbeat loop did not stop within %ss; cancelling", HEARTBEAT_STOP_TIMEOUT)
+        task.cancel()
+    except asyncio.CancelledError:
+        pass
+    except Exception:  # pylint: disable=broad-except
+        _LOGGER.exception("Heartbeat loop raised while stopping")
+
+
 async def async_start_heartbeat(
     hass: HomeAssistant, entry: ConfigEntry, plant_id: str, device_uuid: str, interval: int
 ) -> None:
     """Start (or restart) the EMS heartbeat loop for a plant/device."""
     entry_data = hass.data[DOMAIN][entry.entry_id]
-    stops = entry_data["heartbeat_stop"]
+    heartbeats = entry_data["heartbeats"]
 
-    # Stop any existing loop for this plant before starting a new one.
-    if plant_id in stops:
-        stops[plant_id].set()
-        await asyncio.sleep(0)
+    # Stop any existing loop for this plant and wait for it to exit before
+    # starting a new one, so two loops never run for the same device.
+    existing = heartbeats.pop(plant_id, None)
+    if existing is not None:
+        await _stop_heartbeat(existing)
 
     stop_event = asyncio.Event()
-    stops[plant_id] = stop_event
     control: Control = entry_data["control"]
-    asyncio.create_task(control.heartbeat_loop(device_uuid, interval, stop_event))
+    # Tracked by the config entry so HA cancels it automatically on unload.
+    task = entry.async_create_background_task(
+        hass,
+        control.heartbeat_loop(device_uuid, interval, stop_event),
+        name=f"sungrow-heartbeat-{plant_id}",
+    )
+    heartbeats[plant_id] = (stop_event, task)
 
 
 async def async_stop_heartbeat(hass: HomeAssistant, entry: ConfigEntry, plant_id: str) -> None:
     """Stop the EMS heartbeat loop for a plant."""
     entry_data = hass.data[DOMAIN].get(entry.entry_id, {})
-    stops = entry_data.get("heartbeat_stop", {})
-    if plant_id in stops:
-        stops[plant_id].set()
+    heartbeats = entry_data.get("heartbeats", {})
+    heartbeat = heartbeats.pop(plant_id, None)
+    if heartbeat is not None:
+        await _stop_heartbeat(heartbeat)
 
 
 class SungrowAuthCallbackView(HomeAssistantView):

--- a/custom_components/sungrow/config_flow.py
+++ b/custom_components/sungrow/config_flow.py
@@ -68,7 +68,8 @@ class SungrowConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
     async def async_step_user(self, user_input: dict[str, Any] | None = None):
         """Handle the initial step."""
-        _LOGGER.debug(f"async_step_user called with user_input: {user_input}")
+        # Do not log user_input — it contains the app secret.
+        _LOGGER.debug("async_step_user called (user_input provided: %s)", user_input is not None)
         errors = {}
 
         if user_input is not None:
@@ -128,8 +129,9 @@ class SungrowConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             app_id=self.init_info[CONF_APP_ID],
             websession=session,
         )
-        _LOGGER.info("Initialized Auth client for Sungrow iSolarCloud")
-        _LOGGER.debug("Auth client details: %s", self.auth_client)
+        # Debug, not info (routine setup), and never log the client repr — it
+        # holds the app key/secret.
+        _LOGGER.debug("Initialized Auth client for Sungrow iSolarCloud")
         return True
 
     def _auth_url_with_flow_id(self) -> str:
@@ -285,11 +287,14 @@ class SungrowConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
         try:
             redirect_uri_clean = self.init_info[CONF_REDIRECT_URI]
-            _LOGGER.info("Authorizing with code: %s and redirect_uri: %s", code, redirect_uri_clean)
+            # Never log the authorization code or tokens — they are credentials.
+            _LOGGER.debug("Authorizing with redirect_uri: %s", redirect_uri_clean)
             await self.auth_client.async_authorize(code, redirect_uri_clean)
 
             tokens = self.auth_client.tokens
-            _LOGGER.debug("Received tokens: %s", tokens)
+            _LOGGER.debug(
+                "Authorization succeeded (access token received: %s)", bool(tokens and tokens.get("access_token"))
+            )
 
             if not tokens or not tokens.get("access_token"):
                 _LOGGER.error("Failed to retrieve tokens")

--- a/custom_components/sungrow/number.py
+++ b/custom_components/sungrow/number.py
@@ -99,7 +99,6 @@ class SungrowDispatchNumber(CoordinatorEntity, NumberEntity):
     """Number entity for a Sungrow dispatch parameter."""
 
     _attr_has_entity_name = True
-    _attr_available = False
 
     def __init__(
         self,
@@ -131,11 +130,12 @@ class SungrowDispatchNumber(CoordinatorEntity, NumberEntity):
 
     @property
     def native_value(self) -> float | None:
-        """Return the current parameter value if known."""
-        # Parameters are not polled continuously; they are read once at setup if desired.
-        # For now we keep the entity available once the coordinator is running.
-        if self.coordinator.last_update_success:
-            self._attr_available = True
+        """Return the current parameter value.
+
+        Dispatch parameters are write-only here (not polled back from the API),
+        so there is no meaningful value to report. Availability is inherited from
+        CoordinatorEntity (tracks ``coordinator.last_update_success``).
+        """
         return None
 
     async def async_set_native_value(self, value: float) -> None:

--- a/custom_components/sungrow/select.py
+++ b/custom_components/sungrow/select.py
@@ -76,7 +76,6 @@ class SungrowDispatchSelect(CoordinatorEntity, SelectEntity):
     """Select entity for a Sungrow dispatch parameter."""
 
     _attr_has_entity_name = True
-    _attr_available = False
 
     def __init__(
         self,
@@ -106,9 +105,12 @@ class SungrowDispatchSelect(CoordinatorEntity, SelectEntity):
 
     @property
     def current_option(self) -> str | None:
-        """Return the current option (unknown until the user sets it)."""
-        if self.coordinator.last_update_success:
-            self._attr_available = True
+        """Return the current option.
+
+        Dispatch commands are write-only (not polled back from the API), so the
+        current option is unknown. Availability is inherited from
+        CoordinatorEntity (tracks ``coordinator.last_update_success``).
+        """
         return None
 
     async def async_select_option(self, option: str) -> None:

--- a/tests/test_dispatch.py
+++ b/tests/test_dispatch.py
@@ -34,7 +34,7 @@ def _entry_data_for(devices):
         "coordinators": [_coordinator_with("12345", "Test Plant")],
         "control": control,
         "devices": {"12345": devices},
-        "heartbeat_stop": {},
+        "heartbeats": {},
     }
 
 
@@ -118,6 +118,27 @@ async def test_number_starts_heartbeat_for_power_changes(hass: HomeAssistant):
     assert mock_start.call_args.args[3] == "dev-uuid-1"
 
 
+async def test_number_availability_follows_coordinator(hass: HomeAssistant):
+    """Number availability tracks the coordinator; native_value is None with no side effects."""
+    entry = MockConfigEntry(domain=DOMAIN, data=MOCK_CONFIG_DATA.copy())
+    entry.add_to_hass(hass)
+    devices = [{"uuid": "dev-uuid-1", "device_type": "ENERGY_STORAGE_SYSTEM"}]
+    hass.data.setdefault(DOMAIN, {})[entry.entry_id] = _entry_data_for(devices)
+
+    added = []
+    await number_setup_entry(hass, entry, lambda entities: added.extend(entities))
+    power = next(e for e in added if e.param == "charge_discharge_power")
+
+    assert power.native_value is None
+    assert power.available is True  # coordinator.last_update_success is True
+
+    power.coordinator.last_update_success = False
+    assert power.available is False
+    # Reading native_value must not flip availability back on.
+    assert power.native_value is None
+    assert power.available is False
+
+
 async def test_select_setup_creates_entities_for_ess_device(hass: HomeAssistant):
     """Dispatch selects are created when an ESS device is discovered."""
     entry = MockConfigEntry(domain=DOMAIN, data=MOCK_CONFIG_DATA.copy())
@@ -169,6 +190,45 @@ async def test_select_stop_stops_heartbeat(hass: HomeAssistant):
     command.hass = hass
     with patch("custom_components.sungrow.select.async_stop_heartbeat", new=AsyncMock()) as mock_stop:
         await command.async_select_option("Stop")
+
+    mock_stop.assert_awaited_once_with(hass, command.coordinator.config_entry, "12345")
+
+
+async def test_select_availability_follows_coordinator(hass: HomeAssistant):
+    """Select availability tracks the coordinator; current_option is None with no side effects."""
+    entry = MockConfigEntry(domain=DOMAIN, data=MOCK_CONFIG_DATA.copy())
+    entry.add_to_hass(hass)
+    devices = [{"uuid": "dev-uuid-1", "device_type": "ENERGY_STORAGE_SYSTEM"}]
+    hass.data.setdefault(DOMAIN, {})[entry.entry_id] = _entry_data_for(devices)
+
+    added = []
+    await select_setup_entry(hass, entry, lambda entities: added.extend(entities))
+    command = next(e for e in added if e.param == "charge_discharge_command")
+
+    assert command.current_option is None
+    assert command.available is True
+
+    command.coordinator.last_update_success = False
+    assert command.available is False
+    assert command.current_option is None
+    assert command.available is False
+
+
+async def test_select_removal_stops_heartbeat(hass: HomeAssistant):
+    """Removing a select entity stops the heartbeat for the plant."""
+    entry = MockConfigEntry(domain=DOMAIN, data=MOCK_CONFIG_DATA.copy())
+    entry.add_to_hass(hass)
+    devices = [{"uuid": "dev-uuid-1", "device_type": "ENERGY_STORAGE_SYSTEM"}]
+    entry_data = _entry_data_for(devices)
+    hass.data.setdefault(DOMAIN, {})[entry.entry_id] = entry_data
+
+    added = []
+    await select_setup_entry(hass, entry, lambda entities: added.extend(entities))
+    command = added[0]
+
+    command.hass = hass
+    with patch("custom_components.sungrow.select.async_stop_heartbeat", new=AsyncMock()) as mock_stop:
+        await command.async_will_remove_from_hass()
 
     mock_stop.assert_awaited_once_with(hass, command.coordinator.config_entry, "12345")
 

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -1,6 +1,8 @@
 """Tests for Sungrow component setup and the auth callback view."""
 
-from unittest.mock import AsyncMock
+import asyncio
+import contextlib
+from unittest.mock import AsyncMock, MagicMock, patch
 
 from aiohttp.test_utils import make_mocked_request
 from homeassistant.config_entries import ConfigEntryState
@@ -10,6 +12,8 @@ from pytest_homeassistant_custom_component.common import MockConfigEntry
 from custom_components.sungrow import (
     SungrowAuthCallbackView,
     async_setup,
+    async_start_heartbeat,
+    async_stop_heartbeat,
 )
 from custom_components.sungrow.const import CONF_SCAN_INTERVAL, DOMAIN
 
@@ -65,6 +69,105 @@ async def test_async_unload_entry(hass: HomeAssistant, mock_setup_auth, mock_pla
 
     assert entry.entry_id not in hass.data.get(DOMAIN, {})
     assert entry.state is ConfigEntryState.NOT_LOADED
+
+
+# ---------------------------------------------------------------------------
+# Heartbeat lifecycle
+# ---------------------------------------------------------------------------
+
+
+def _entry_with_heartbeats(hass: HomeAssistant) -> MockConfigEntry:
+    """Create a minimal entry whose heartbeat_loop waits on its stop event."""
+    entry = MockConfigEntry(domain=DOMAIN, data=MOCK_CONFIG_DATA.copy())
+    entry.add_to_hass(hass)
+    control = MagicMock()
+    # A realistic loop: block until the stop event is set.
+    control.heartbeat_loop = lambda uuid, interval, stop_event: stop_event.wait()
+    hass.data.setdefault(DOMAIN, {})[entry.entry_id] = {
+        "coordinators": [],
+        "control": control,
+        "devices": {},
+        "heartbeats": {},
+    }
+    return entry
+
+
+async def test_start_heartbeat_creates_tracked_task(hass: HomeAssistant):
+    """Starting a heartbeat stores a (stop_event, task) pair and runs the loop."""
+    entry = _entry_with_heartbeats(hass)
+    await async_start_heartbeat(hass, entry, "12345", "dev-1", interval=60)
+
+    heartbeats = hass.data[DOMAIN][entry.entry_id]["heartbeats"]
+    assert "12345" in heartbeats
+    stop_event, task = heartbeats["12345"]
+    assert isinstance(stop_event, asyncio.Event)
+    assert not task.done()
+
+    await async_stop_heartbeat(hass, entry, "12345")
+    assert stop_event.is_set()
+    assert task.done()
+    assert "12345" not in heartbeats
+
+
+async def test_restart_heartbeat_stops_previous_loop(hass: HomeAssistant):
+    """Restarting stops and awaits the previous loop before starting a new one (no double-run)."""
+    entry = _entry_with_heartbeats(hass)
+    await async_start_heartbeat(hass, entry, "12345", "dev-1", interval=60)
+    first_event, first_task = hass.data[DOMAIN][entry.entry_id]["heartbeats"]["12345"]
+
+    await async_start_heartbeat(hass, entry, "12345", "dev-1", interval=60)
+    second_event, second_task = hass.data[DOMAIN][entry.entry_id]["heartbeats"]["12345"]
+
+    assert first_event.is_set()
+    assert first_task.done()
+    assert second_task is not first_task
+    assert not second_task.done()
+
+    await async_stop_heartbeat(hass, entry, "12345")
+
+
+async def test_stop_heartbeat_absent_is_noop(hass: HomeAssistant):
+    """Stopping a heartbeat that isn't running does not raise."""
+    entry = _entry_with_heartbeats(hass)
+    await async_stop_heartbeat(hass, entry, "nonexistent")
+
+
+async def test_stop_heartbeat_cancels_stubborn_loop(hass: HomeAssistant):
+    """A loop that ignores its stop event is force-cancelled after the timeout."""
+    entry = _entry_with_heartbeats(hass)
+
+    async def _stubborn(uuid, interval, stop_event):
+        await asyncio.sleep(3600)
+
+    entry_data = hass.data[DOMAIN][entry.entry_id]
+    entry_data["control"].heartbeat_loop = _stubborn
+
+    with patch("custom_components.sungrow.HEARTBEAT_STOP_TIMEOUT", 0.01):
+        await async_start_heartbeat(hass, entry, "12345", "dev-1", interval=60)
+        _, task = entry_data["heartbeats"]["12345"]
+        await async_stop_heartbeat(hass, entry, "12345")
+
+    with contextlib.suppress(asyncio.CancelledError):
+        await task
+    assert task.done()
+
+
+async def test_unload_cancels_running_heartbeat(hass: HomeAssistant, mock_setup_auth, mock_plants_service):
+    """Unloading the entry signals and awaits any running heartbeat loop."""
+    entry = MockConfigEntry(domain=DOMAIN, data=MOCK_CONFIG_DATA.copy(), unique_id="test_app_id")
+    entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+
+    stop_event = asyncio.Event()
+    task = entry.async_create_background_task(hass, stop_event.wait(), name="test-heartbeat")
+    hass.data[DOMAIN][entry.entry_id]["heartbeats"]["12345"] = (stop_event, task)
+
+    assert await hass.config_entries.async_unload(entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert stop_event.is_set()
+    assert task.done()
 
 
 async def test_setup_entry_no_tokens_triggers_reauth(hass: HomeAssistant, mock_setup_auth, mock_plants_service):

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -256,7 +256,7 @@ async def test_sensor_setup_creates_entities(hass: HomeAssistant):
         "coordinators": coordinators,
         "control": MagicMock(),
         "devices": {},
-        "heartbeat_stop": {},
+        "heartbeats": {},
     }
 
     added = []
@@ -277,7 +277,7 @@ async def test_sensor_setup_skips_plant_with_no_data(hass: HomeAssistant):
         "coordinators": coordinators,
         "control": MagicMock(),
         "devices": {},
-        "heartbeat_stop": {},
+        "heartbeats": {},
     }
 
     added = []


### PR DESCRIPTION
First half of the review's **Batch A** (runtime safety & security). CI-security hardening (script-injection, action pinning, fork guard) follows in a separate PR to avoid `ci.yml` conflicts with #47.

## Heartbeat background task
The EMS heartbeat loop was started with a bare `asyncio.create_task(...)` whose handle was thrown away — so exceptions were swallowed until GC, HA didn't track it, and on unload we set the stop event but never awaited the task (it could outlive the entry). Restart also raced: the old loop wasn't awaited before a new one started, so two loops could briefly double-call the EMS API.

- Track each plant's heartbeat as `(stop_event, task)` (`heartbeats` dict, renamed from `heartbeat_stop`).
- Start via `entry.async_create_background_task(...)` → HA auto-cancels on unload, exceptions surface.
- New `_stop_heartbeat` helper: set the event, `await` the task with a 10s timeout, then force-cancel. Used by restart, `async_stop_heartbeat`, and unload.

## Entity availability (number/select)
`native_value`/`current_option` mutated `self._attr_available = True` **inside a property getter** and never reset it. Both entities subclass `CoordinatorEntity`, whose `available` already returns `coordinator.last_update_success` and ignores `_attr_available` — so this was misleading dead code (availability was already correct). Removed the mutation and the dead `_attr_available = False` class attr; getters are now pure.

## Secret logging (config flow)
Stopped logging credentials: `user_input` (app secret), the authorization code, the token dict, and the `Auth` client repr (app key/secret). Demoted routine setup chatter from `info` to `debug`.

## Tests
Added heartbeat lifecycle tests (start creates a tracked task, restart stops+awaits the previous loop, stop/unload signal-and-await, stubborn-loop force-cancel) and availability tests for number & select (tracks coordinator, getters have no side effects). Full suite: **120 passed**.

Part of the repo-wide review. Batches B–D to follow as issues/PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)