### PR TITLE
ci: stop changelog action from pushing (re-land lost fix)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -133,6 +133,9 @@ jobs:
           skip-commit: true
           skip-tag: true
           skip-git-pull: true
+          # Compute-only: never commit/tag/push. Without this the action still
+          # tries to `git push` at the end and fails in a detached HEAD.
+          git-push: false
           output-file: false
 
       - name: Build dev tag

--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -56,6 +56,9 @@ jobs:
                   # Redundant with fetch-depth: 0 and the exact call that fails in
                   # detached HEAD — skip it.
                   skip-git-pull: true
+                  # The release PR is pushed by create-pull-request below, not by
+                  # this action.
+                  git-push: false
 
             - name: Sync versions to manifest and pyproject
               if: steps.changelog.outputs.skipped != 'true'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,6 +47,9 @@ jobs:
                   skip-commit: true
                   skip-tag: true
                   skip-git-pull: true
+                  # Compute-only: never commit/tag/push. Without this the action
+                  # still tries to `git push` at the end and fails in detached HEAD.
+                  git-push: false
                   output-file: false
 
             - name: Build dev tag


### PR DESCRIPTION
## What happened
The `dev-release` / `Dev Release (main)` jobs still fail at *Compute next version*:
```
error: src refspec main does not match any        (release.yml on main)
error: src refspec refs/pull/58/merge does not match any   (PR builds)
```
`conventional-changelog-action` runs a `git push` at the end even with `skip-commit`/`skip-tag`, which fails on the detached / non-matching ref.

The fix (`git-push: false`) was committed to #57's branch **after** GitHub squash-merged it, so it never reached `main`. This PR re-lands that lost commit onto `main`.

## Fix
Adds `git-push: false` to all three `conventional-changelog-action` steps (`ci.yml`, `release.yml`, `release-pr.yml`) so they only compute the version — no commit, tag, or push.

Until this merges, every PR's `dev-release` job (and the main dev release) keeps failing. After merge, other open PRs (#59) should be rebased/updated to pick it up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)