### PR TITLE
fix(dispatch): select ESS device when device_type is a DeviceType enum

### DIFF
--- a/custom_components/sungrow/__init__.py
+++ b/custom_components/sungrow/__init__.py
@@ -53,6 +53,30 @@ class SungrowData:
 type SungrowConfigEntry = ConfigEntry[SungrowData]
 
 
+def _matches_device_type(device: dict, target: DeviceType) -> bool:
+    """Return True if a discovered device is of ``target`` type.
+
+    pysolarcloud converts a *known* device type to a ``DeviceType`` enum, but the
+    raw API (and test mocks) may present it as an int or a string, so match against
+    all three representations rather than a single one.
+    """
+    dt = device.get("device_type")
+    return dt in (target, target.value, target.name)
+
+
+def select_dispatch_device(devices: list[dict]) -> dict | None:
+    """Pick the device to attach dispatch (number/select) entities to.
+
+    Prefer an energy-storage system — that's what accepts charge/discharge dispatch
+    — and fall back to the first discovered device otherwise. Returns ``None`` when
+    there are no devices.
+    """
+    if not devices:
+        return None
+    ess = [d for d in devices if _matches_device_type(d, DeviceType.ENERGY_STORAGE_SYSTEM)]
+    return ess[0] if ess else devices[0]
+
+
 class IterableSchema(vol.Schema):
     """A Schema that can be iterated over (yielding nothing) to satisfy HA's checks."""
 

--- a/custom_components/sungrow/number.py
+++ b/custom_components/sungrow/number.py
@@ -12,7 +12,7 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 from pysolarcloud.control import Control
 
-from . import async_start_heartbeat, async_stop_heartbeat
+from . import async_start_heartbeat, async_stop_heartbeat, select_dispatch_device
 from .const import DOMAIN
 from .coordinator import SungrowPlantCoordinator
 
@@ -78,11 +78,10 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry, async_add_e
     for coordinator in coordinators:
         plant_id = coordinator.plant_id
         devices = devices_by_plant.get(plant_id, [])
-        if not devices:
+        # Prefer the ESS device if present, otherwise fall back to the first device.
+        target = select_dispatch_device(devices)
+        if target is None:
             continue
-        # Prefer the ESS device if present, otherwise fall back to the first inverter.
-        ess_devices = [d for d in devices if d.get("device_type") == "ENERGY_STORAGE_SYSTEM"]
-        target = ess_devices[0] if ess_devices else devices[0]
         device_uuid = target.get("uuid")
         if not device_uuid:
             continue

--- a/custom_components/sungrow/select.py
+++ b/custom_components/sungrow/select.py
@@ -12,7 +12,7 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 from pysolarcloud.control import Control
 
-from . import async_start_heartbeat, async_stop_heartbeat
+from . import async_start_heartbeat, async_stop_heartbeat, select_dispatch_device
 from .const import DOMAIN
 from .coordinator import SungrowPlantCoordinator
 
@@ -50,10 +50,10 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry, async_add_e
     for coordinator in coordinators:
         plant_id = coordinator.plant_id
         devices = devices_by_plant.get(plant_id, [])
-        if not devices:
+        # Prefer the ESS device if present, otherwise fall back to the first device.
+        target = select_dispatch_device(devices)
+        if target is None:
             continue
-        ess_devices = [d for d in devices if d.get("device_type") == "ENERGY_STORAGE_SYSTEM"]
-        target = ess_devices[0] if ess_devices else devices[0]
         device_uuid = target.get("uuid")
         if not device_uuid:
             continue

--- a/tests/test_dispatch.py
+++ b/tests/test_dispatch.py
@@ -5,9 +5,10 @@ from unittest.mock import AsyncMock, MagicMock, patch
 from homeassistant.components.number import NumberDeviceClass
 from homeassistant.components.select import SelectEntity
 from homeassistant.core import HomeAssistant
+from pysolarcloud.plants import DeviceType
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 
-from custom_components.sungrow import SungrowData
+from custom_components.sungrow import SungrowData, select_dispatch_device
 from custom_components.sungrow.const import DOMAIN
 from custom_components.sungrow.number import DISPATCH_NUMBERS
 from custom_components.sungrow.number import async_setup_entry as number_setup_entry
@@ -55,6 +56,42 @@ async def test_number_setup_creates_entities_for_ess_device(hass: HomeAssistant)
     power = next(e for e in added if e.param == "charge_discharge_power")
     assert power._attr_device_class == NumberDeviceClass.POWER
     assert power._attr_native_unit_of_measurement == "W"
+
+
+def test_select_dispatch_device_matches_all_representations():
+    """The ESS is chosen whether device_type is an enum, int, or string."""
+    assert select_dispatch_device([]) is None
+    # Inverter first, ESS second — the ESS must still win (not just devices[0]).
+    enum_devices = [
+        {"uuid": "inv", "device_type": DeviceType.INVERTER},
+        {"uuid": "ess", "device_type": DeviceType.ENERGY_STORAGE_SYSTEM},
+    ]
+    assert select_dispatch_device(enum_devices)["uuid"] == "ess"
+    assert select_dispatch_device([{"uuid": "ess", "device_type": 14}])["uuid"] == "ess"
+    assert select_dispatch_device([{"uuid": "ess", "device_type": "ENERGY_STORAGE_SYSTEM"}])["uuid"] == "ess"
+    # No ESS -> first device.
+    assert select_dispatch_device([{"uuid": "inv", "device_type": DeviceType.INVERTER}])["uuid"] == "inv"
+
+
+async def test_number_setup_prefers_ess_with_enum_device_type(hass: HomeAssistant):
+    """ESS is selected even when device_type is a DeviceType enum (the production path).
+
+    Regression test: the old string comparison never matched the enum, so dispatch
+    silently fell back to devices[0] (here the inverter).
+    """
+    entry = MockConfigEntry(domain=DOMAIN, data=MOCK_CONFIG_DATA.copy())
+    entry.add_to_hass(hass)
+    devices = [
+        {"uuid": "inv-1", "device_type": DeviceType.INVERTER},
+        {"uuid": "ess-1", "device_type": DeviceType.ENERGY_STORAGE_SYSTEM},
+    ]
+    _setup_entry_data(entry, devices)
+
+    added = []
+    await number_setup_entry(hass, entry, lambda entities: added.extend(entities))
+
+    assert added
+    assert all(e.device_uuid == "ess-1" for e in added)
 
 
 async def test_number_setup_falls_back_to_inverter(hass: HomeAssistant):


### PR DESCRIPTION
Found while working on #18.

## The bug
`number.py`/`select.py` picked the dispatch target with:
```python
ess_devices = [d for d in devices if d.get("device_type") == "ENERGY_STORAGE_SYSTEM"]
```
But pysolarcloud converts a **known** device type to a `DeviceType` **enum** (a plain `Enum`, so `DeviceType.ENERGY_STORAGE_SYSTEM == "ENERGY_STORAGE_SYSTEM"` is `False`, and `== 14` is also `False`). So in production `ess_devices` is always empty and dispatch silently falls back to `devices[0]` — which may be an inverter rather than the battery it should target. The tests never caught it because they mock `device_type` as a string.

## The fix
A shared `select_dispatch_device()` helper matches the ESS across **all** representations the API/mocks can produce — `DeviceType` enum, raw int (`14`), or string (`"ENERGY_STORAGE_SYSTEM"`) — and both platforms use it.

- Regression test with real `DeviceType` enums (inverter first, ESS second → ESS must win).
- Unit test for the helper across enum/int/string + the no-ESS fallback + empty-list `None`.

Suite green (131 passed), coverage ~97%.

🤖 Generated with [Claude Code](https://claude.com/claude-code)