### PR TITLE
test: cover the load-bearing paths (Batch C)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ omit = ["tests/*"]
 
 [tool.coverage.report]
 show_missing = true
-fail_under = 70
+fail_under = 90
 exclude_lines = [
     "pragma: no cover",
     "if __name__ == .__main__.",

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -200,6 +200,38 @@ async def test_auth_step_library_missing(hass: HomeAssistant):
     assert result2["reason"] == "library_missing"
 
 
+def _flow_at_finish(hass: HomeAssistant):
+    """Build a config flow primed to run async_step_finish in isolation."""
+    from custom_components.sungrow.config_flow import SungrowConfigFlow
+
+    flow = SungrowConfigFlow()
+    flow.hass = hass
+    flow.init_info = dict(MOCK_USER_INPUT)
+    flow.context = {}
+    return flow
+
+
+async def test_finish_step_library_missing(hass: HomeAssistant):
+    """async_step_finish aborts with library_missing when the library is gone."""
+    flow = _flow_at_finish(hass)
+    flow.context["code"] = "some_code"
+    with patch("custom_components.sungrow.config_flow.Auth", None):
+        result = await flow.async_step_finish()
+
+    assert result["type"] == data_entry_flow.FlowResultType.ABORT
+    assert result["reason"] == "library_missing"
+
+
+async def test_finish_step_missing_code(hass: HomeAssistant, mock_auth):
+    """async_step_finish aborts with missing_code when no code reached the step."""
+    flow = _flow_at_finish(hass)
+    # No "code" in context.
+    result = await flow.async_step_finish()
+
+    assert result["type"] == data_entry_flow.FlowResultType.ABORT
+    assert result["reason"] == "missing_code"
+
+
 # ---------------------------------------------------------------------------
 # Auth URL from URL with code in fragment
 # ---------------------------------------------------------------------------

--- a/tests/test_dispatch.py
+++ b/tests/test_dispatch.py
@@ -82,6 +82,30 @@ async def test_number_setup_no_devices(hass: HomeAssistant):
     assert added == []
 
 
+async def test_number_setup_skips_device_without_uuid(hass: HomeAssistant):
+    """A discovered device with no uuid is skipped (no entities created)."""
+    entry = MockConfigEntry(domain=DOMAIN, data=MOCK_CONFIG_DATA.copy())
+    entry.add_to_hass(hass)
+    _setup_entry_data(entry, [{"device_type": "ENERGY_STORAGE_SYSTEM", "device_name": "No UUID"}])
+
+    added = []
+    await number_setup_entry(hass, entry, lambda entities: added.extend(entities))
+
+    assert added == []
+
+
+async def test_select_setup_skips_device_without_uuid(hass: HomeAssistant):
+    """A discovered device with no uuid is skipped (no select entities created)."""
+    entry = MockConfigEntry(domain=DOMAIN, data=MOCK_CONFIG_DATA.copy())
+    entry.add_to_hass(hass)
+    _setup_entry_data(entry, [{"device_type": "ENERGY_STORAGE_SYSTEM", "device_name": "No UUID"}])
+
+    added = []
+    await select_setup_entry(hass, entry, lambda entities: added.extend(entities))
+
+    assert added == []
+
+
 async def test_number_set_value_calls_control(hass: HomeAssistant):
     """Setting a number entity writes the parameter via Control."""
     entry = MockConfigEntry(domain=DOMAIN, data=MOCK_CONFIG_DATA.copy())

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -4,6 +4,7 @@ import asyncio
 import contextlib
 from unittest.mock import AsyncMock, MagicMock, patch
 
+import pysolarcloud
 from aiohttp.test_utils import make_mocked_request
 from homeassistant.config_entries import ConfigEntryState
 from homeassistant.core import HomeAssistant
@@ -18,7 +19,7 @@ from custom_components.sungrow import (
 )
 from custom_components.sungrow.const import CONF_SCAN_INTERVAL, DOMAIN
 
-from .conftest import MOCK_CONFIG_DATA
+from .conftest import MOCK_CONFIG_DATA, MOCK_PLANT_LIST, MOCK_REALTIME_DATA
 
 # ---------------------------------------------------------------------------
 # async_setup (registers the HTTP callback view)
@@ -54,6 +55,54 @@ async def test_async_setup_entry_success(hass: HomeAssistant, mock_setup_auth, m
     assert len(coordinators) == 2
     # Entities were created for the data points.
     assert hass.states.async_all("sensor")
+
+
+async def test_setup_persists_rotated_tokens(hass: HomeAssistant):
+    """End-to-end: a token rotation during setup is written back to entry.data.
+
+    This is the fix for #14/#15/#20/#21 — the ``_save_tokens`` callback wired into
+    ``async_setup_entry`` must persist the rotated tokens so they survive a restart.
+    Uses the real ``SungrowAuth`` (not the ``mock_setup_auth`` fixture) so the
+    token_updater wiring is exercised for real.
+    """
+    entry = MockConfigEntry(domain=DOMAIN, data=MOCK_CONFIG_DATA.copy(), unique_id="test_app_id")
+    entry.add_to_hass(hass)
+
+    rotated = {"access_token": "new_access", "refresh_token": "new_refresh", "token_type": "bearer"}
+    captured: dict = {}
+
+    class _FakePlants:
+        def __init__(self, auth):
+            captured["auth"] = auth
+
+        async def async_get_plants(self):
+            # pysolarcloud refreshes the access token here and rotates the dict.
+            await captured["auth"].async_get_access_token()
+            return MOCK_PLANT_LIST
+
+        async def async_get_realtime_data(self, *args, **kwargs):
+            return MOCK_REALTIME_DATA
+
+        async def async_get_plant_devices(self, *args, **kwargs):
+            return []
+
+    async def _fake_parent_get_token(self):
+        # Simulate pysolarcloud assigning a brand-new tokens dict on refresh.
+        self.tokens = rotated
+        return "new_access"
+
+    with (
+        patch("custom_components.sungrow.Plants", _FakePlants),
+        patch("custom_components.sungrow.Control", MagicMock()),
+        patch("custom_components.sungrow.async_get_clientsession", return_value=MagicMock()),
+        patch.object(pysolarcloud.Auth, "async_get_access_token", _fake_parent_get_token),
+    ):
+        assert await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+
+    assert entry.state is ConfigEntryState.LOADED
+    # The rotated tokens must be persisted back to the entry, not just held in memory.
+    assert entry.data["tokens"] == rotated
 
 
 async def test_async_unload_entry(hass: HomeAssistant, mock_setup_auth, mock_plants_service):
@@ -293,3 +342,22 @@ class TestSungrowAuthCallbackView:
 
         assert response.status == 400
         assert "not found" in response.text.lower()
+
+    async def test_callback_single_pending_flow_fallback(self, hass: HomeAssistant):
+        """No flow_id but exactly one pending flow: resolve it.
+
+        iSolarCloud strips extra query params from the redirect URI, so the real
+        production callback usually has no flow_id. With a single pending flow the
+        view falls back to it (the ``elif len(flows) == 1`` branch).
+        """
+        future: asyncio.Future[str] = asyncio.Future()
+        hass.data.setdefault(DOMAIN, {})["flows"] = {"only_flow": future}
+
+        mock_request = make_mocked_request("GET", "/api/sungrow_hass/callback?code=the_code")
+        mock_request.app["hass"] = hass
+
+        response = await self.view.get(mock_request)
+
+        assert response.status == 200
+        assert future.done()
+        assert future.result() == "the_code"


### PR DESCRIPTION
Closes #51.

Coverage sat at ~90% but the most safety-critical paths were mocked away. This raises the floor and covers them for real.

- **Raise `fail_under` 70 → 90** in `pyproject.toml` — the suite is already ~97%, so 70 was no real floor.
- **Token write-back end-to-end** — drives `async_setup_entry` with the *real* `SungrowAuth` and a fake refresh that rotates the tokens dict, then asserts the rotated tokens land in `entry.data` (the #14/#15/#20/#21 fix). Previously fully mocked, so a refactor could silently drop it green.
- **Single-flow callback fallback** — covers the callback view's `elif len(flows) == 1` branch (flow_id stripped by iSolarCloud — the real production path); only the zero-flows case was tested before.
- **`async_step_finish` aborts** — covers the `library_missing` and `missing_code` branches.
- **`device_uuid` missing → skip** in `number.py`/`select.py`.

Total coverage after: **~97%** (branch coverage on).

🤖 Generated with [Claude Code](https://claude.com/claude-code)