### PR TITLE
ci: replace deprecated codecov/test-results-action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,9 +77,10 @@ jobs:
 
       - name: Upload test results to Codecov
         if: ${{ !cancelled() }}
-        uses: codecov/test-results-action@v1
+        uses: codecov/codecov-action@v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
+          report_type: test_results
           files: junit.xml
 
   hacs_validate:


### PR DESCRIPTION
CI logs a deprecation warning:

> This action is being deprecated in favor of 'codecov-action'. Please update CI accordingly to use 'codecov-action@v5' with 'report_type: test_results'.

Swaps `codecov/test-results-action@v1` for `codecov/codecov-action@v5` with `report_type: test_results`, as recommended. The `test` job now runs two `codecov-action@v5` steps — one for coverage (default) and one for test results — which is the supported pattern.

(#54 merged the original `test-results-action` version; this applies the fix on `main`.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)