### PR TITLE
feat(diagnostics): capture all devices + per-device realtime (helps #18)

### DIFF
--- a/custom_components/sungrow/diagnostics.py
+++ b/custom_components/sungrow/diagnostics.py
@@ -2,18 +2,79 @@
 
 from __future__ import annotations
 
+import enum
+import logging
 from typing import Any
 
 from homeassistant.core import HomeAssistant
 
 from . import SungrowConfigEntry, SungrowData
 
+_LOGGER = logging.getLogger(__name__)
+
+
+def _jsonable(obj: Any) -> Any:
+    """Make API payloads JSON-serialisable for the diagnostics download.
+
+    pysolarcloud converts *known* device types / fault statuses to ``enum`` members
+    (which ``json`` can't serialise); an *unknown* device type — e.g. an EV charger
+    the library hasn't catalogued — is left as its raw int, which is exactly the
+    identifier we want to surface. Convert enums to ``"NAME (value)"`` and recurse
+    into containers; everything else passes through untouched.
+    """
+    if isinstance(obj, enum.Enum):
+        return f"{obj.name} ({obj.value})"
+    if isinstance(obj, dict):
+        return {k: _jsonable(v) for k, v in obj.items()}
+    if isinstance(obj, (list, tuple)):
+        return [_jsonable(v) for v in obj]
+    return obj
+
+
+async def _probe_plant_devices(service: Any, plant_id: str) -> tuple[list, dict]:
+    """Best-effort capture of every device and its per-device realtime data.
+
+    Returns ``(all_devices, device_realtime)``. The plant realtime endpoint only
+    returns point IDs the library knows about, so hardware like EV chargers never
+    shows up as sensors (issue #18). This walks the *full* device list (not just
+    inverter/ESS) and attempts a per-device realtime fetch for each distinct type,
+    so a diagnostics download reveals an unmapped device's type and reachable
+    points — enough to add a proper mapping. All failures are captured, never
+    raised, so a diagnostics download always succeeds.
+    """
+    try:
+        all_devices = await service.async_get_plant_devices(plant_id)
+    except Exception as err:  # pylint: disable=broad-except
+        _LOGGER.debug("Diagnostics: could not list devices for plant %s: %s", plant_id, err)
+        return [{"error": str(err)}], {}
+
+    device_realtime: dict[str, Any] = {}
+    seen_types: set = set()
+    for device in all_devices:
+        if not isinstance(device, dict):
+            continue
+        device_type = device.get("device_type")
+        if device_type is None:
+            continue
+        type_id = getattr(device_type, "value", device_type)
+        if type_id in seen_types:
+            continue
+        seen_types.add(type_id)
+        try:
+            device_realtime[str(type_id)] = _jsonable(await service.async_get_device_realtime(plant_id, device_type))
+        except Exception as err:  # pylint: disable=broad-except
+            _LOGGER.debug("Diagnostics: device realtime failed for type %s: %s", type_id, err)
+            device_realtime[str(type_id)] = {"error": str(err)}
+
+    return _jsonable(all_devices), device_realtime
+
 
 async def async_get_config_entry_diagnostics(hass: HomeAssistant, entry: SungrowConfigEntry) -> dict[str, Any]:
     """Return diagnostics for a config entry.
 
-    Tokens and secrets are redacted; raw coordinator data and device lists are
-    included to help identify unsupported point IDs (e.g. EV chargers).
+    Tokens and secrets are redacted; raw coordinator data, the full device list,
+    and per-device realtime data are included to help identify unsupported point
+    IDs (e.g. EV chargers — see issue #18).
     """
     data = getattr(entry, "runtime_data", None)
     coordinators = data.coordinators if isinstance(data, SungrowData) else []
@@ -21,11 +82,23 @@ async def async_get_config_entry_diagnostics(hass: HomeAssistant, entry: Sungrow
 
     plant_data: dict[str, dict[str, Any]] = {}
     for coordinator in coordinators:
-        plant_data[coordinator.plant_id] = {
+        plant_id = coordinator.plant_id
+        service = getattr(coordinator, "plants_service", None)
+        all_devices: list = []
+        device_realtime: dict[str, Any] = {}
+        if service is not None:
+            all_devices, device_realtime = await _probe_plant_devices(service, plant_id)
+
+        plant_data[plant_id] = {
             "plant_name": coordinator.plant_name,
             "last_update_success": coordinator.last_update_success,
             "data": coordinator.data,
-            "devices": devices_by_plant.get(coordinator.plant_id, []),
+            # Devices the integration created dispatch entities for (inverter/ESS).
+            "devices": _jsonable(devices_by_plant.get(plant_id, [])),
+            # Every device on the plant, including hardware without mapped sensors.
+            "all_devices": all_devices,
+            # Per-device-type realtime data (best effort; {} where unsupported).
+            "device_realtime": device_realtime,
         }
 
     return {

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -93,6 +93,32 @@ issue with the sensor's unit and the `code` shown in its attributes.
 
 ---
 
+## A device (EV charger, meter, etc.) isn't showing up
+
+The plant realtime endpoint only returns the point IDs the integration knows to
+ask for, so hardware the upstream library hasn't catalogued — e.g. a **Sungrow
+AC011E EV charger** ([#18](https://github.com/KRoperUK/sungrow-hass/issues/18)) —
+won't create sensors automatically even though it appears in the iSolarCloud app.
+
+To help map it:
+
+1. **Download diagnostics.** Go to **Settings → Devices & services → Sungrow
+   iSolarCloud → ⋮ → Download diagnostics**. The JSON is redacted (no tokens or
+   secrets) and now includes:
+   - `all_devices` — every device on your plant, including the charger, with its
+     `device_type` (unmapped hardware shows a raw numeric type).
+   - `device_realtime` — a best-effort per-device realtime fetch for each device
+     type, so any reachable charger points show up here.
+2. **Attach that JSON to [#18](https://github.com/KRoperUK/sungrow-hass/issues/18)**
+   so the point IDs can be added to the default mapping.
+3. **Stopgap — surface points yourself.** If you already know a point ID (from the
+   iSolarCloud Developer Portal's *Common Measuring Point Enumeration*), add it
+   under **Configure → Extra measure points** as `point_id=code` (for example
+   `<id>=ev_charger_power`). Recognised codes like `ev_charger_power` /
+   `ev_charger_energy` get a friendly name automatically.
+
+---
+
 ## Still stuck?
 
 Open a [bug report](https://github.com/KRoperUK/sungrow-hass/issues/new/choose)

--- a/tests/test_diagnostics.py
+++ b/tests/test_diagnostics.py
@@ -1,25 +1,28 @@
 """Tests for the Sungrow diagnostics platform."""
 
-from unittest.mock import MagicMock
+import json
+from unittest.mock import AsyncMock, MagicMock
 
 from homeassistant.core import HomeAssistant
+from pysolarcloud.plants import DeviceType
 
 from custom_components.sungrow import SungrowData
 from custom_components.sungrow.diagnostics import async_get_config_entry_diagnostics
 
 
-def _make_coordinator(plant_id: str, plant_name: str, data: dict):
+def _make_coordinator(plant_id: str, plant_name: str, data: dict, *, plants_service=None):
     """Build a minimal coordinator mock."""
     coordinator = MagicMock()
     coordinator.plant_id = plant_id
     coordinator.plant_name = plant_name
     coordinator.last_update_success = True
     coordinator.data = data
+    coordinator.plants_service = plants_service
     return coordinator
 
 
 async def test_config_entry_diagnostics(hass: HomeAssistant):
-    """Diagnostics include plant data and device lists without tokens."""
+    """Diagnostics include plant data, the full device list, and per-device realtime."""
     entry = MagicMock()
     entry.entry_id = "test_entry"
     entry.data = {
@@ -29,7 +32,26 @@ async def test_config_entry_diagnostics(hass: HomeAssistant):
     }
     entry.options = {"scan_interval": 10}
 
-    coordinator = _make_coordinator("123", "Test Plant", {"total_active_power": {"value": "1.23"}})
+    # A plant with a known ESS device (converted to an enum by the library) and an
+    # unmapped EV charger (an unknown type the library leaves as a raw int).
+    service = MagicMock()
+    service.async_get_plant_devices = AsyncMock(
+        return_value=[
+            {"uuid": "dev-1", "device_name": "Inverter", "device_type": DeviceType.ENERGY_STORAGE_SYSTEM},
+            {"uuid": "chg-1", "device_name": "AC011E", "device_type": 999},
+        ]
+    )
+
+    async def _fake_realtime(plant_id, device_type):
+        if getattr(device_type, "value", device_type) == 999:
+            return {"chg-1": {"ev_charger_power": {"code": "ev_charger_power", "value": "7.2"}}}
+        return {}
+
+    service.async_get_device_realtime = AsyncMock(side_effect=_fake_realtime)
+
+    coordinator = _make_coordinator(
+        "123", "Test Plant", {"total_active_power": {"value": "1.23"}}, plants_service=service
+    )
 
     entry.runtime_data = SungrowData(
         coordinators=[coordinator],
@@ -45,9 +67,23 @@ async def test_config_entry_diagnostics(hass: HomeAssistant):
     assert diag["tokens_present"] is True
     assert "access_token" not in diag
     assert diag["options"] == {"scan_interval": 10}
-    assert diag["plants"]["123"]["plant_name"] == "Test Plant"
-    assert diag["plants"]["123"]["data"]["total_active_power"]["value"] == "1.23"
-    assert diag["plants"]["123"]["devices"] == [{"uuid": "dev-1", "device_name": "Inverter"}]
+
+    plant = diag["plants"]["123"]
+    assert plant["plant_name"] == "Test Plant"
+    assert plant["data"]["total_active_power"]["value"] == "1.23"
+    # The dispatch-discovered subset is unchanged.
+    assert plant["devices"] == [{"uuid": "dev-1", "device_name": "Inverter"}]
+    # The full device list surfaces the unmapped charger with its raw type id, and
+    # serialises the known enum device type to a readable "NAME (value)" string.
+    charger = next(d for d in plant["all_devices"] if d["uuid"] == "chg-1")
+    assert charger["device_type"] == 999
+    ess = next(d for d in plant["all_devices"] if d["uuid"] == "dev-1")
+    assert ess["device_type"] == "ENERGY_STORAGE_SYSTEM (14)"
+    # Per-device realtime is captured, keyed by device type id.
+    assert plant["device_realtime"]["999"]["chg-1"]["ev_charger_power"]["value"] == "7.2"
+
+    # The whole payload must be JSON-serialisable (no leftover enums).
+    json.dumps(diag)
 
 
 async def test_config_entry_diagnostics_no_data(hass: HomeAssistant):
@@ -61,3 +97,63 @@ async def test_config_entry_diagnostics_no_data(hass: HomeAssistant):
 
     assert diag["tokens_present"] is False
     assert diag["plants"] == {}
+
+
+async def test_diagnostics_device_probe_failure_is_captured(hass: HomeAssistant):
+    """A device-listing failure is captured in the dump, never raised."""
+    entry = MagicMock()
+    entry.entry_id = "e"
+    entry.data = {"gateway": "Europe", "app_id": "a"}
+    entry.options = {}
+
+    service = MagicMock()
+    service.async_get_plant_devices = AsyncMock(side_effect=RuntimeError("boom"))
+    coordinator = _make_coordinator("1", "P", {}, plants_service=service)
+    entry.runtime_data = SungrowData(coordinators=[coordinator], control=MagicMock(), devices={})
+
+    diag = await async_get_config_entry_diagnostics(hass, entry)
+
+    assert diag["plants"]["1"]["all_devices"] == [{"error": "boom"}]
+    assert diag["plants"]["1"]["device_realtime"] == {}
+    json.dumps(diag)
+
+
+async def test_diagnostics_per_device_realtime_failure_is_captured(hass: HomeAssistant):
+    """A per-device realtime failure is captured per type; malformed devices are skipped."""
+    entry = MagicMock()
+    entry.entry_id = "e"
+    entry.data = {"gateway": "Europe", "app_id": "a"}
+    entry.options = {}
+
+    service = MagicMock()
+    service.async_get_plant_devices = AsyncMock(
+        return_value=[
+            "not-a-dict",  # skipped
+            {"uuid": "x", "device_name": "No type"},  # no device_type -> skipped
+            {"uuid": "chg-1", "device_type": 999},
+        ]
+    )
+    service.async_get_device_realtime = AsyncMock(side_effect=RuntimeError("nope"))
+    coordinator = _make_coordinator("1", "P", {}, plants_service=service)
+    entry.runtime_data = SungrowData(coordinators=[coordinator], control=MagicMock(), devices={})
+
+    diag = await async_get_config_entry_diagnostics(hass, entry)
+
+    assert diag["plants"]["1"]["device_realtime"]["999"] == {"error": "nope"}
+    json.dumps(diag)
+
+
+async def test_diagnostics_without_service_skips_probe(hass: HomeAssistant):
+    """A coordinator without a plants_service yields empty device sections (no crash)."""
+    entry = MagicMock()
+    entry.entry_id = "e"
+    entry.data = {"gateway": "Europe", "app_id": "a"}
+    entry.options = {}
+
+    coordinator = _make_coordinator("1", "P", {}, plants_service=None)
+    entry.runtime_data = SungrowData(coordinators=[coordinator], control=MagicMock(), devices={})
+
+    diag = await async_get_config_entry_diagnostics(hass, entry)
+
+    assert diag["plants"]["1"]["all_devices"] == []
+    assert diag["plants"]["1"]["device_realtime"] == {}


### PR DESCRIPTION
Toward #18 (EV charger / AC011E support).

## The real blocker
The plant realtime endpoint only returns the point IDs the library explicitly requests (its 73 known battery/inverter points). There's no EV-charger `DeviceType` and no charger points in `measure_points`, so an AC011E's data is **never requested → never returned**. It's not hidden in the response — we're just not asking for it. So the missing piece is *knowing the charger's device type and point IDs*, and until now a diagnostics dump couldn't even reveal those (it only listed inverter/ESS devices and plant-level data).

## What this does
Enhances the diagnostics platform so a single download exposes exactly what's needed to add a mapping:

- **`all_devices`** — lists *every* device on the plant (via the already-unfiltered `async_get_plant_devices`), so an unmapped EV charger shows up with its `device_type`. An unknown type is left as a **raw int** by the library — precisely the identifier needed to query it.
- **`device_realtime`** — best-effort `async_get_device_realtime` per device type, so any reachable charger points are captured.
- **Enum serialisation** — `DeviceType` etc. are converted to `"NAME (value)"` so the JSON download never fails.
- All probing is wrapped; a diagnostics download always succeeds and records failures inline.
- **TROUBLESHOOTING** gains a *"A device (EV charger, meter, etc.) isn't showing up"* section describing the capture-and-map workflow and the **Extra measure points** stopgap.

This also helps *any* "device X isn't showing" report (meters, extra batteries), not just EV chargers.

## What still needs the hardware owner
The actual AC011E point IDs — which this dump now surfaces. Once an owner attaches their diagnostics to #18, the point IDs can be added to the library's `measure_points` (and default aliases) so the charger's sensors appear automatically. No `sungrow-isolarcloud` change was needed for this PR (it uses helpers already in 0.5.0); the follow-up mapping is where a library update would land.

Coverage: diagnostics.py at 97%, suite green at ~97%.

🤖 Generated with [Claude Code](https://claude.com/claude-code)