### PR TITLE
ci: fix dev-release checkout when PR branch is deleted on merge

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -109,10 +109,12 @@ jobs:
     steps:
       - uses: actions/checkout@v7
         with:
-          # Check out the PR branch (same-repo only, per the job guard) so we are
-          # on a real branch — the changelog action's `git pull --tags --ff-only`
-          # fails in detached HEAD — and with full history to compute the version.
-          ref: ${{ github.head_ref }}
+          # Check out the immutable head SHA, not the branch name: a CI run can
+          # race with the PR merging, which deletes the branch, after which
+          # github.head_ref no longer resolves ("could not be found").
+          # fetch-depth: 0 gives full history + tags so the changelog action can
+          # run with skip-git-pull (it doesn't need to be on a branch).
+          ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 0
 
       # Compute the next (unreleased) version from conventional commits so the PR
@@ -130,6 +132,7 @@ jobs:
           skip-version-file: true
           skip-commit: true
           skip-tag: true
+          skip-git-pull: true
           output-file: false
 
       - name: Build dev tag
@@ -138,6 +141,7 @@ jobs:
         # the script — an attacker-controlled branch name would be shell-injected.
         env:
           BRANCH_RAW: ${{ github.head_ref }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         run: |
           # No releasable commits -> no bump; fall back to the manifest version.
           if [ "${{ steps.nextver.outputs.skipped }}" = "true" ]; then
@@ -145,7 +149,7 @@ jobs:
           else
             VERSION="${{ steps.nextver.outputs.version }}"
           fi
-          SHA="${GITHUB_SHA::7}"
+          SHA="${HEAD_SHA::7}"
           BRANCH=$(printf '%s' "$BRANCH_RAW" | sed 's/[^a-zA-Z0-9._-]/-/g' | sed 's/-\{2,\}/-/g')
           TAG="dev-${BRANCH}-v${VERSION}-${SHA}"
           echo "tag=${TAG}" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -53,6 +53,9 @@ jobs:
                   create-summary: true
                   skip-tag: true
                   skip-commit: true
+                  # Redundant with fetch-depth: 0 and the exact call that fails in
+                  # detached HEAD — skip it.
+                  skip-git-pull: true
 
             - name: Sync versions to manifest and pyproject
               if: steps.changelog.outputs.skipped != 'true'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,10 +24,10 @@ jobs:
             - name: Checkout
               uses: actions/checkout@v7
               with:
-                  # On a branch (not the detached SHA) so the changelog action's
-                  # `git pull --tags --ff-only` works, and with full history so it
-                  # can compute the next version from the commit log.
-                  ref: ${{ github.event.workflow_run.head_branch || github.ref_name }}
+                  # Immutable SHA of the commit that passed CI, with full history
+                  # + tags so the changelog action can compute the next version
+                  # (it runs with skip-git-pull, so a detached HEAD is fine).
+                  ref: ${{ github.event.workflow_run.head_sha || github.sha }}
                   fetch-depth: 0
 
             # Compute the next (unreleased) version from conventional commits, the
@@ -46,6 +46,7 @@ jobs:
                   skip-version-file: true
                   skip-commit: true
                   skip-tag: true
+                  skip-git-pull: true
                   output-file: false
 
             - name: Build dev tag


### PR DESCRIPTION
## Problem (run 28618702736)
The PR `dev-release` job failed at `actions/checkout`:
> A branch or tag with the name 'ci/dev-release-next-version' could not be found

As diagnosed: the CI run raced with the PR **merging**, which **deleted the branch**. The checkout used `ref: ${{ github.head_ref }}` — a branch name that no longer existed (the fetch log lists every branch *except* the deleted one).

## Fix
- **Check out the immutable head SHA** instead of the branch name — it survives branch deletion:
  - `ci.yml`: `ref: ${{ github.event.pull_request.head.sha }}`
  - `release.yml`: `ref: ${{ github.event.workflow_run.head_sha || github.sha }}`
- **`skip-git-pull: true`** on every `conventional-changelog-action` call. With `fetch-depth: 0` the repo is already fully cloned with tags, so the action's internal `git pull --tags --ff-only` is redundant — and it's the exact call that requires being on a branch (fails in detached HEAD). Skipping it means a detached SHA checkout works fine, and it also removes the redundant network round-trip in `release-pr.yml`.
- `ci.yml` tags with the PR head SHA now (matches the checked-out commit).

This keeps the "dev builds track the next version" behaviour from #56 while making the checkout robust against the merge/branch-deletion race.

🤖 Generated with [Claude Code](https://claude.com/claude-code)