### PR TITLE
ci: re-enable mypy with proper type annotations (#76)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,6 +54,9 @@ jobs:
       - name: Install dependencies
         run: pip install -r requirements_test.txt
 
+      - name: Type check with mypy
+        run: mypy
+
       - name: Run tests with coverage
         run: >-
           pytest tests/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -38,9 +38,10 @@ this working — **do not remove it**, and keep `pysolarcloud` pinned in
 uv venv --python 3.13 .venv
 uv pip install --python .venv -r requirements_test.txt
 
-# Lint, format, test (mirror CI)
+# Lint, type-check, format, test (mirror CI)
 .venv/bin/ruff check custom_components/ tests/
 .venv/bin/ruff format --check custom_components/ tests/
+.venv/bin/mypy
 .venv/bin/python -m pytest tests/
 
 # Live tests (need real creds in .env; skipped otherwise)

--- a/custom_components/sungrow/config_flow.py
+++ b/custom_components/sungrow/config_flow.py
@@ -52,10 +52,15 @@ class SungrowConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
     def __init__(self):
         """Initialize the config flow."""
-        self.init_info = {}
-        self.auth_client = None
+        self.init_info: dict[str, Any] = {}
+        self.auth_client: Any = None
         self._reauth_entry: ConfigEntry | None = None
         self._is_reconfigure = False
+        # OAuth flow state (kept on the instance, which persists across steps and the
+        # callback background task, rather than in the typed ConfigFlowContext).
+        self._code: str | None = None
+        self._callback_timeout = False
+        self._manual_waiter_armed = False
 
     @staticmethod
     @callback
@@ -82,7 +87,7 @@ class SungrowConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         new region invalidate the stored tokens, submitting always re-runs the OAuth
         authorization and updates the entry in place (no delete & re-add).
         """
-        entry = self.hass.config_entries.async_get_entry(self.context["entry_id"])
+        entry = self._get_reconfigure_entry()
         self._reauth_entry = entry
         self._is_reconfigure = True
 
@@ -113,7 +118,7 @@ class SungrowConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         """Handle the initial step."""
         # Do not log user_input — it contains the app secret.
         _LOGGER.debug("async_step_user called (user_input provided: %s)", user_input is not None)
-        errors = {}
+        errors: dict[str, str] = {}
 
         if user_input is not None:
             self.init_info = user_input
@@ -240,12 +245,12 @@ class SungrowConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         If the callback does not arrive within the timeout, the flow falls back
         to the manual code-entry form instead of aborting.
         """
-        if self.context.get("callback_timeout"):
+        if self._callback_timeout:
             # The redirect never arrived — hand off to manual code entry so the
             # user can paste the authorization code or full redirect URL.
             return self.async_show_progress_done(next_step_id="auth_manual")
         if user_input is not None and user_input.get("code"):
-            self.context["code"] = user_input["code"]
+            self._code = user_input["code"]
             self._drop_callback_future()
             return self.async_show_progress_done(next_step_id="finish")
 
@@ -280,7 +285,7 @@ class SungrowConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             except TimeoutError:
                 if fall_back_to_manual:
                     _LOGGER.warning("OAuth callback not received within timeout for flow %s", self.flow_id)
-                    self.context["callback_timeout"] = True
+                    self._callback_timeout = True
                     await self._resume_flow(user_input={})
                 return
             except asyncio.CancelledError:
@@ -338,7 +343,7 @@ class SungrowConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 else:
                     code = code_input
 
-                self.context["code"] = code
+                self._code = code
                 self._drop_callback_future()
                 return self.async_show_progress_done(next_step_id="finish")
 
@@ -350,8 +355,8 @@ class SungrowConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         # that lands late (after the auto-wait timed out) still completes the flow
         # automatically instead of stranding a "successful" callback with no effect.
         # A context flag arms it exactly once (not on every form re-render).
-        if not self.context.get("manual_waiter_armed"):
-            self.context["manual_waiter_armed"] = True
+        if not self._manual_waiter_armed:
+            self._manual_waiter_armed = True
             self._arm_callback_wait(fall_back_to_manual=False)
 
         auth_url = self._auth_url()
@@ -382,7 +387,7 @@ class SungrowConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         if not self._ensure_auth_client():
             return self.async_abort(reason="library_missing")
 
-        code = self.context.get("code")
+        code = self._code
         if not code:
             _LOGGER.error("Finish step reached without an authorization code")
             return self.async_abort(reason="missing_code")

--- a/custom_components/sungrow/number.py
+++ b/custom_components/sungrow/number.py
@@ -101,7 +101,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry, async_add_e
     async_add_entities(entities)
 
 
-class SungrowDispatchNumber(CoordinatorEntity, NumberEntity):
+class SungrowDispatchNumber(CoordinatorEntity[SungrowPlantCoordinator], NumberEntity):
     """Number entity for a Sungrow dispatch parameter."""
 
     _attr_has_entity_name = True
@@ -154,9 +154,11 @@ class SungrowDispatchNumber(CoordinatorEntity, NumberEntity):
         # If the user is actively dispatching, ensure a heartbeat is running so the
         # inverter stays in External EMS mode.
         if self.param == "charge_discharge_power":
+            entry = self.coordinator.config_entry
+            assert entry is not None
             await async_start_heartbeat(
                 self.hass,
-                self.coordinator.config_entry,
+                entry,
                 self.coordinator.plant_id,
                 self.device_uuid,
                 interval=60,
@@ -164,5 +166,7 @@ class SungrowDispatchNumber(CoordinatorEntity, NumberEntity):
 
     async def async_will_remove_from_hass(self) -> None:
         """Stop the heartbeat when the entity is removed."""
-        await async_stop_heartbeat(self.hass, self.coordinator.config_entry, self.coordinator.plant_id)
+        entry = self.coordinator.config_entry
+        assert entry is not None
+        await async_stop_heartbeat(self.hass, entry, self.coordinator.plant_id)
         await super().async_will_remove_from_hass()

--- a/custom_components/sungrow/select.py
+++ b/custom_components/sungrow/select.py
@@ -73,7 +73,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry, async_add_e
     async_add_entities(entities)
 
 
-class SungrowDispatchSelect(CoordinatorEntity, SelectEntity):
+class SungrowDispatchSelect(CoordinatorEntity[SungrowPlantCoordinator], SelectEntity):
     """Select entity for a Sungrow dispatch parameter."""
 
     _attr_has_entity_name = True
@@ -124,18 +124,22 @@ class SungrowDispatchSelect(CoordinatorEntity, SelectEntity):
         await self.control.async_update_parameters(self.device_uuid, {self.param: value})
 
         # Keep the inverter in dispatch mode while actively charging/discharging.
+        entry = self.coordinator.config_entry
+        assert entry is not None
         if self.param == "charge_discharge_command" and option in {"Charge", "Discharge"}:
             await async_start_heartbeat(
                 self.hass,
-                self.coordinator.config_entry,
+                entry,
                 self.coordinator.plant_id,
                 self.device_uuid,
                 interval=60,
             )
         elif self.param == "charge_discharge_command" and option == "Stop":
-            await async_stop_heartbeat(self.hass, self.coordinator.config_entry, self.coordinator.plant_id)
+            await async_stop_heartbeat(self.hass, entry, self.coordinator.plant_id)
 
     async def async_will_remove_from_hass(self) -> None:
         """Stop the heartbeat when the entity is removed."""
-        await async_stop_heartbeat(self.hass, self.coordinator.config_entry, self.coordinator.plant_id)
+        entry = self.coordinator.config_entry
+        assert entry is not None
+        await async_stop_heartbeat(self.hass, entry, self.coordinator.plant_id)
         await super().async_will_remove_from_hass()

--- a/custom_components/sungrow/sensor.py
+++ b/custom_components/sungrow/sensor.py
@@ -116,7 +116,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry, async_add_e
     coordinators = entry.runtime_data.coordinators
     devices_by_plant = entry.runtime_data.devices
     # Point the device "Visit" link at the region's iSolarCloud web console.
-    console_url = GATEWAY_CONSOLE_URLS.get(entry.data.get(CONF_GATEWAY), DEFAULT_CONSOLE_URL)
+    console_url = GATEWAY_CONSOLE_URLS.get(entry.data.get(CONF_GATEWAY, ""), DEFAULT_CONSOLE_URL)
 
     entities: list[SungrowSensor] = []
     for coordinator in coordinators:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,3 +42,10 @@ select = [
     "SIM", # flake8-simplify
 ]
 ignore = ["E501"]
+
+[tool.mypy]
+python_version = "3.13"
+ignore_missing_imports = true
+check_untyped_defs = true
+# Scope to our own package; Home Assistant is imported for types only.
+files = ["custom_components/sungrow"]

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -7,6 +7,7 @@ python-dotenv
 
 # Linting & formatting (keep in sync with ci.yml and .pre-commit-config.yaml)
 ruff==0.15.16
+mypy==2.1.0
 
 # Component dependencies
 sungrow-isolarcloud==0.5.0


### PR DESCRIPTION
Closes #76.

The `[tool.mypy]` config was removed in #64 because enforcing it surfaced ~21 real type errors. This fixes all of them and re-adds **mypy as an enforced CI step** (runs in the `test` job, so it gates merges).

## Fixes
- **config_flow**: annotate `init_info` / `auth_client` / `errors`; move OAuth flow state (`code`, `callback_timeout`, `manual_waiter_armed`) off the typed `ConfigFlowContext` onto instance attrs (they persist across steps + the callback task just the same); use `_get_reconfigure_entry()` for a non-optional entry.
- **number / select**: parametrise the entity base as `CoordinatorEntity[SungrowPlantCoordinator]` so `.plant_id` is typed, and narrow the coordinator's `config_entry` (Optional) before passing it to the heartbeat helpers.
- **sensor**: default the gateway lookup so the console-URL key is never `None`.

## Wiring
- `pyproject.toml`: restore `[tool.mypy]` (python 3.13, `check_untyped_defs`, scoped to `custom_components/sungrow`).
- `requirements_test.txt`: `mypy==2.1.0` (pinned).
- `ci.yml`: `mypy` step in the `test` job. `CLAUDE.md` commands mirror it.

`mypy` passes clean across all 9 source files; suite green (**141**). No behaviour change — annotations + narrowing only.

*Not auto-merged — yours to review.*

🤖 Generated with [Claude Code](https://claude.com/claude-code)