### PR TITLE
ci(dependabot): expand configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -33,12 +33,9 @@ updates:
       - "dependencies"
       - "python"
     groups:
-      # Batch the test/lint tooling into one PR. Exclude the load-bearing runtime
-      # client (sungrow-isolarcloud) so it arrives as its own PR — it must stay
-      # pinned and kept in sync with manifest.json by hand (see CLAUDE.md), so it
-      # needs individual review rather than being auto-batched.
-      dev-dependencies:
+      # Batch every Python dependency (all update types) into a single PR to keep
+      # the PR count down. Note: when this PR bumps sungrow-isolarcloud, also bump
+      # manifest.json to match before merging (see CLAUDE.md).
+      python:
         patterns:
           - "*"
-        exclude-patterns:
-          - "sungrow-isolarcloud"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,19 +1,44 @@
 version: 2
 updates:
+  # GitHub Actions — keeps the workflow actions (including the SHA-pinned ones)
+  # up to date. Batched into a single weekly PR.
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "weekly"
+    open-pull-requests-limit: 5
+    commit-message:
+      # Conventional-commit prefix so these never look like feat/fix and never
+      # trigger a release (see the release-pr / conventionalcommits workflow).
+      prefix: "chore(deps)"
+    labels:
+      - "dependencies"
+      - "github-actions"
     groups:
-      actions:
+      github-actions:
         patterns:
           - "*"
 
+  # Python test / lint dependencies (requirements_test.txt).
   - package-ecosystem: "pip"
     directory: "/"
     schedule:
       interval: "weekly"
+    open-pull-requests-limit: 5
+    versioning-strategy: increase
+    commit-message:
+      prefix: "chore(deps)"
+      prefix-development: "chore(deps-dev)"
+    labels:
+      - "dependencies"
+      - "python"
     groups:
-      python:
+      # Batch the test/lint tooling into one PR. Exclude the load-bearing runtime
+      # client (sungrow-isolarcloud) so it arrives as its own PR — it must stay
+      # pinned and kept in sync with manifest.json by hand (see CLAUDE.md), so it
+      # needs individual review rather than being auto-batched.
+      dev-dependencies:
         patterns:
           - "*"
+        exclude-patterns:
+          - "sungrow-isolarcloud"


### PR DESCRIPTION
Improves the existing (minimal) Dependabot config, optimised for **few PRs**.

## Grouping (minimal PR count)
- **GitHub Actions** → one grouped weekly PR (all actions, all update types).
- **Python** (`requirements_test.txt`) → one grouped weekly PR (all deps, all update types).

Dependabot groups are per-ecosystem, so this is the floor: at most ~2 PRs/week total. Major/minor/patch are all included in the group, so nothing splits off into extra PRs.

## Other improvements
- **Conventional-commit prefixes** — `chore(deps)` / `chore(deps-dev)`. The repo's release automation reads conventional commits, so Dependabot PRs must stay release-neutral (not `feat`/`fix`).
- **Labels** — `dependencies` + ecosystem label for triage.
- **`versioning-strategy: increase`** and **`open-pull-requests-limit: 5`** for pip; PR limit for actions too.

## Notes
- Dependabot now also keeps the SHA-pinned actions (`hacs/action`, `hassfest`) current.
- No `docker` ecosystem: `docker-compose.yaml` uses `ghcr.io/home-assistant/home-assistant:stable` (a rolling tag Dependabot can't version-bump).
- When the grouped Python PR bumps `sungrow-isolarcloud`, also bump `manifest.json` to match before merging (kept in sync by hand — see `CLAUDE.md`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)