### PR TITLE
feat: opt-in per-device sensors (EV chargers, meters, extra batteries)

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ After setup, go to **Settings → Devices & Services → Sungrow → Configure**
 
 - **Polling interval** (default 5 minutes)
 - **Extra measure points** — add custom `point_id=code` pairs to request additional data points from iSolarCloud
+- **Create per-device sensors** — off by default. When enabled, each discovered device (EV charger, meter, extra battery) is polled for its own realtime points and exposed as sensors under its own device card, grouped beneath the plant. Combine with **Extra measure points** to surface device-specific point IDs (e.g. an EV charger). Adds extra API calls, so leave it off if you only need plant-level data.
 
 ### Sensor mapping
 

--- a/custom_components/sungrow/__init__.py
+++ b/custom_components/sungrow/__init__.py
@@ -67,14 +67,15 @@ def _matches_device_type(device: dict, target: DeviceType) -> bool:
 def select_dispatch_device(devices: list[dict]) -> dict | None:
     """Pick the device to attach dispatch (number/select) entities to.
 
-    Prefer an energy-storage system — that's what accepts charge/discharge dispatch
-    — and fall back to the first discovered device otherwise. Returns ``None`` when
-    there are no devices.
+    Only inverters and energy-storage systems accept charge/discharge dispatch, so
+    ignore any other discovered devices (meters, EV chargers, ...). Prefer an ESS,
+    then fall back to an inverter. Returns ``None`` when neither is present.
     """
-    if not devices:
-        return None
     ess = [d for d in devices if _matches_device_type(d, DeviceType.ENERGY_STORAGE_SYSTEM)]
-    return ess[0] if ess else devices[0]
+    if ess:
+        return ess[0]
+    inverters = [d for d in devices if _matches_device_type(d, DeviceType.INVERTER)]
+    return inverters[0] if inverters else None
 
 
 class IterableSchema(vol.Schema):
@@ -166,22 +167,22 @@ async def async_setup_entry(hass: HomeAssistant, entry: SungrowConfigEntry) -> b
     for plant_info in plant_list:
         plant_id = str(plant_info["ps_id"])
         plant_name = plant_info["ps_name"]
-        coordinator = SungrowPlantCoordinator(hass, entry, plants_service, plant_id, plant_name)
+
+        # Discover ALL devices first (not just inverter/ESS): dispatch filters down to
+        # the dispatch-capable ones, while per-device sensors (issue #74) can use any
+        # of them. Failures here are non-fatal — the plant still works on plant-level
+        # data, just without device discovery.
+        try:
+            devices = await plants_service.async_get_plant_devices(plant_id)
+        except Exception as err:
+            _LOGGER.warning("Could not fetch devices for plant %s: %s", plant_name, err)
+            devices = []
+        devices_by_plant[plant_id] = devices
+
+        coordinator = SungrowPlantCoordinator(hass, entry, plants_service, plant_id, plant_name, devices)
         # Raises ConfigEntryNotReady / ConfigEntryAuthFailed as classified by the coordinator.
         await coordinator.async_config_entry_first_refresh()
         coordinators.append(coordinator)
-
-        # Discover dispatch-capable devices (inverters / ESS) for this plant. Failures here are
-        # non-fatal — dispatch entities simply won't be created for this plant.
-        try:
-            devices = await plants_service.async_get_plant_devices(
-                plant_id,
-                device_types=[DeviceType.INVERTER, DeviceType.ENERGY_STORAGE_SYSTEM],
-            )
-            devices_by_plant[plant_id] = devices
-        except Exception as err:
-            _LOGGER.warning("Could not fetch devices for plant %s: %s", plant_name, err)
-            devices_by_plant[plant_id] = []
 
     entry.runtime_data = SungrowData(
         coordinators=coordinators,

--- a/custom_components/sungrow/config_flow.py
+++ b/custom_components/sungrow/config_flow.py
@@ -16,6 +16,7 @@ from .const import (
     CONF_APP_ID,
     CONF_APP_KEY,
     CONF_APP_SECRET,
+    CONF_ENABLE_DEVICE_SENSORS,
     CONF_EXTRA_MEASURE_POINTS,
     CONF_GATEWAY,
     CONF_REDIRECT_URI,
@@ -388,6 +389,7 @@ class SungrowOptionsFlow(config_entries.OptionsFlow):
 
         current_interval = self.config_entry.options.get(CONF_SCAN_INTERVAL, DEFAULT_SCAN_INTERVAL)
         current_extras = self.config_entry.options.get(CONF_EXTRA_MEASURE_POINTS, {})
+        current_device_sensors = self.config_entry.options.get(CONF_ENABLE_DEVICE_SENSORS, False)
         extras_str = ",".join(f"{pid}={code}" for pid, code in current_extras.items())
         return self.async_show_form(
             step_id="init",
@@ -402,6 +404,7 @@ class SungrowOptionsFlow(config_entries.OptionsFlow):
                         default=extras_str,
                         description={"suggested_value": extras_str},
                     ): str,
+                    vol.Optional(CONF_ENABLE_DEVICE_SENSORS, default=current_device_sensors): bool,
                 }
             ),
             errors=errors,

--- a/custom_components/sungrow/const.py
+++ b/custom_components/sungrow/const.py
@@ -10,6 +10,10 @@ CONF_REDIRECT_URI = "redirect_uri"
 # Options
 CONF_SCAN_INTERVAL = "scan_interval"
 CONF_EXTRA_MEASURE_POINTS = "extra_measure_points"
+# Opt-in: also poll each discovered device (charger, meter, extra battery) for its
+# own realtime points and expose them as sensors under that device. Off by default
+# to avoid extra API calls / entity clutter for users who only need plant data.
+CONF_ENABLE_DEVICE_SENSORS = "enable_device_sensors"
 
 GATEWAYS = {
     "Europe": "https://gateway.isolarcloud.eu",

--- a/custom_components/sungrow/coordinator.py
+++ b/custom_components/sungrow/coordinator.py
@@ -13,7 +13,12 @@ from pysolarcloud import PySolarCloudException
 from pysolarcloud.plants import Plants
 
 from .auth import AUTH_ERRORS
-from .const import CONF_EXTRA_MEASURE_POINTS, CONF_SCAN_INTERVAL, DEFAULT_SCAN_INTERVAL
+from .const import (
+    CONF_ENABLE_DEVICE_SENSORS,
+    CONF_EXTRA_MEASURE_POINTS,
+    CONF_SCAN_INTERVAL,
+    DEFAULT_SCAN_INTERVAL,
+)
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -43,6 +48,7 @@ class SungrowPlantCoordinator(DataUpdateCoordinator):
         plants_service: Plants,
         plant_id: str,
         plant_name: str,
+        devices: list[dict] | None = None,
     ) -> None:
         """Initialize the coordinator."""
         scan_seconds = config_entry.options.get(CONF_SCAN_INTERVAL, DEFAULT_SCAN_INTERVAL)
@@ -56,7 +62,11 @@ class SungrowPlantCoordinator(DataUpdateCoordinator):
         self.plants_service = plants_service
         self.plant_id = plant_id
         self.plant_name = plant_name
+        self.devices: list[dict] = list(devices or [])
         self.extra_measure_points: dict[str, str] = dict(config_entry.options.get(CONF_EXTRA_MEASURE_POINTS, {}))
+        self.enable_device_sensors: bool = bool(config_entry.options.get(CONF_ENABLE_DEVICE_SENSORS, False))
+        # uuid -> { code: point } for per-device realtime (populated when enabled).
+        self.device_data: dict[str, dict] = {}
 
     async def _async_update_data(self):
         """Fetch data from the API for this plant."""
@@ -71,4 +81,40 @@ class SungrowPlantCoordinator(DataUpdateCoordinator):
                 raise ConfigEntryAuthFailed(f"Authentication with iSolarCloud failed: {err}") from err
             raise UpdateFailed(f"Error communicating with iSolarCloud API: {err}") from err
 
+        if self.enable_device_sensors:
+            self.device_data = await self._async_fetch_device_data()
+
         return all_plants_data.get(self.plant_id, {})
+
+    async def _async_fetch_device_data(self) -> dict[str, dict]:
+        """Fetch per-device realtime for each distinct device type (best effort).
+
+        The plant realtime endpoint only returns the plant-level points, so devices
+        like EV chargers or meters need a per-device fetch (issue #74). This is
+        best-effort: a device type whose endpoint is unavailable or errors simply
+        contributes nothing rather than failing the whole update. Any user-configured
+        extra measure points are requested here too, so newly identified charger/meter
+        point IDs surface without a code change.
+        """
+        merged: dict[str, dict] = {}
+        seen_types: set = set()
+        for device in self.devices:
+            device_type = device.get("device_type")
+            if device_type is None:
+                continue
+            type_id = getattr(device_type, "value", device_type)
+            if type_id in seen_types:
+                continue
+            seen_types.add(type_id)
+            try:
+                result = await self.plants_service.async_get_device_realtime(
+                    self.plant_id,
+                    device_type,
+                    extra_measure_points=self.extra_measure_points or None,
+                )
+            except Exception as err:  # pylint: disable=broad-except
+                _LOGGER.debug("Per-device realtime failed for plant %s type %s: %s", self.plant_id, type_id, err)
+                continue
+            for uuid, points in (result or {}).items():
+                merged.setdefault(str(uuid), {}).update(points)
+        return merged

--- a/custom_components/sungrow/sensor.py
+++ b/custom_components/sungrow/sensor.py
@@ -114,28 +114,51 @@ def infer_device_class(unit: str | None, point_code: str) -> tuple[SensorDeviceC
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry, async_add_entities: AddEntitiesCallback) -> None:
     """Set up Sungrow sensors from the coordinators created during entry setup."""
     coordinators = entry.runtime_data.coordinators
+    devices_by_plant = entry.runtime_data.devices
     # Point the device "Visit" link at the region's iSolarCloud web console.
     console_url = GATEWAY_CONSOLE_URLS.get(entry.data.get(CONF_GATEWAY), DEFAULT_CONSOLE_URL)
 
     entities: list[SungrowSensor] = []
     for coordinator in coordinators:
-        if not coordinator.data:
-            _LOGGER.warning("No data received for plant %s", coordinator.plant_name)
-            continue
-
+        # Plant-level sensors.
         # The data structure is { "P_CODE": { "code": ..., "value": ..., "unit": ..., "name": ... } }
-        for point_code, point_data in coordinator.data.items():
-            entities.append(
-                SungrowSensor(
-                    coordinator, point_code, coordinator.plant_id, coordinator.plant_name, point_data, console_url
+        if coordinator.data:
+            for point_code, point_data in coordinator.data.items():
+                entities.append(
+                    SungrowSensor(
+                        coordinator, point_code, coordinator.plant_id, coordinator.plant_name, point_data, console_url
+                    )
                 )
-            )
+        else:
+            _LOGGER.warning("No data received for plant %s", coordinator.plant_name)
+
+        # Per-device sensors (opt-in, issue #74): surface points reported per device
+        # (EV chargers, meters, extra batteries). Points already present at the plant
+        # level are skipped so enabling this doesn't just duplicate every plant sensor
+        # under the inverter.
+        if coordinator.enable_device_sensors and coordinator.device_data:
+            plant_codes = set(coordinator.data or {})
+            device_names = {
+                str(d.get("uuid")): (d.get("device_name") or d.get("device_model_name") or coordinator.plant_name)
+                for d in devices_by_plant.get(coordinator.plant_id, [])
+                if d.get("uuid")
+            }
+            for uuid, points in coordinator.device_data.items():
+                device_name = device_names.get(uuid, f"Device {uuid}")
+                for point_code, point_data in points.items():
+                    if point_code in plant_codes:
+                        continue
+                    entities.append(
+                        SungrowDeviceSensor(
+                            coordinator, point_code, coordinator.plant_id, uuid, device_name, point_data
+                        )
+                    )
 
     async_add_entities(entities)
 
 
 class SungrowSensor(CoordinatorEntity, SensorEntity):
-    """Representation of a Sungrow Sensor."""
+    """Representation of a plant-level Sungrow sensor."""
 
     has_entity_name = True
 
@@ -144,26 +167,9 @@ class SungrowSensor(CoordinatorEntity, SensorEntity):
         super().__init__(coordinator)
         self.point_code = point_code
         self.plant_id = plant_id
-
-        # Prefer generating name from code to avoid Chinese names from API
-        # The API often returns Chinese names even when locale is set to English
-        # We assume point_code is a readable string identifier (e.g. 'total_active_power')
-        if point_code.isdigit():
-            # Fallback if we only have a number, but ideally we should have a string key
-            sensor_name = init_data.get("name", f"Sensor {point_code}")
-        else:
-            sensor_name = point_code.replace("_", " ").title()
-
-        # Apply friendly aliases for known opaque codes, including user-configured
-        # extra measure points that have a documented alias.
-        sensor_name = EXTRA_CODE_ALIASES.get(point_code, SENSOR_ALIASES.get(point_code, sensor_name))
-
-        # With has_entity_name = True, HA prefixes the device name automatically
-        self._attr_name = sensor_name
-        _LOGGER.debug("Created sensor: %s %s (code: %s)", plant_name, sensor_name, point_code)
         self._attr_unique_id = f"{plant_id}_{point_code}"
 
-        # Group sensors under a device per plant
+        # Group sensors under a device per plant.
         self._attr_device_info = DeviceInfo(
             identifiers={(DOMAIN, plant_id)},
             name=plant_name,
@@ -171,9 +177,30 @@ class SungrowSensor(CoordinatorEntity, SensorEntity):
             entry_type=DeviceEntryType.SERVICE,
             configuration_url=console_url,
         )
+        self._apply_point_metadata(point_code, init_data, plant_name)
 
-        # Programmatically hide sensors that are "Unknown" at first setup
-        # This prevents UI clutter for unsupported attributes (e.g. meters/batteries not present)
+    def _apply_point_metadata(self, point_code, init_data, label):
+        """Set the name, unit and device/state class from a point payload.
+
+        Shared by plant-level and per-device sensors so both name and classify points
+        the same way.
+        """
+        # Prefer generating the name from the code to avoid Chinese names from the API
+        # (the API often returns Chinese names even when locale is English). We assume
+        # point_code is a readable string identifier (e.g. 'total_active_power').
+        if point_code.isdigit():
+            sensor_name = init_data.get("name", f"Sensor {point_code}")
+        else:
+            sensor_name = point_code.replace("_", " ").title()
+        # Apply friendly aliases for known opaque / user-configured extra codes.
+        sensor_name = EXTRA_CODE_ALIASES.get(point_code, SENSOR_ALIASES.get(point_code, sensor_name))
+
+        # With has_entity_name = True, HA prefixes the device name automatically.
+        self._attr_name = sensor_name
+        _LOGGER.debug("Created sensor: %s %s (code: %s)", label, sensor_name, point_code)
+
+        # Hide points that are "Unknown" at first setup to reduce UI clutter
+        # (e.g. meters/batteries not present).
         initial_value = init_data.get("value")
         if initial_value is None or str(initial_value).strip() == "" or str(initial_value).lower() == "unknown":
             self._attr_entity_registry_enabled_default = False
@@ -186,26 +213,61 @@ class SungrowSensor(CoordinatorEntity, SensorEntity):
         self._attr_device_class = device_class
         self._attr_state_class = state_class
 
-        # Let HA choose the icon automatically for sensors with a known device class
-        # (e.g. mdi:battery for BATTERY, mdi:lightning-bolt for POWER/ENERGY).
-        # Fall back to the solar panel icon only for unclassified sensors.
+        # Let HA choose the icon for sensors with a known device class; fall back to
+        # the solar panel icon only for unclassified sensors.
         self._attr_icon = None if device_class else "mdi:solar-power-variant"
+
+    def _current_point(self):
+        """Return the current point payload for this sensor (plant-level source)."""
+        data = self.coordinator.data
+        if data and self.point_code in data:
+            return data[self.point_code]
+        return None
 
     @property
     def native_value(self):
         """Return the state of the sensor."""
-        if self.coordinator.data and self.point_code in self.coordinator.data:
-            val = self.coordinator.data[self.point_code].get("value")
-            # Try convert to float if it looks like a number but is string
-            try:
-                return float(val)
-            except (ValueError, TypeError):
-                return val
-        return None
+        point = self._current_point()
+        if point is None:
+            return None
+        val = point.get("value")
+        # Convert to float if it looks numeric but is a string.
+        try:
+            return float(val)
+        except (ValueError, TypeError):
+            return val
 
     @property
     def extra_state_attributes(self):
         """Return attributes."""
-        if self.coordinator.data and self.point_code in self.coordinator.data:
-            return self.coordinator.data[self.point_code]
-        return {}
+        return self._current_point() or {}
+
+
+class SungrowDeviceSensor(SungrowSensor):
+    """A sensor for a specific device (EV charger, meter, extra battery) under a plant.
+
+    Reads from the coordinator's per-device realtime data and is grouped under its own
+    device, linked to the plant device via ``via_device`` (issue #74).
+    """
+
+    def __init__(self, coordinator, point_code, plant_id, device_uuid, device_name, init_data):
+        """Initialize a device-scoped sensor."""
+        # Skip SungrowSensor.__init__ (it builds the plant device); reuse the shared
+        # metadata helper but with a device-scoped identity and data source.
+        CoordinatorEntity.__init__(self, coordinator)
+        self.point_code = point_code
+        self.plant_id = plant_id
+        self.device_uuid = device_uuid
+        self._attr_unique_id = f"{plant_id}_{device_uuid}_{point_code}"
+        self._attr_device_info = DeviceInfo(
+            identifiers={(DOMAIN, device_uuid)},
+            name=device_name,
+            manufacturer="Sungrow",
+            via_device=(DOMAIN, plant_id),
+        )
+        self._apply_point_metadata(point_code, init_data, device_name)
+
+    def _current_point(self):
+        """Return the current point payload from the coordinator's per-device data."""
+        device_data = getattr(self.coordinator, "device_data", None) or {}
+        return device_data.get(self.device_uuid, {}).get(self.point_code)

--- a/custom_components/sungrow/strings.json
+++ b/custom_components/sungrow/strings.json
@@ -52,7 +52,8 @@
         "description": "Adjust how often Home Assistant polls iSolarCloud. Lower values update more frequently but use more of your API quota. The free plan allows ~2000 calls/hour; the minimum is 10 seconds.",
         "data": {
           "scan_interval": "Polling interval (seconds)",
-          "extra_measure_points": "Extra measure points (point_id=code, comma separated)"
+          "extra_measure_points": "Extra measure points (point_id=code, comma separated)",
+          "enable_device_sensors": "Create per-device sensors (EV chargers, meters, extra batteries)"
         }
       }
     }

--- a/custom_components/sungrow/translations/en.json
+++ b/custom_components/sungrow/translations/en.json
@@ -52,7 +52,8 @@
         "description": "Adjust how often Home Assistant polls iSolarCloud. Lower values update more frequently but use more of your API quota. The free plan allows ~2000 calls/hour; the minimum is 10 seconds.",
         "data": {
           "scan_interval": "Polling interval (seconds)",
-          "extra_measure_points": "Extra measure points (point_id=code, comma separated)"
+          "extra_measure_points": "Extra measure points (point_id=code, comma separated)",
+          "enable_device_sensors": "Create per-device sensors (EV chargers, meters, extra batteries)"
         }
       }
     }

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -115,11 +115,13 @@ To help map it:
      type, so any reachable charger points show up here.
 2. **Attach that JSON to [#18](https://github.com/KRoperUK/sungrow-hass/issues/18)**
    so the point IDs can be added to the default mapping.
-3. **Stopgap — surface points yourself.** If you already know a point ID (from the
-   iSolarCloud Developer Portal's *Common Measuring Point Enumeration*), add it
-   under **Configure → Extra measure points** as `point_id=code` (for example
-   `<id>=ev_charger_power`). Recognised codes like `ev_charger_power` /
-   `ev_charger_energy` get a friendly name automatically.
+3. **Surface the device's own sensors.** Enable **Configure → Create per-device
+   sensors**. Each discovered device is then polled for its own realtime points and
+   gets sensors under its own device card. Combine with **Extra measure points**
+   (`point_id=code`, e.g. `<id>=ev_charger_power`) if the charger's points aren't
+   returned by default — recognised codes like `ev_charger_power` /
+   `ev_charger_energy` get a friendly name automatically. Leave the option off if
+   you only need plant-level data (it adds extra API calls).
 
 ---
 

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -7,8 +7,13 @@ from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryAuthFailed
 from homeassistant.helpers.update_coordinator import UpdateFailed
 from pysolarcloud import PySolarCloudException
+from pysolarcloud.plants import DeviceType
 
-from custom_components.sungrow.const import CONF_EXTRA_MEASURE_POINTS, CONF_SCAN_INTERVAL
+from custom_components.sungrow.const import (
+    CONF_ENABLE_DEVICE_SENSORS,
+    CONF_EXTRA_MEASURE_POINTS,
+    CONF_SCAN_INTERVAL,
+)
 from custom_components.sungrow.coordinator import SungrowPlantCoordinator, is_auth_error
 
 from .conftest import MOCK_REALTIME_DATA
@@ -163,3 +168,84 @@ async def test_extra_measure_points_empty_passes_none(hass: HomeAssistant):
     await coordinator._async_update_data()
 
     plants.async_get_realtime_data.assert_awaited_once_with(["12345"], extra_measure_points=None)
+
+
+# ---------------------------------------------------------------------------
+# Per-device realtime (issue #74)
+# ---------------------------------------------------------------------------
+
+
+async def test_device_data_fetched_when_enabled(hass: HomeAssistant):
+    """With the option on, per-device realtime is fetched and stored on the coordinator."""
+    plants = MagicMock()
+    plants.async_get_realtime_data = AsyncMock(return_value=MOCK_REALTIME_DATA)
+    plants.async_get_device_realtime = AsyncMock(
+        return_value={"chg-1": {"ev_charger_power": {"code": "ev_charger_power", "value": "7.2"}}}
+    )
+    devices = [{"uuid": "chg-1", "device_type": 999}]  # unknown type left as raw int
+    coordinator = SungrowPlantCoordinator(
+        hass, _make_entry({CONF_ENABLE_DEVICE_SENSORS: True}), plants, "12345", "Test Plant", devices
+    )
+
+    await coordinator._async_update_data()
+
+    assert coordinator.device_data["chg-1"]["ev_charger_power"]["value"] == "7.2"
+    plants.async_get_device_realtime.assert_awaited_once()
+
+
+async def test_device_data_not_fetched_when_disabled(hass: HomeAssistant):
+    """With the option off, per-device realtime is never requested."""
+    plants = MagicMock()
+    plants.async_get_realtime_data = AsyncMock(return_value=MOCK_REALTIME_DATA)
+    plants.async_get_device_realtime = AsyncMock(return_value={})
+    devices = [{"uuid": "chg-1", "device_type": 999}]
+    coordinator = SungrowPlantCoordinator(hass, _make_entry(), plants, "12345", "Test Plant", devices)
+
+    await coordinator._async_update_data()
+
+    assert coordinator.device_data == {}
+    plants.async_get_device_realtime.assert_not_awaited()
+
+
+async def test_device_data_best_effort_on_error(hass: HomeAssistant):
+    """A failing device type is skipped without failing the whole update."""
+    plants = MagicMock()
+    plants.async_get_realtime_data = AsyncMock(return_value=MOCK_REALTIME_DATA)
+
+    async def _realtime(plant_id, device_type, **kwargs):
+        if getattr(device_type, "value", device_type) == 999:
+            raise RuntimeError("charger endpoint down")
+        return {"inv-1": {"foo": {"code": "foo", "value": "1"}}}
+
+    plants.async_get_device_realtime = AsyncMock(side_effect=_realtime)
+    devices = [
+        {"uuid": "inv-1", "device_type": DeviceType.INVERTER},
+        {"uuid": "chg-1", "device_type": 999},
+    ]
+    coordinator = SungrowPlantCoordinator(
+        hass, _make_entry({CONF_ENABLE_DEVICE_SENSORS: True}), plants, "12345", "Test Plant", devices
+    )
+
+    # Must not raise even though one device type errors.
+    await coordinator._async_update_data()
+
+    assert "inv-1" in coordinator.device_data
+    assert "chg-1" not in coordinator.device_data
+
+
+async def test_device_data_dedupes_device_types(hass: HomeAssistant):
+    """Two devices of the same type trigger a single per-type fetch."""
+    plants = MagicMock()
+    plants.async_get_realtime_data = AsyncMock(return_value=MOCK_REALTIME_DATA)
+    plants.async_get_device_realtime = AsyncMock(return_value={})
+    devices = [
+        {"uuid": "inv-1", "device_type": DeviceType.INVERTER},
+        {"uuid": "inv-2", "device_type": DeviceType.INVERTER},
+    ]
+    coordinator = SungrowPlantCoordinator(
+        hass, _make_entry({CONF_ENABLE_DEVICE_SENSORS: True}), plants, "12345", "Test Plant", devices
+    )
+
+    await coordinator._async_update_data()
+
+    plants.async_get_device_realtime.assert_awaited_once()

--- a/tests/test_dispatch.py
+++ b/tests/test_dispatch.py
@@ -308,3 +308,15 @@ async def test_entity_removal_stops_heartbeat(hass: HomeAssistant):
         await number.async_will_remove_from_hass()
 
     mock_stop.assert_awaited_once_with(hass, number.coordinator.config_entry, "12345")
+
+
+def test_select_dispatch_device_ignores_non_dispatch_devices():
+    """Meters / EV chargers are never chosen for dispatch (only inverter/ESS)."""
+    # A non-dispatch device alone -> nothing dispatch-capable.
+    assert select_dispatch_device([{"uuid": "meter", "device_type": DeviceType.METER}]) is None
+    # Meter listed first, inverter second -> the inverter wins (not devices[0]).
+    devices = [
+        {"uuid": "meter", "device_type": DeviceType.METER},
+        {"uuid": "inv", "device_type": DeviceType.INVERTER},
+    ]
+    assert select_dispatch_device(devices)["uuid"] == "inv"

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -10,6 +10,7 @@ from pytest_homeassistant_custom_component.common import MockConfigEntry
 from custom_components.sungrow import SungrowData
 from custom_components.sungrow.const import DOMAIN
 from custom_components.sungrow.sensor import (
+    SungrowDeviceSensor,
     SungrowSensor,
     async_setup_entry,
     infer_device_class,
@@ -275,3 +276,65 @@ async def test_sensor_setup_skips_plant_with_no_data(hass: HomeAssistant):
     await async_setup_entry(hass, entry, lambda entities: added.extend(entities))
 
     assert added == []
+
+
+# ---------------------------------------------------------------------------
+# Per-device sensors (issue #74)
+# ---------------------------------------------------------------------------
+
+
+async def test_device_sensors_created_when_enabled(hass: HomeAssistant):
+    """Device points not already at plant level become sensors under their device."""
+    entry = MockConfigEntry(domain=DOMAIN, data=MOCK_CONFIG_DATA.copy())
+    entry.add_to_hass(hass)
+
+    coordinator = _coordinator_with("12345", "Plant A", {"total_active_power": {"value": "5.0", "unit": "kW"}})
+    coordinator.enable_device_sensors = True
+    coordinator.device_data = {
+        "chg-1": {
+            "ev_charger_power": {"code": "ev_charger_power", "value": "7.2", "unit": "kW"},
+            # Duplicate of a plant-level point -> should be skipped.
+            "total_active_power": {"code": "total_active_power", "value": "5.0", "unit": "kW"},
+        }
+    }
+    entry.runtime_data = SungrowData(
+        coordinators=[coordinator],
+        control=MagicMock(),
+        devices={"12345": [{"uuid": "chg-1", "device_name": "AC011E", "device_type": 999}]},
+    )
+
+    added = []
+    await async_setup_entry(hass, entry, lambda entities: added.extend(entities))
+
+    device_sensors = [e for e in added if isinstance(e, SungrowDeviceSensor)]
+    assert len(device_sensors) == 1  # the plant-duplicate point was skipped
+    sensor = device_sensors[0]
+    assert sensor.point_code == "ev_charger_power"
+    assert sensor.device_uuid == "chg-1"
+    assert sensor._attr_unique_id == "12345_chg-1_ev_charger_power"
+    assert (DOMAIN, "chg-1") in sensor._attr_device_info["identifiers"]
+    assert sensor._attr_device_info["via_device"] == (DOMAIN, "12345")
+    # Reads its value from the coordinator's per-device data.
+    assert sensor.native_value == 7.2
+
+
+async def test_device_sensors_not_created_when_disabled(hass: HomeAssistant):
+    """No device sensors are created when the option is off, even with device data present."""
+    entry = MockConfigEntry(domain=DOMAIN, data=MOCK_CONFIG_DATA.copy())
+    entry.add_to_hass(hass)
+
+    coordinator = _coordinator_with("12345", "Plant A", {"total_active_power": {"value": "5.0", "unit": "kW"}})
+    coordinator.enable_device_sensors = False
+    coordinator.device_data = {"chg-1": {"ev_charger_power": {"value": "7.2"}}}
+    entry.runtime_data = SungrowData(
+        coordinators=[coordinator],
+        control=MagicMock(),
+        devices={"12345": [{"uuid": "chg-1", "device_name": "AC011E"}]},
+    )
+
+    added = []
+    await async_setup_entry(hass, entry, lambda entities: added.extend(entities))
+
+    assert not any(isinstance(e, SungrowDeviceSensor) for e in added)
+    # Plant sensors are still created.
+    assert any(isinstance(e, SungrowSensor) for e in added)


### PR DESCRIPTION
Closes #74. Builds on the #67 diagnostics probe to actually surface per-device data as sensors.

## Problem
The coordinator only polls **plant-level** realtime, so devices whose data isn't aggregated at the plant level — EV chargers, meters, secondary batteries — never become sensors even though they show in the iSolarCloud app and diagnostics.

## What this adds
- **New option "Create per-device sensors"** (off by default — avoids extra API calls / entity clutter). Configure → toggle on.
- **Discover all devices**: `__init__` now fetches the full device list (not just inverter/ESS) and passes it to the coordinator. `select_dispatch_device` is tightened to only pick an **inverter/ESS** so the broader discovery can't accidentally attach dispatch controls to a meter or charger.
- **Coordinator per-device polling**: when enabled, best-effort `async_get_device_realtime` per distinct device type (forwarding your **extra measure points**) into `coordinator.device_data`. A device type whose endpoint errors is skipped without failing the update.
- **`SungrowDeviceSensor`**: reads per-device data and is grouped under its own device card, linked to the plant via `via_device`. `SungrowSensor` was refactored so both share point naming/classification.
- **Dedup**: device points already present at the plant level are skipped, so enabling the option doesn't just duplicate every plant sensor under the inverter — you get the genuinely device-specific points (charger/meter).

## Using it for an EV charger (the #18 case)
1. Get the charger's point IDs from a diagnostics dump (`all_devices` / `device_realtime`).
2. Add them under **Extra measure points** (`<id>=ev_charger_power`).
3. Enable **Create per-device sensors** → the charger appears as its own device with sensors.

## Tests
Coordinator fetch (enabled/disabled/best-effort/dedupe), device-sensor creation + plant-duplicate skip + `via_device` grouping + value read-through, and `select_dispatch_device` ignoring non-dispatch devices. Suite green (**138**), `sensor.py` at **100%**, docs updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)