### PR TITLE
ci: prevent code injection in workflow run scripts (CodeQL alert #1)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -147,12 +147,14 @@ jobs:
         env:
           BRANCH_RAW: ${{ github.head_ref }}
           HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          SKIPPED: ${{ steps.nextver.outputs.skipped }}
+          NEXT_VERSION: ${{ steps.nextver.outputs.version }}
         run: |
           # No releasable commits -> no bump; fall back to the manifest version.
-          if [ "${{ steps.nextver.outputs.skipped }}" = "true" ]; then
+          if [ "$SKIPPED" = "true" ]; then
             VERSION=$(jq -r .version custom_components/sungrow/manifest.json)
           else
-            VERSION="${{ steps.nextver.outputs.version }}"
+            VERSION="$NEXT_VERSION"
           fi
           SHA="${HEAD_SHA::7}"
           BRANCH=$(printf '%s' "$BRANCH_RAW" | sed 's/[^a-zA-Z0-9._-]/-/g' | sed 's/-\{2,\}/-/g')

--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -64,8 +64,11 @@ jobs:
 
             - name: Sync versions to manifest and pyproject
               if: steps.changelog.outputs.skipped != 'true'
+              # Pass the computed version via env, not inline ${{ }}, so it can't be
+              # shell-injected.
+              env:
+                  VERSION: ${{ steps.changelog.outputs.version }}
               run: |
-                  VERSION="${{ steps.changelog.outputs.version }}"
                   # Update manifest.json (preserving quotes and comma)
                   sed -i "s/\"version\": \".*\"/\"version\": \"${VERSION}\"/" custom_components/sungrow/manifest.json
                   # Update pyproject.toml

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,22 +56,31 @@ jobs:
 
             - name: Build dev tag
               id: tag
+              # Pass step/context values via env and reference them as shell vars —
+              # never inline ${{ }} into the script (avoids code injection from a
+              # workflow_dispatch-controlled value).
+              env:
+                  SKIPPED: ${{ steps.nextver.outputs.skipped }}
+                  NEXT_VERSION: ${{ steps.nextver.outputs.version }}
+                  RUN_NUMBER: ${{ github.run_number }}
               run: |
                   # No releasable commits since the last release -> no bump; fall
                   # back to the current manifest version.
-                  if [ "${{ steps.nextver.outputs.skipped }}" = "true" ]; then
+                  if [ "$SKIPPED" = "true" ]; then
                     VERSION=$(jq -r .version custom_components/sungrow/manifest.json)
                   else
-                    VERSION="${{ steps.nextver.outputs.version }}"
+                    VERSION="$NEXT_VERSION"
                   fi
-                  TAG="dev-v${VERSION}-${{ github.run_number }}"
+                  TAG="dev-v${VERSION}-${RUN_NUMBER}"
                   echo "tag=${TAG}" >> "$GITHUB_OUTPUT"
 
             - name: Create pre-release
               env:
                   GH_TOKEN: ${{ github.token }}
+                  TAG: ${{ steps.tag.outputs.tag }}
+                  COMMIT_SHA: ${{ github.event.workflow_run.head_sha || github.sha }}
               run: |
-                  gh release create "${{ steps.tag.outputs.tag }}" \
+                  gh release create "$TAG" \
                     --prerelease \
-                    --title "${{ steps.tag.outputs.tag }}" \
-                    --notes "Development build from \`main\` at commit \`${{ github.event.workflow_run.head_sha || github.sha }}\`."
+                    --title "$TAG" \
+                    --notes "Development build from \`main\` at commit \`${COMMIT_SHA}\`."


### PR DESCRIPTION
Closes the **critical** CodeQL finding [code-scanning/1](https://github.com/KRoperUK/sungrow-hass/security/code-scanning/1) — `actions/code-injection/critical` on `release.yml`.

### Problem
`${{ steps.tag.outputs.tag }}` (and similar step-output / context values) were interpolated **directly into `run:` shell scripts**. On a `workflow_dispatch` run such a value is treated as potentially external-controlled, so a crafted value could inject shell commands.

### Fix
Move every GitHub-context / step-output value used in a `run:` block into `env:` and reference it as a shell variable (`"$VAR"`) instead of inlining `${{ }}`. This is the GitHub-recommended mitigation.

Hardened across the class (not just the flagged line):
- `release.yml` — *Build dev tag* and *Create pre-release*
- `ci.yml` — dev-release *Build dev tag*
- `release-pr.yml` — *Sync versions*

Verified no `run:` script interpolates `${{ }}` anymore. Action `with:` inputs (e.g. `tag_name`, create-pull-request fields) are left as-is — they're passed to actions, not evaluated by a shell.

🤖 Generated with [Claude Code](https://claude.com/claude-code)