### PR TITLE
ci: dev releases track next version + fix Release PR detached-HEAD failure

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -107,6 +107,29 @@ jobs:
       contents: write
     steps:
       - uses: actions/checkout@v7
+        with:
+          # Check out the PR branch (same-repo only, per the job guard) so we are
+          # on a real branch — the changelog action's `git pull --tags --ff-only`
+          # fails in detached HEAD — and with full history to compute the version.
+          ref: ${{ github.head_ref }}
+          fetch-depth: 0
+
+      # Compute the next (unreleased) version from conventional commits so the PR
+      # dev build is a pre-release of the upcoming version.
+      - name: Compute next version
+        id: nextver
+        uses: TriPSs/conventional-changelog-action@v6
+        with:
+          github-token: ${{ github.token }}
+          version-file: custom_components/sungrow/manifest.json
+          version-path: version
+          tag-prefix: v
+          preset: conventionalcommits
+          skip-on-empty: true
+          skip-version-file: true
+          skip-commit: true
+          skip-tag: true
+          output-file: false
 
       - name: Build dev tag
         id: tag
@@ -115,7 +138,12 @@ jobs:
         env:
           BRANCH_RAW: ${{ github.head_ref }}
         run: |
-          VERSION=$(jq -r .version custom_components/sungrow/manifest.json)
+          # No releasable commits -> no bump; fall back to the manifest version.
+          if [ "${{ steps.nextver.outputs.skipped }}" = "true" ]; then
+            VERSION=$(jq -r .version custom_components/sungrow/manifest.json)
+          else
+            VERSION="${{ steps.nextver.outputs.version }}"
+          fi
           SHA="${GITHUB_SHA::7}"
           BRANCH=$(printf '%s' "$BRANCH_RAW" | sed 's/[^a-zA-Z0-9._-]/-/g' | sed 's/-\{2,\}/-/g')
           TAG="dev-${BRANCH}-v${VERSION}-${SHA}"

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -44,15 +44,19 @@ jobs:
                   prerelease: false
                   token: ${{ github.token }}
 
-            - name: Delete dev pre-releases for this version
+            - name: Delete main dev pre-releases
               env:
                   GH_TOKEN: ${{ github.token }}
                   GH_REPO: ${{ github.repository }}
               run: |
-                  TAG_PREFIX="dev-v${{ steps.version.outputs.version }}-"
-                  echo "Deleting pre-releases with tag prefix: ${TAG_PREFIX}"
+                  # A published release supersedes every main dev build, so remove
+                  # all "dev-v<semver>-<n>" pre-releases regardless of version — the
+                  # dev version now tracks the *next* version, which can drift
+                  # (e.g. 1.1.0 dev builds when a later breaking change ships 2.0.0).
+                  # PR dev builds ("dev-<branch>-v*") are cleaned up on PR close.
+                  echo "Deleting all main dev pre-releases (dev-v<semver>-<n>)"
                   gh release list --limit 1000 --json tagName,isPrerelease \
-                    --jq ".[] | select(.isPrerelease and (.tagName | startswith(\"${TAG_PREFIX}\"))) | .tagName" \
+                    --jq '.[] | select(.isPrerelease and (.tagName | test("^dev-v[0-9]+\\.[0-9]+\\.[0-9]+-[0-9]+$"))) | .tagName' \
                   | while read -r tag; do
                       echo "Deleting release and tag: ${tag}"
                       gh release delete "$tag" --yes --cleanup-tag

--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -28,7 +28,10 @@ jobs:
             - name: Checkout
               uses: actions/checkout@v7
               with:
-                  ref: ${{ github.event.workflow_run.head_sha || github.sha }}
+                  # Check out the branch, NOT the triggering SHA: the changelog
+                  # action runs `git pull --tags --ff-only`, which fails in a
+                  # detached HEAD ("You are not currently on a branch").
+                  ref: ${{ github.event.workflow_run.head_branch || github.ref_name }}
                   fetch-depth: 0
 
             - name: Conventional Changelog (no tag/release)

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,12 +24,40 @@ jobs:
             - name: Checkout
               uses: actions/checkout@v7
               with:
-                  ref: ${{ github.event.workflow_run.head_sha || github.sha }}
+                  # On a branch (not the detached SHA) so the changelog action's
+                  # `git pull --tags --ff-only` works, and with full history so it
+                  # can compute the next version from the commit log.
+                  ref: ${{ github.event.workflow_run.head_branch || github.ref_name }}
+                  fetch-depth: 0
+
+            # Compute the next (unreleased) version from conventional commits, the
+            # same way the release PR does, so a dev build is a pre-release of the
+            # *upcoming* version (e.g. dev-v1.1.0-N while main is still at 1.0.0).
+            - name: Compute next version
+              id: nextver
+              uses: TriPSs/conventional-changelog-action@v6
+              with:
+                  github-token: ${{ github.token }}
+                  version-file: custom_components/sungrow/manifest.json
+                  version-path: version
+                  tag-prefix: v
+                  preset: conventionalcommits
+                  skip-on-empty: true
+                  skip-version-file: true
+                  skip-commit: true
+                  skip-tag: true
+                  output-file: false
 
             - name: Build dev tag
               id: tag
               run: |
-                  VERSION=$(jq -r .version custom_components/sungrow/manifest.json)
+                  # No releasable commits since the last release -> no bump; fall
+                  # back to the current manifest version.
+                  if [ "${{ steps.nextver.outputs.skipped }}" = "true" ]; then
+                    VERSION=$(jq -r .version custom_components/sungrow/manifest.json)
+                  else
+                    VERSION="${{ steps.nextver.outputs.version }}"
+                  fi
                   TAG="dev-v${VERSION}-${{ github.run_number }}"
                   echo "tag=${TAG}" >> "$GITHUB_OUTPUT"
 


### PR DESCRIPTION
## The recurring "Release PR" failure (run 28618059756)
`release-pr.yml` checks out the triggering commit **SHA**, which leaves git in **detached HEAD**. `TriPSs/conventional-changelog-action` then runs `git pull --tags --ff-only`, which aborts:
> You are not currently on a branch. Please specify which branch you want to merge with.

So the job fails at the *Conventional Changelog* step on **every push to main** (the workflow is triggered by `workflow_run` after each CI completion). Fixed by checking out the **branch** (`workflow_run.head_branch`) instead of the SHA.

## Dev releases now track the *next* version
Per request: instead of tagging dev builds with the current `manifest.json` version (`dev-v1.0.0-49`), compute the **next** version from conventional commits — the same `conventionalcommits` preset the release PR uses — so a dev build is a pre-release of the upcoming version (`dev-v1.1.0-49` while main is still at 1.0.0). Applied to both:
- `release.yml` (main dev release) — `dev-v<next>-<run_number>`
- `ci.yml` (PR dev release) — `dev-<branch>-v<next>-<sha>`

Falls back to the current manifest version when there are no releasable commits (no bump). Both jobs now check out a branch + full history (needed by the action).

## Cleanup reflects the new scheme
`publish-release.yml` previously deleted only `dev-v<published-version>-*`. Under the old scheme that prefix **never matched** the actual dev builds (they used the current, not next, version), so main dev pre-releases were never cleaned. Now, on publish we delete **all** `dev-v<semver>-<n>` pre-releases regardless of version (the next-version tag can drift, e.g. 1.1.0 builds when a later breaking change ships 2.0.0). Verified the jq regex matches main dev builds of any version but **not** PR builds (`dev-<branch>-v*`, including a `v2-work` branch) or real releases (`v1.1.0`). PR dev-build cleanup on close is unchanged (already version-agnostic).

🤖 Generated with [Claude Code](https://claude.com/claude-code)