### PR TITLE
fix: use one bare redirect_uri for auth + token exchange (invalid auth)

### DIFF
--- a/custom_components/sungrow/config_flow.py
+++ b/custom_components/sungrow/config_flow.py
@@ -146,17 +146,31 @@ class SungrowConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         _LOGGER.debug("Initialized Auth client for Sungrow iSolarCloud")
         return True
 
-    def _auth_url_with_flow_id(self) -> str:
-        """Build the iSolarCloud authorization URL including this flow's ID.
+    def _redirect_uri(self) -> str:
+        """Canonical redirect URI used for BOTH the auth request and token exchange.
 
-        The flow_id lets the callback view resume the correct config flow when
-        iSolarCloud redirects back to /api/sungrow_hass/callback.
+        iSolarCloud validates that the ``redirect_uri`` sent to the token endpoint
+        matches the one from the authorization request, so they must be byte-for-byte
+        identical — hence a single source here (trailing slash normalised).
+
+        We deliberately do NOT append a ``flow_id``: iSolarCloud strips extra query
+        params from the redirect, so it never round-tripped anyway (the callback view
+        resolves the pending flow via its single-flow fallback). Appending it only
+        broke the token exchange, which uses the bare URI, with "invalid
+        authentication".
         """
-        redirect_uri = self.init_info[CONF_REDIRECT_URI].rstrip("/")
-        # Preserve any existing query params on the configured redirect URI.
-        separator = "&" if "?" in redirect_uri else "?"
-        callback_redirect = f"{redirect_uri}{separator}flow_id={self.flow_id}"
-        return self.auth_client.auth_url(callback_redirect)
+        return self.init_info[CONF_REDIRECT_URI].rstrip("/")
+
+    def _auth_url(self) -> str:
+        """Build the iSolarCloud authorization URL for the canonical redirect URI.
+
+        Always called at render time (never cached), so every screen that shows the
+        link — the progress wait, the manual-entry form, and the error-retry form —
+        displays a freshly generated, current URL. The URL no longer embeds a
+        per-flow ``flow_id`` that could go stale, so it stays valid for the whole
+        flow and each visit yields a fresh authorization code from iSolarCloud.
+        """
+        return self.auth_client.auth_url(self._redirect_uri())
 
     async def async_step_auth(self, user_input: dict[str, Any] | None = None):
         """Begin authorization by automatically waiting for the OAuth redirect.
@@ -196,7 +210,7 @@ class SungrowConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         future: asyncio.Future[str] = asyncio.Future()
         flows[self.flow_id] = future
 
-        auth_url = self._auth_url_with_flow_id()
+        auth_url = self._auth_url()
 
         async def _wait_for_callback() -> None:
             """Resume the flow once the OAuth callback delivers a code."""
@@ -263,7 +277,7 @@ class SungrowConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 _LOGGER.exception("Unexpected exception in async_step_auth_manual: %s", e)
                 errors["base"] = "unknown"
 
-        auth_url = self._auth_url_with_flow_id()
+        auth_url = self._auth_url()
         return self.async_show_form(
             step_id="auth_manual",
             description_placeholders={"auth_url": auth_url},
@@ -277,7 +291,7 @@ class SungrowConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         Both the automatic and manual paths land here on failure; showing the
         manual form lets the user paste a fresh code or full redirect URL.
         """
-        auth_url = self._auth_url_with_flow_id()
+        auth_url = self._auth_url()
         return self.async_show_form(
             step_id="auth_manual",
             description_placeholders={"auth_url": auth_url},
@@ -297,7 +311,7 @@ class SungrowConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             return self.async_abort(reason="missing_code")
 
         try:
-            redirect_uri_clean = self.init_info[CONF_REDIRECT_URI]
+            redirect_uri_clean = self._redirect_uri()
             # Never log the authorization code or tokens — they are credentials.
             _LOGGER.debug("Authorizing with redirect_uri: %s", redirect_uri_clean)
             await self.auth_client.async_authorize(code, redirect_uri_clean)

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -282,14 +282,40 @@ async def test_reauth_auto_wait_registers_future(hass: HomeAssistant, mock_auth)
     assert isinstance(flows[result["flow_id"]], asyncio.Future)
 
 
-async def test_auth_url_includes_flow_id(hass: HomeAssistant, mock_auth):
-    """The authorization URL embeds the current (reauth) flow ID."""
+async def test_auth_url_uses_bare_redirect(hass: HomeAssistant, mock_auth):
+    """The auth URL uses the bare redirect URI (no flow_id).
+
+    iSolarCloud strips extra query params from the redirect and validates the
+    token-exchange redirect_uri against the auth request's, so appending a flow_id
+    would break the exchange. The callback view resolves the flow via its
+    single-flow fallback instead.
+    """
     entry = _hub_entry(hass)
-    result = await entry.start_reauth_flow(hass)
+    await entry.start_reauth_flow(hass)
 
     mock_auth.auth_url.assert_called_once()
     redirect_uri = mock_auth.auth_url.call_args[0][0]
-    assert f"flow_id={result['flow_id']}" in redirect_uri
+    assert "flow_id=" not in redirect_uri
+    assert redirect_uri == MOCK_USER_INPUT["redirect_uri"].rstrip("/")
+
+
+async def test_token_exchange_redirect_matches_auth_request(hass: HomeAssistant, mock_auth):
+    """Regression: the token exchange must use the same redirect_uri as the auth URL.
+
+    A mismatch (previously the auth URL had a flow_id appended while the exchange
+    used the bare URI) makes iSolarCloud reject the exchange with 'invalid
+    authentication'.
+    """
+    entry = _hub_entry(hass)
+    flow_id = await _reauth_to_manual(hass, entry)
+
+    with patch("custom_components.sungrow.async_setup_entry", return_value=True):
+        await hass.config_entries.flow.async_configure(flow_id, user_input={"code": "abc"})
+        await hass.async_block_till_done()
+
+    auth_redirect = mock_auth.auth_url.call_args[0][0]
+    exchange_redirect = mock_auth.async_authorize.call_args[0][1]
+    assert exchange_redirect == auth_redirect
 
 
 async def test_reauth_timeout_falls_back_to_manual(hass: HomeAssistant, mock_auth):


### PR DESCRIPTION
Fixes the **"Invalid authentication"** you hit — both the automatic callback and the manual code/URL paste failed at the token exchange.

## Root cause
iSolarCloud validates that the `redirect_uri` sent to the **token endpoint** matches the one from the **authorization request**. But:
- Auth request: `…/callback?flow_id=…` (`_auth_url_with_flow_id` appended the flow id)
- Token exchange: bare `…/callback` (from `async_step_finish`)

Mismatch → iSolarCloud returns no `access_token` → the flow shows *Invalid authentication*. (Also a possible trailing-slash mismatch, since the two came from different code.)

Your callback URL had **no** `flow_id` (`…/callback?code=LDYEEq`) — confirming iSolarCloud strips extra query params, so the `flow_id` never round-tripped and the callback already relied on its single-pending-flow fallback. Appending it gained nothing and broke the exchange.

## Fix
- `_redirect_uri()` — one canonical redirect URI (trailing slash normalised) used by **both** the auth URL and the token exchange, so they're byte-for-byte identical.
- Drop `flow_id` from the redirect entirely.
- The auth URL is rebuilt on every screen (progress / manual / error-retry), so the link is always current and no longer carries a per-flow id that could go stale (addresses "keep the OAuth URL up to date / regenerate each time").

Regression test asserts the token-exchange `redirect_uri` equals the auth request's, and that the auth URL carries no `flow_id`. Suite green (131), ~96% coverage.

## Note
The **404 is confirmed fixed** by the hub-first rework (#71) — your callback returned "Authorization successful". This PR fixes the *next* step (the token exchange). Please retest with a fresh authorization on the new dev build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)