### PR TITLE
fix: register OAuth callback view during config flow (first-install 404)

### DIFF
--- a/custom_components/sungrow/__init__.py
+++ b/custom_components/sungrow/__init__.py
@@ -93,9 +93,26 @@ class IterableSchema(vol.Schema):
 CONFIG_SCHEMA = IterableSchema({}, extra=vol.ALLOW_EXTRA)
 
 
+def _ensure_callback_view_registered(hass: HomeAssistant) -> None:
+    """Register the OAuth callback HTTP view exactly once.
+
+    iSolarCloud redirects back to ``/api/sungrow_hass/callback`` *during* the very
+    first config flow — before any config entry exists, and therefore before
+    ``async_setup`` (which used to be the only place the view was registered) has
+    run. Without this, a first-time install gets a 404 on the callback while an
+    install that already has a Sungrow entry works. Registering here, guarded by a
+    flag so aiohttp never sees a duplicate route, fixes the first-time case.
+    """
+    domain_data = hass.data.setdefault(DOMAIN, {})
+    if domain_data.get("callback_view_registered"):
+        return
+    hass.http.register_view(SungrowAuthCallbackView())
+    domain_data["callback_view_registered"] = True
+
+
 async def async_setup(hass: HomeAssistant, config: dict) -> bool:
     """Set up the Sungrow iSolarCloud component."""
-    hass.http.register_view(SungrowAuthCallbackView())
+    _ensure_callback_view_registered(hass)
     return True
 
 

--- a/custom_components/sungrow/config_flow.py
+++ b/custom_components/sungrow/config_flow.py
@@ -156,6 +156,11 @@ class SungrowConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         """
         if not self._ensure_auth_client():
             return self.async_abort(reason="library_missing")
+        # Register the callback view now: on a first-time install async_setup has
+        # not run yet, so without this the OAuth redirect would 404.
+        from . import _ensure_callback_view_registered
+
+        _ensure_callback_view_registered(self.hass)
         return await self.async_step_auth_callback()
 
     async def async_step_auth_callback(self, user_input: dict[str, Any] | None = None):

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -309,6 +309,25 @@ async def test_auth_url_includes_flow_id(hass: HomeAssistant, mock_auth):
     assert f"flow_id={result['flow_id']}" in redirect_uri
 
 
+async def test_callback_view_registered_during_first_flow(hass: HomeAssistant, mock_auth):
+    """The callback view is registered by the flow itself, before any entry exists.
+
+    Regression for the 404-on-callback bug on a first-time install: async_setup
+    (the old sole place the view was registered) only runs once an entry is being
+    set up, which is after the OAuth redirect. The flow must register it so the
+    redirect resolves.
+    """
+    # Nothing has registered the callback view yet (async_setup has not run).
+    assert not hass.data.get(DOMAIN, {}).get("callback_view_registered")
+
+    result = await hass.config_entries.flow.async_init(DOMAIN, context={"source": config_entries.SOURCE_USER})
+    result2 = await hass.config_entries.flow.async_configure(result["flow_id"], user_input=MOCK_USER_INPUT)
+
+    # Reaching the OAuth wait must have registered the callback view.
+    assert result2["type"] == data_entry_flow.FlowResultType.SHOW_PROGRESS
+    assert hass.data[DOMAIN]["callback_view_registered"] is True
+
+
 async def test_auth_callback_step_registers_future(hass: HomeAssistant, mock_auth):
     """Test the automatic auth step registers a callback future."""
     result = await hass.config_entries.flow.async_init(DOMAIN, context={"source": config_entries.SOURCE_USER})


### PR DESCRIPTION
Fixes the **404 on the OAuth callback during a first-time install** (works fine once a Sungrow entry already exists).

## Root cause
The `/api/sungrow_hass/callback` HTTP view was only registered in `async_setup()`. For a config-entry-only integration, `async_setup` doesn't run until a config entry is being set up — which for a fresh install is *after* the OAuth redirect happens during the config flow. So:
- **First-time install:** no entry yet → `async_setup` hasn't run → view not registered → iSolarCloud's redirect **404s**.
- **Existing Sungrow entry:** `async_setup` ran at startup → view registered → callback works.

That's exactly the reported behaviour.

## Fix
Register the view from the config flow as well, via an idempotent `_ensure_callback_view_registered()` guarded by a flag in `hass.data[DOMAIN]` (so aiohttp never sees a duplicate route). `async_setup` now uses the same helper, so the two paths can't double-register.

Regression test asserts the view is registered as soon as the flow reaches the OAuth wait, before any entry exists.

Suite green (132 passed), coverage ~97%.

🤖 Generated with [Claude Code](https://claude.com/claude-code)