### PR TITLE
docs: refresh README auth flow, add regions/limits and SECURITY.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,15 +46,15 @@ Or manually:
 
 | Field | Description |
 |---|---|
-| **Gateway** | Your region (Europe, Australia, China, etc.) |
+| **Gateway** | Your region: **Europe**, **International**, **China**, or **Australia** |
 | **App Key** | AppKey from the [iSolarCloud Developer Platform](https://developer-api.isolarcloud.com/#/application) |
 | **App Secret** | AppSecret from the Developer Platform |
 | **App ID** | App ID — found in the Developer Platform URL: `…/editApplication?id=1234` |
 | **Redirect URI** | Pre-filled; leave as default unless you know what you're doing |
 
-4. Click **Submit** — you'll be shown an authorisation URL.
-5. Choose **Authorize automatically (recommended)**. A browser window opens for the iSolarCloud login; after you authorize, Home Assistant receives the code automatically via the `/api/sungrow_hass/callback` endpoint.
-6. If the automatic redirect doesn't work (for example, because iSolarCloud strips query parameters from your redirect URI), choose **Enter code manually** and paste the `code` from the URL.
+4. Click **Submit**. Home Assistant shows a **"Waiting for authorization"** screen with a link.
+5. Open the link, log in to iSolarCloud, and approve the application. You're redirected back and Home Assistant receives the authorization code automatically (via the `/api/sungrow_hass/callback` endpoint) and finishes setup — no copy-and-paste needed.
+6. If the automatic redirect doesn't complete within a couple of minutes (for example because iSolarCloud strips query parameters from your redirect URI), the flow falls back to a **manual entry** form. Paste the `code` from the redirect URL — or the whole redirect URL — to finish.
 
 ### Obtaining Credentials
 
@@ -72,6 +72,19 @@ After setup, go to **Settings → Devices & Services → Sungrow → Configure**
 ### Sensor mapping
 
 Not sure which sensor corresponds to which value in the iSolarCloud app? See [docs/SENSORS.md](docs/SENSORS.md).
+
+## Supported devices & regions
+
+- **Regions / gateways:** Europe, International, China, and Australia. Pick the one matching the account you registered your developer application under.
+- **Devices:** grid-tied inverters, hybrid inverters, and energy storage systems (ESS / batteries) that appear in your iSolarCloud account. Sensors are created for whatever data points iSolarCloud returns for your plant.
+- **Dispatch / control:** number and select entities (charge/discharge command & power, SOC limits, forced charging) are created for inverter / ESS devices that support External EMS control.
+
+## Limitations
+
+- **Cloud-only.** All data comes from the iSolarCloud cloud API — there is no local polling. If iSolarCloud is unreachable, or your account/plan loses API access, entities become unavailable.
+- **API quota.** The free developer plan allows ~2000 calls/hour; keep the polling interval sensible, especially with many sensors.
+- **Dispatch needs compatible firmware and plan.** External EMS / parameter setting requires an inverter and iSolarCloud plan that permit it. Where unsupported, dispatch entities may error on write.
+- **Developer app approval.** New iSolarCloud developer applications must be approved by Sungrow (with OAuth 2.0 enabled) before authorization works — this can take up to a week.
 
 ## Troubleshooting
 
@@ -110,6 +123,19 @@ To run live tests against the real iSolarCloud API:
    ```
 
    > Live tests are automatically skipped when credentials are not set.
+
+### Logo & icon
+
+The integration ships `icon.png` / `logo.png` under `custom_components/sungrow/`.
+For the brand images to appear in the Home Assistant UI's official brand system
+(and on [brands.home-assistant.io](https://brands.home-assistant.io)), the
+`sungrow` domain also needs a PR to the
+[home-assistant/brands](https://github.com/home-assistant/brands) repository.
+
+### Security
+
+Found a security issue? Please follow the disclosure process in
+[SECURITY.md](SECURITY.md) rather than opening a public issue.
 
 ## Support
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,45 @@
+# Security Policy
+
+## Supported versions
+
+This is a Home Assistant custom integration distributed via HACS. Security fixes
+are made against the latest release only. Please update to the newest version
+before reporting a suspected vulnerability.
+
+## What this integration handles
+
+The integration stores and uses sensitive credentials on your behalf:
+
+- Your iSolarCloud **App Key**, **App Secret**, and **App ID**.
+- OAuth 2.0 **access and refresh tokens** (rotated and persisted to the Home
+  Assistant config entry so entities survive restarts).
+
+These are held in Home Assistant's config-entry storage and are **redacted** from
+diagnostics downloads. They are never logged (debug logging deliberately avoids
+printing secrets, tokens, or authorization codes).
+
+## Reporting a vulnerability
+
+**Please do not open a public GitHub issue for security problems.**
+
+Instead, report privately via GitHub's
+[private vulnerability reporting](https://github.com/KRoperUK/sungrow-hass/security/advisories/new)
+("**Report a vulnerability**" on the repository's **Security** tab). This opens a
+private advisory visible only to the maintainers.
+
+Please include:
+
+- A description of the issue and its impact.
+- Steps to reproduce (or a proof of concept).
+- The integration version, Home Assistant version, and gateway region.
+
+You can expect an initial acknowledgement within a few days. Once a fix is
+available it will be released and, where appropriate, a security advisory will be
+published crediting the reporter (unless you prefer to remain anonymous).
+
+## Scope
+
+This policy covers the integration code in this repository. Vulnerabilities in
+the upstream [`sungrow-isolarcloud`](https://github.com/KRoperUK/pysolarcloud)
+library, Home Assistant core, or the iSolarCloud cloud service should be reported
+to their respective projects.

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -53,21 +53,21 @@ by the integration itself.
 
 ## Entities go "unavailable" after restarting / updating Home Assistant
 
-**This is fixed in v0.3.0+.** Earlier versions did not persist the rotated
-refresh token, so after a restart the stored token was already invalid and every
-entity went unavailable — the only workaround was to delete and re-add the
-integration.
+**This is handled automatically by current versions.** Very old versions
+(pre-0.3.0) did not persist the rotated refresh token, so after a restart the
+stored token was already invalid and every entity went unavailable — the only
+workaround was to delete and re-add the integration.
 
-As of v0.3.0:
+The integration now:
 
-- Refreshed tokens are saved back to the config entry automatically, so they
+- Saves refreshed tokens back to the config entry automatically, so they
   survive restarts.
 - If the stored credentials ever do become invalid, Home Assistant shows a
   **"Reconfigure"/reauth** prompt for the integration. Click it and re-authorize
   — you no longer need to delete and re-add the integration or lose your entity
   history.
 
-If you are on an older version, please update first.
+If you are on a pre-0.3.0 version, please update first.
 
 ---
 
@@ -85,7 +85,7 @@ API and your account.
 
 ## The Energy dashboard can't use my sensors
 
-v0.3.0+ infers `device_class` and `state_class` from each sensor's unit (energy,
+The integration infers `device_class` and `state_class` from each sensor's unit (energy,
 power, voltage, current, temperature, etc.). Energy sensors (`Wh`/`kWh`/`MWh`) are
 exposed with `device_class: energy` and `state_class: total_increasing`, which the
 Energy dashboard requires. If a specific sensor still isn't selectable, open an


### PR DESCRIPTION
Closes #53.

- **README auth flow** — the setup steps described the removed "Authorize automatically / Enter code manually" menu. Rewritten to match the current flow: submit → *Waiting for authorization* screen → approve in browser → auto-completes, with a manual code/URL fallback if the redirect doesn't arrive. (`docs/TROUBLESHOOTING.md` was already correct and was the model.)
- **Regions** — README now lists all four gateways (Europe, **International**, China, Australia) and adds **Supported devices & regions** + **Limitations** sections (cloud-only, API quota, dispatch firmware/plan requirements, developer-app approval).
- **Branding note** — documents that the official HA brand logo/icon needs a [home-assistant/brands](https://github.com/home-assistant/brands) PR for the `sungrow` domain.
- **SECURITY.md** — new file with a private disclosure channel (GitHub private vulnerability reporting) describing the OAuth tokens + API secrets the integration handles and how they're protected (redacted diagnostics, never logged). Linked from the README.
- **TROUBLESHOOTING.md** — dropped the stale "fixed in v0.3.0+" anchoring now that v1.0.0 has shipped; the token-persistence and Energy-dashboard behaviour is described as current.

Docs/standard-files only — no code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)