### PR TITLE
ci: add Codecov Test Analytics (JUnit upload)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,7 +53,12 @@ jobs:
         run: pip install -r requirements_test.txt
 
       - name: Run tests with coverage
-        run: pytest tests/ --cov=custom_components/sungrow --cov-branch --cov-report=xml --cov-report=term-missing -v
+        run: >-
+          pytest tests/
+          --cov=custom_components/sungrow --cov-branch
+          --cov-report=xml --cov-report=term-missing
+          --junitxml=junit.xml -o junit_family=legacy
+          -v
 
       - name: Upload coverage report
         if: always()
@@ -69,6 +74,13 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: coverage.xml
           fail_ci_if_error: false
+
+      - name: Upload test results to Codecov
+        if: ${{ !cancelled() }}
+        uses: codecov/test-results-action@v1
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: junit.xml
 
   hacs_validate:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Follow-up to the Codecov integration (#47). Enables [Codecov Test Analytics](https://docs.codecov.com/docs/test-analytics) so the dashboard surfaces test run times, failure rates, and flaky tests.

## Changes
- **`ci.yml`** — the `test` job now emits a JUnit report (`--junitxml=junit.xml -o junit_family=legacy`) and uploads it via `codecov/test-results-action@v1`. The upload runs with `if: ${{ !cancelled() }}`, so results are reported even when tests fail (which is exactly when the failed-test report is useful).

Uses the existing `CODECOV_TOKEN` secret. Touches only the `test` job, so it's independent of the open CI-security PR (#49).

🤖 Generated with [Claude Code](https://claude.com/claude-code)