### PR TITLE
ci: polish the CI/release pipeline (Batch D)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,18 +39,15 @@ jobs:
   test:
     runs-on: ubuntu-latest
     timeout-minutes: 15
-    strategy:
-      fail-fast: false
-      matrix:
-        # Project supports 3.12+, so test the full supported range.
-        python-version: ["3.12", "3.13"]
     steps:
       - uses: actions/checkout@v7
 
-      - name: Set up Python ${{ matrix.python-version }}
+      - name: Set up Python
         uses: actions/setup-python@v6
         with:
-          python-version: ${{ matrix.python-version }}
+          # Home Assistant requires Python >=3.13, so that's the only supported
+          # runtime for this integration.
+          python-version: "3.13"
           cache: pip
           cache-dependency-path: requirements_test.txt
 
@@ -69,8 +66,7 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v7
         with:
-          # Matrix jobs must not share an artifact name (upload-artifact v4+ errors).
-          name: coverage-report-${{ matrix.python-version }}
+          name: coverage-report
           path: coverage.xml
 
       - name: Upload coverage to Codecov

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,13 +39,18 @@ jobs:
   test:
     runs-on: ubuntu-latest
     timeout-minutes: 15
+    strategy:
+      fail-fast: false
+      matrix:
+        # Project supports 3.12+, so test the full supported range.
+        python-version: ["3.12", "3.13"]
     steps:
       - uses: actions/checkout@v7
 
-      - name: Set up Python
+      - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v6
         with:
-          python-version: "3.13"
+          python-version: ${{ matrix.python-version }}
           cache: pip
           cache-dependency-path: requirements_test.txt
 
@@ -64,7 +69,8 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v7
         with:
-          name: coverage-report
+          # Matrix jobs must not share an artifact name (upload-artifact v4+ errors).
+          name: coverage-report-${{ matrix.python-version }}
           path: coverage.xml
 
       - name: Upload coverage to Codecov
@@ -121,7 +127,7 @@ jobs:
       # dev build is a pre-release of the upcoming version.
       - name: Compute next version
         id: nextver
-        uses: TriPSs/conventional-changelog-action@v6
+        uses: TriPSs/conventional-changelog-action@952b14bbc4be87e8458a6ac5926fc655608b1b19 # v6
         with:
           github-token: ${{ github.token }}
           version-file: custom_components/sungrow/manifest.json

--- a/.github/workflows/cleanup-dev-releases.yml
+++ b/.github/workflows/cleanup-dev-releases.yml
@@ -1,0 +1,42 @@
+name: Cleanup stale dev releases
+
+# Dev pre-releases accumulate for version lines that never ship a real release
+# (abandoned PR builds, superseded next-version dev builds). A published release
+# prunes the current main dev builds, but the long tail needs a scheduled sweep.
+
+on:
+    schedule:
+        - cron: "0 3 * * 1" # Mondays 03:00 UTC
+    workflow_dispatch: {}
+
+permissions:
+    contents: write
+
+concurrency:
+    group: cleanup-dev-releases
+    cancel-in-progress: false
+
+jobs:
+    cleanup:
+        runs-on: ubuntu-latest
+        timeout-minutes: 15
+        steps:
+            - name: Delete dev pre-releases older than 30 days
+              env:
+                  GH_TOKEN: ${{ github.token }}
+                  GH_REPO: ${{ github.repository }}
+              run: |
+                  # Sweep every "dev-*" pre-release (both main dev-v<semver>-<n> and
+                  # PR dev-<branch>-v* builds) created more than 30 days ago. Real
+                  # releases (no "dev-" prefix) and recent dev builds are kept.
+                  CUTOFF=$(date -u -d '30 days ago' +%s)
+                  echo "Deleting dev-* pre-releases created before $(date -u -d @"$CUTOFF")"
+                  gh release list --limit 1000 --json tagName,isPrerelease,createdAt \
+                    --jq '.[] | select(.isPrerelease and (.tagName | startswith("dev-"))) | [.tagName, .createdAt] | @tsv' \
+                  | while IFS=$'\t' read -r tag created; do
+                      created_epoch=$(date -u -d "$created" +%s)
+                      if [ "$created_epoch" -lt "$CUTOFF" ]; then
+                        echo "Deleting stale pre-release: ${tag} (created ${created})"
+                        gh release delete "$tag" --yes --cleanup-tag
+                      fi
+                    done

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -16,9 +16,13 @@ concurrency:
 
 jobs:
     publish:
+        # Only publish for a merged release PR (label 'release' AND a release/v*
+        # head branch) so an unrelated PR that happens to carry the label can't
+        # trigger a real release.
         if: |
             github.event.pull_request.merged == true &&
-            contains(github.event.pull_request.labels.*.name, 'release')
+            contains(github.event.pull_request.labels.*.name, 'release') &&
+            startsWith(github.event.pull_request.head.ref, 'release/v')
         runs-on: ubuntu-latest
         timeout-minutes: 15
         steps:
@@ -30,16 +34,31 @@ jobs:
             - name: Extract version from manifest
               id: version
               run: |
-                  VERSION=$(grep '"version":' custom_components/sungrow/manifest.json | grep -o '[0-9]\+\.[0-9]\+\.[0-9]\+' | head -1)
-                  echo "version=${VERSION}" >> $GITHUB_OUTPUT
+                  VERSION=$(jq -r .version custom_components/sungrow/manifest.json)
+                  echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
                   echo "Version extracted: ${VERSION}"
 
+            - name: Extract latest changelog section
+              run: |
+                  # Publish only the newest version's notes, not the whole CHANGELOG.
+                  # Print from the first version heading ("## [x.y.z]") up to the next.
+                  awk '
+                    /^#{1,2} \[[0-9]/ { n++; if (n > 1) exit }
+                    n == 1 { print }
+                  ' CHANGELOG.md > release_notes.md
+                  if [ ! -s release_notes.md ]; then
+                    echo "No version section matched; falling back to full CHANGELOG."
+                    cp CHANGELOG.md release_notes.md
+                  fi
+                  echo "----- release notes -----"
+                  cat release_notes.md
+
             - name: Create release tag and GitHub release
-              uses: softprops/action-gh-release@v3
+              uses: softprops/action-gh-release@718ea10b132b3b2eba29c1007bb80653f286566b # v3.0.1
               with:
                   tag_name: v${{ steps.version.outputs.version }}
                   name: Release v${{ steps.version.outputs.version }}
-                  body_path: CHANGELOG.md
+                  body_path: release_notes.md
                   draft: false
                   prerelease: false
                   token: ${{ github.token }}

--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -21,6 +21,8 @@ jobs:
         if: >-
             github.event_name == 'workflow_dispatch' ||
             (github.event.workflow_run.conclusion == 'success' &&
+             github.event.workflow_run.head_branch == 'main' &&
+             github.event.workflow_run.event == 'push' &&
              !contains(github.event.workflow_run.head_commit.message, 'chore: release') &&
              !contains(github.event.workflow_run.head_commit.message, '[skip ci]'))
         runs-on: ubuntu-latest
@@ -41,7 +43,7 @@ jobs:
               #   feat                             -> minor
               #   fix                              -> patch
               #   chore / docs / style / refactor / test / ci / build -> no release
-              uses: TriPSs/conventional-changelog-action@v6
+              uses: TriPSs/conventional-changelog-action@952b14bbc4be87e8458a6ac5926fc655608b1b19 # v6
               with:
                   github-token: ${{ github.token }}
                   output-file: CHANGELOG.md
@@ -72,7 +74,7 @@ jobs:
 
             - name: Create release PR
               if: steps.changelog.outputs.skipped != 'true'
-              uses: peter-evans/create-pull-request@v8
+              uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8
               with:
                   token: ${{ github.token }}
                   committer: "github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,9 @@ jobs:
     dev-release:
         if: >-
             github.event_name == 'workflow_dispatch' ||
-            github.event.workflow_run.conclusion == 'success'
+            (github.event.workflow_run.conclusion == 'success' &&
+             github.event.workflow_run.head_branch == 'main' &&
+             github.event.workflow_run.event == 'push')
         runs-on: ubuntu-latest
         steps:
             - name: Checkout
@@ -35,7 +37,7 @@ jobs:
             # *upcoming* version (e.g. dev-v1.1.0-N while main is still at 1.0.0).
             - name: Compute next version
               id: nextver
-              uses: TriPSs/conventional-changelog-action@v6
+              uses: TriPSs/conventional-changelog-action@952b14bbc4be87e8458a6ac5926fc655608b1b19 # v6
               with:
                   github-token: ${{ github.token }}
                   version-file: custom_components/sungrow/manifest.json

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,8 +2,20 @@
 # See https://pre-commit.com/hooks.html for more hooks
 repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.11.0
+    # Keep in sync with the ruff pin in requirements_test.txt and ci.yml.
+    rev: v0.15.16
     hooks:
       - id: ruff
         args: [--fix]
       - id: ruff-format
+
+  - repo: local
+    hooks:
+      # Keep manifest.json keys in the order hassfest expects (domain/name first,
+      # then alphabetical) so CI's hassfest validation never trips on ordering.
+      - id: sort-manifest
+        name: sort manifest.json
+        entry: python scripts/sort_manifest.py
+        language: system
+        files: ^custom_components/sungrow/manifest\.json$
+        pass_filenames: false

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -51,7 +51,7 @@ Coverage threshold (`fail_under`) is set in `pyproject.toml`; keep it green.
 
 ## Conventions
 
-- **Python 3.12+/3.13**, ruff (line length 120) for lint + format.
+- **Python 3.13** (Home Assistant requires >=3.13), ruff (line length 120) for lint + format.
 - **Conventional Commits** for commit and PR titles (`fix:`, `feat:`, `chore:`,
   `docs:`) — this drives changelog and version bumps.
 - Every behaviour change needs tests. Tests mock `pysolarcloud` (`SungrowAuth`,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 name = "sungrow-hass"
 version = "1.0.0"
 description = "Sungrow iSolarCloud custom integration for Home Assistant"
-requires-python = ">=3.12"
+requires-python = ">=3.13"
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]
@@ -28,7 +28,7 @@ exclude_lines = [
 ]
 
 [tool.ruff]
-target-version = "py312"
+target-version = "py313"
 line-length = 120
 
 [tool.ruff.lint]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,8 +42,3 @@ select = [
     "SIM", # flake8-simplify
 ]
 ignore = ["E501"]
-
-[tool.mypy]
-python_version = "3.12"
-ignore_missing_imports = true
-check_untyped_defs = true

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -5,8 +5,8 @@ pytest-cov
 pytest-sugar
 python-dotenv
 
-# Linting & formatting (match pre-commit versions)
-ruff
+# Linting & formatting (keep in sync with ci.yml and .pre-commit-config.yaml)
+ruff==0.15.16
 
 # Component dependencies
 sungrow-isolarcloud==0.5.0


### PR DESCRIPTION
Closes #52.

CI/release hardening from the repo review.

- **Pin third-party actions to SHAs**: `conventional-changelog-action@v6`, `peter-evans/create-pull-request@v8`, `softprops/action-gh-release@v3.0.1` are now SHA-pinned with a version comment. `codecov/codecov-action` is intentionally left for the active Dependabot bump (#61, 5→7) to avoid a merge conflict — worth pinning once that lands.
- **Ruff version drift**: pre-commit `v0.11.0` → `v0.15.16`, and `requirements_test.txt` now pins `ruff==0.15.16`, matching `ci.yml`. All three sources aligned.
- **mypy**: the `[tool.mypy]` block was configured but never run. Enforcing it surfaces ~18 real typing gaps that need a dedicated typing pass — out of scope for CI polish — so the dead config is removed rather than left as a false signal.
- **Python version**: rather than a 3.12/3.13 matrix, the project now **requires Python ≥3.13** (`requires-python`, ruff `target-version = py313`, CLAUDE.md). Home Assistant (2026.2.x) itself requires ≥3.13.2, so 3.12 can't run the target HA — testing it only surfaced 3.12-specific test-harness teardown artifacts, not real bugs. Keeping the `test` job single (non-matrix) also preserves the required `test` status-check name for branch protection.
- **`publish-release.yml`**: publishes only the newest CHANGELOG section (awk-extracted) instead of the whole file; extracts the version with `jq`; and restricts publishing to a merged `release/v*` PR.
- **Guard release triggers**: `release.yml` / `release-pr.yml` now require `head_branch == 'main' && event == 'push'` on the triggering CI run.
- **`sort_manifest.py`**: wired into pre-commit as a local hook (verified idempotent against the current manifest) so it's no longer dead.
- **Scheduled cleanup**: new `cleanup-dev-releases.yml` sweeps `dev-*` pre-releases older than 30 days weekly (+ manual dispatch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)