### PR TITLE
docs: add quality_scale.yaml (Silver) and removal instructions (#77)

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,13 @@ App Secret, or redirect URI without deleting and re-adding the integration (your
 entity history is kept). You'll be asked to authorize again in the browser, since
 new credentials or a new region need fresh tokens. The App ID stays fixed.
 
+### Removing the integration
+
+Go to **Settings → Devices & Services → Sungrow iSolarCloud → ⋮ → Delete**. This
+removes the config entry and all of its entities and devices; no files are left
+behind (uninstall the repository from HACS separately if you also want to remove
+the code). Your iSolarCloud account and developer application are unaffected.
+
 ### Sensor mapping
 
 Not sure which sensor corresponds to which value in the iSolarCloud app? See [docs/SENSORS.md](docs/SENSORS.md).

--- a/custom_components/sungrow/manifest.json
+++ b/custom_components/sungrow/manifest.json
@@ -15,6 +15,7 @@
   "loggers": [
     "pysolarcloud"
   ],
+  "quality_scale": "silver",
   "requirements": [
     "sungrow-isolarcloud==0.5.0"
   ],

--- a/custom_components/sungrow/quality_scale.yaml
+++ b/custom_components/sungrow/quality_scale.yaml
@@ -1,0 +1,143 @@
+# Home Assistant Integration Quality Scale — self-assessment.
+#
+# Note: hassfest only *validates* this file for core integrations; for a custom
+# (HACS) integration it is an honest status record and roadmap. The integration
+# currently meets the Bronze and Silver tiers (and already satisfies several Gold
+# and Platinum rules).
+rules:
+  # --- Bronze ---
+  action-setup:
+    status: exempt
+    comment: The integration registers no actions/services.
+  appropriate-polling:
+    status: done
+  brands:
+    status: exempt
+    comment: >-
+      Custom/HACS integration. Brand images are shipped in the repository; the
+      home-assistant/brands repository applies to core integrations only.
+  common-modules:
+    status: done
+  config-flow:
+    status: done
+  config-flow-test-coverage:
+    status: done
+  dependency-transparency:
+    status: done
+  docs-actions:
+    status: exempt
+    comment: No actions/services are registered.
+  docs-conditions:
+    status: exempt
+    comment: The integration provides no conditions.
+  docs-high-level-description:
+    status: done
+  docs-installation-instructions:
+    status: done
+  docs-removal-instructions:
+    status: done
+  docs-triggers:
+    status: exempt
+    comment: The integration provides no triggers.
+  entity-event-setup:
+    status: done
+  entity-unique-id:
+    status: done
+  has-entity-name:
+    status: done
+  runtime-data:
+    status: done
+  test-before-configure:
+    status: exempt
+    comment: >-
+      Two-phase OAuth setup: the hub entry is created first so the callback
+      endpoint exists for the redirect, then credentials are validated during
+      authorization (reauth). Validating before entry creation isn't possible
+      with this flow.
+  test-before-setup:
+    status: done
+  unique-config-entry:
+    status: done
+
+  # --- Silver ---
+  action-exceptions:
+    status: exempt
+    comment: No actions/services are registered.
+  config-entry-unloading:
+    status: done
+  docs-configuration-parameters:
+    status: done
+  docs-installation-parameters:
+    status: done
+  entity-unavailable:
+    status: done
+  integration-owner:
+    status: done
+  log-when-unavailable:
+    status: done
+  parallel-updates:
+    status: done
+  reauthentication-flow:
+    status: done
+  test-coverage:
+    status: done
+
+  # --- Gold ---
+  devices:
+    status: done
+    comment: Sensors group under a plant device; dispatch controls under their own device.
+  diagnostics:
+    status: done
+  discovery:
+    status: exempt
+    comment: Cloud-polling integration; devices are enumerated via the API, not discovered on the network.
+  discovery-update-info:
+    status: exempt
+    comment: No network discovery.
+  docs-data-update:
+    status: todo
+  docs-examples:
+    status: todo
+  docs-known-limitations:
+    status: done
+  docs-supported-devices:
+    status: done
+  docs-supported-functions:
+    status: done
+  docs-troubleshooting:
+    status: done
+  docs-use-cases:
+    status: todo
+  dynamic-devices:
+    status: todo
+  entity-category:
+    status: todo
+  entity-device-class:
+    status: done
+  entity-disabled-by-default:
+    status: done
+    comment: Sensors with an unknown/empty initial value are disabled by default.
+  entity-translations:
+    status: todo
+    comment: Dispatch number/select entities are translated; sensors use API/code-derived names.
+  exception-translations:
+    status: todo
+  icon-translations:
+    status: todo
+  reconfiguration-flow:
+    status: done
+  repair-issues:
+    status: todo
+  stale-devices:
+    status: todo
+
+  # --- Platinum ---
+  async-dependency:
+    status: done
+    comment: The sungrow-isolarcloud client is fully async.
+  inject-websession:
+    status: done
+    comment: The Home Assistant aiohttp client session is injected into the API client.
+  strict-typing:
+    status: todo
+    comment: mypy runs in CI (check_untyped_defs) but not yet in strict mode.


### PR DESCRIPTION
Closes #77.

Adds a Home Assistant **Integration Quality Scale** self-assessment and declares `quality_scale: silver` in the manifest.

## What's here
- **`quality_scale.yaml`** — all 54 canonical rules (validated against `home-assistant/core`'s `ALL_RULES`) with an honest status. Every **Bronze** and **Silver** rule is `done` or `exempt` (with a documented reason), so the Silver claim is accurate. It already satisfies several **Gold** rules (devices, diagnostics, reconfiguration-flow, docs-supported-devices/known-limitations/troubleshooting, entity-device-class, entity-disabled-by-default) and **2 of 3 Platinum** (async-dependency, inject-websession). Remaining Gold/Platinum gaps are left as `todo` as a roadmap.
- **`manifest.json`** — `quality_scale: silver`.
- **README** — a "Removing the integration" section (satisfies the Bronze `docs-removal-instructions` rule).

## Honest caveat
hassfest's quality-scale validator starts with `if not integration.core: return` — so for a **custom / HACS** integration this file is **not enforced or surfaced as a badge**. It's an accurate status record and roadmap (and would be ready if the integration is ever proposed for core). No functional change, hence `docs:`.

Suite green; manifest key order stable under `sort_manifest.py`.

*Not auto-merged — yours to review.*

🤖 Generated with [Claude Code](https://claude.com/claude-code)