### PR TITLE
fix: complete the flow from a late OAuth callback (#75)

### DIFF
--- a/custom_components/sungrow/config_flow.py
+++ b/custom_components/sungrow/config_flow.py
@@ -38,6 +38,12 @@ except ImportError:
 
 _LOGGER = logging.getLogger(__name__)
 
+# How long to wait for the OAuth redirect before offering (or, on the manual step,
+# giving up on) automatic completion. Generous, since iSolarCloud's approval page
+# can be slow — a redirect that lands within this window completes the flow
+# automatically even if the user has already reached the manual-entry form.
+CALLBACK_WAIT_TIMEOUT = 300
+
 
 class SungrowConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     """Handle a config flow for Sungrow iSolarCloud."""
@@ -204,44 +210,69 @@ class SungrowConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             return self.async_show_progress_done(next_step_id="auth_manual")
         if user_input is not None and user_input.get("code"):
             self.context["code"] = user_input["code"]
+            self._drop_callback_future()
             return self.async_show_progress_done(next_step_id="finish")
 
-        # Register this flow so the callback view can resume it.
-        flows = self.hass.data.setdefault(DOMAIN, {}).setdefault("flows", {})
-        future: asyncio.Future[str] = asyncio.Future()
-        flows[self.flow_id] = future
-
         auth_url = self._auth_url()
-
-        async def _wait_for_callback() -> None:
-            """Resume the flow once the OAuth callback delivers a code."""
-            try:
-                code = await asyncio.wait_for(future, timeout=120)
-            except TimeoutError:
-                _LOGGER.warning("OAuth callback not received within timeout for flow %s", self.flow_id)
-                self.context["callback_timeout"] = True
-                try:
-                    await self.hass.config_entries.flow.async_configure(flow_id=self.flow_id, user_input={})
-                except Exception:  # pylint: disable=broad-except
-                    _LOGGER.exception("Failed to resume config flow after callback timeout")
-                return
-            except asyncio.CancelledError:
-                return
-            finally:
-                flows.pop(self.flow_id, None)
-            try:
-                await self.hass.config_entries.flow.async_configure(flow_id=self.flow_id, user_input={"code": code})
-            except Exception:  # pylint: disable=broad-except
-                _LOGGER.exception("Failed to resume config flow from OAuth callback")
-
-        task = self.hass.async_create_background_task(_wait_for_callback(), name="sungrow-oauth-callback")
-
+        # Fall back to the manual form if the redirect doesn't arrive in time.
+        task = self._arm_callback_wait(fall_back_to_manual=True)
         return self.async_show_progress(
             step_id="auth_callback",
             progress_action="wait_for_callback",
             progress_task=task,
             description_placeholders={"auth_url": auth_url},
         )
+
+    def _arm_callback_wait(self, *, fall_back_to_manual: bool) -> asyncio.Task:
+        """Register a callback future and spawn a task that resumes the flow.
+
+        Used by both the automatic progress step and the manual-entry form, so a
+        redirect that arrives late (after the auto-wait timed out and the user
+        reached the manual form) still completes the flow automatically. Reuses the
+        registered future when one is still pending so the callback view always has
+        a live target.
+        """
+        flows = self.hass.data.setdefault(DOMAIN, {}).setdefault("flows", {})
+        future = flows.get(self.flow_id)
+        if not isinstance(future, asyncio.Future) or future.done():
+            future = asyncio.Future()
+            flows[self.flow_id] = future
+
+        async def _wait_for_callback() -> None:
+            try:
+                code = await asyncio.wait_for(future, timeout=CALLBACK_WAIT_TIMEOUT)
+            except TimeoutError:
+                if fall_back_to_manual:
+                    _LOGGER.warning("OAuth callback not received within timeout for flow %s", self.flow_id)
+                    self.context["callback_timeout"] = True
+                    await self._resume_flow(user_input={})
+                return
+            except asyncio.CancelledError:
+                return
+            else:
+                await self._resume_flow(user_input={"code": code})
+            finally:
+                # Drop the future once it has been consumed / expired so a stale one
+                # isn't reused; leave a newer future (e.g. re-armed for manual) alone.
+                if flows.get(self.flow_id) is future:
+                    flows.pop(self.flow_id, None)
+
+        return self.hass.async_create_background_task(_wait_for_callback(), name="sungrow-oauth-callback")
+
+    async def _resume_flow(self, *, user_input: dict[str, Any]) -> None:
+        """Re-enter the config flow from the OAuth callback background task."""
+        try:
+            await self.hass.config_entries.flow.async_configure(flow_id=self.flow_id, user_input=user_input)
+        except Exception:  # pylint: disable=broad-except
+            # The flow may already have progressed (e.g. the user finished manually);
+            # a late resume is harmless.
+            _LOGGER.debug("Could not resume config flow %s from OAuth callback", self.flow_id)
+
+    def _drop_callback_future(self) -> None:
+        """Remove this flow's pending callback future (it has been consumed)."""
+        flows = self.hass.data.get(DOMAIN, {}).get("flows", {})
+        if isinstance(flows, dict):
+            flows.pop(self.flow_id, None)
 
     async def async_step_auth_manual(self, user_input: dict[str, Any] | None = None):
         """Handle manual entry of the authorization code or full redirect URL.
@@ -272,11 +303,20 @@ class SungrowConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                     code = code_input
 
                 self.context["code"] = code
+                self._drop_callback_future()
                 return self.async_show_progress_done(next_step_id="finish")
 
             except Exception as e:  # pylint: disable=broad-except
                 _LOGGER.exception("Unexpected exception in async_step_auth_manual: %s", e)
                 errors["base"] = "unknown"
+
+        # Keep a callback waiter armed while the manual form is shown, so a redirect
+        # that lands late (after the auto-wait timed out) still completes the flow
+        # automatically instead of stranding a "successful" callback with no effect.
+        # A context flag arms it exactly once (not on every form re-render).
+        if not self.context.get("manual_waiter_armed"):
+            self.context["manual_waiter_armed"] = True
+            self._arm_callback_wait(fall_back_to_manual=False)
 
         auth_url = self._auth_url()
         return self.async_show_form(

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -51,7 +51,9 @@ by the integration itself.
    Authorization Code* form after a short wait. Paste the `code` value from the
    URL bar there — or paste the whole redirect URL and the integration extracts
    the code for you. Make sure the base redirect URI still matches the developer
-   portal exactly.
+   portal exactly. Even once you're on this form, **finishing the login in your
+   browser still completes setup automatically** — a redirect that lands late is
+   no longer lost.
 
 ---
 

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -325,6 +325,51 @@ async def test_reauth_timeout_falls_back_to_manual(hass: HomeAssistant, mock_aut
     await _reauth_to_manual(hass, entry)
 
 
+async def test_late_callback_completes_from_manual_step(hass: HomeAssistant, mock_auth):
+    """A redirect that lands while the user is on the manual form still completes the flow (#75)."""
+    from custom_components.sungrow import SungrowAuthCallbackView
+
+    entry = _hub_entry(hass)
+
+    # Time out only the FIRST wait (the automatic one) so the flow reaches the manual
+    # form; the manual re-armed waiter then waits normally for the late callback.
+    real_wait_for = asyncio.wait_for
+    calls = {"n": 0}
+
+    async def _wait_for(aw, timeout):
+        calls["n"] += 1
+        if calls["n"] == 1:
+            await asyncio.sleep(0)
+            aw.cancel()  # real asyncio.wait_for cancels the awaited future on timeout
+            raise TimeoutError
+        return await real_wait_for(aw, timeout=None)
+
+    with patch("custom_components.sungrow.config_flow.asyncio.wait_for", side_effect=_wait_for):
+        result = await entry.start_reauth_flow(hass)
+        assert result["type"] == data_entry_flow.FlowResultType.SHOW_PROGRESS
+        await hass.async_block_till_done()
+        await hass.async_block_till_done()
+
+        flow = hass.config_entries.flow.async_get(result["flow_id"])
+        assert flow["step_id"] == "auth_manual"
+
+        # The OAuth redirect finally lands (flow_id stripped -> single-flow fallback).
+        request = MagicMock()
+        request.app = {"hass": hass}
+        request.query = {"code": "late_code"}
+        view = SungrowAuthCallbackView()
+
+        with patch("custom_components.sungrow.async_setup_entry", return_value=True):
+            response = await view.get(request)
+            await hass.async_block_till_done()
+            await hass.async_block_till_done()
+
+    assert response.status == 200
+    # The flow completed automatically without the user pasting anything.
+    assert mock_auth.async_authorize.call_args[0][0] == "late_code"
+    assert entry.data["tokens"]["access_token"] == "test_access_token"
+
+
 async def test_callback_view_resumes_reauth(hass: HomeAssistant, mock_auth):
     """The HTTP callback view delivers the code and completes the reauth flow."""
     from custom_components.sungrow import SungrowAuthCallbackView


### PR DESCRIPTION
Closes #75. Fixes the confusing race you hit during v2.0.0 testing.

## Problem
If the OAuth redirect arrived **after** the 120s auto-wait timed out, the flow had already dropped to the manual *Enter Authorization Code* form. The callback view still resolved the orphaned future and showed *"Authorization successful"* — but the flow never advanced, so the code was effectively lost and you had to paste it manually.

## Fix
- **Keep a callback waiter armed while the manual form is shown** (armed once via a context flag). A redirect that lands late now completes the flow automatically, and the *"Authorization successful"* page is accurate because the flow actually finishes.
- Extracted the register-future + resume-flow logic into a shared `_arm_callback_wait` used by both the progress step and the manual form. Consumed futures are dropped; late resumes (after the user finished manually) fail gracefully.
- Raised the wait timeout **120s → 300s** (`CALLBACK_WAIT_TIMEOUT`) since iSolarCloud's approval page can be slow, reducing how often the manual fallback is hit at all.

## Test
New regression test drives the flow to the manual form (one-shot auto-timeout) and then fires the callback view — the flow completes with **no manual paste**. Suite green (**139**), ~96% coverage. TROUBLESHOOTING updated.

*Not auto-merged — yours to review.*

🤖 Generated with [Claude Code](https://claude.com/claude-code)