### PR TITLE
feat: derive dispatch power max from the device model code (#81)

### DIFF
--- a/custom_components/sungrow/number.py
+++ b/custom_components/sungrow/number.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import logging
+import re
 
 from homeassistant.components.number import NumberDeviceClass, NumberEntity, NumberMode
 from homeassistant.config_entries import ConfigEntry
@@ -22,12 +23,34 @@ _LOGGER = logging.getLogger(__name__)
 # rapid slider changes don't race on the API.
 PARALLEL_UPDATES = 1
 
-# Conservative default upper bound (watts) for charge/discharge power. iSolarCloud
-# does not expose the per-device inverter rating through the realtime API, so this
-# is a fixed clamp rather than a derived limit. Users with larger inverters can
-# still command higher power via the underlying API; adjust here if a rating source
-# becomes available.
+# Fallback upper bound (watts) for charge/discharge power, used when the device's
+# rated power can't be derived from its model code.
 DEFAULT_MAX_DISPATCH_POWER = 5000
+
+# Sungrow residential inverters encode their kW rating in the model code, e.g.
+# SG3.6RS -> 3.6 kW, SH10RT-V112 -> 10 kW, SG110CX -> 110 kW. Batteries, meters and
+# comms modules (SBR256, SGSmartMeter, WiNet-S) don't match and fall back to the
+# default. This is the only rating signal iSolarCloud exposes via getDeviceListByPsId.
+_MODEL_POWER_RE = re.compile(r"S[GH](\d+(?:\.\d+)?)", re.IGNORECASE)
+
+
+def rated_power_w(device: dict) -> int | None:
+    """Best-effort rated power in watts parsed from a device's model code.
+
+    Returns ``None`` when no rating can be parsed, so callers fall back to the
+    default clamp.
+    """
+    match = _MODEL_POWER_RE.match(str(device.get("device_model_code") or ""))
+    if not match:
+        return None
+    try:
+        kw = float(match.group(1))
+    except ValueError:
+        return None
+    if kw <= 0 or kw > 1000:  # guard against nonsense parses
+        return None
+    return int(round(kw * 1000))
+
 
 # Number parameters exposed as HA Number entities.
 # Keys are canonical Control parameter names; values describe the HA entity.
@@ -86,7 +109,12 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry, async_add_e
         if not device_uuid:
             continue
         device_name = target.get("device_name") or coordinator.plant_name
+        # Size the charge/discharge power slider to the device's rated power when it
+        # can be derived from the model code; otherwise use the conservative default.
+        max_power = rated_power_w(target) or DEFAULT_MAX_DISPATCH_POWER
         for param, meta in DISPATCH_NUMBERS.items():
+            if param == "charge_discharge_power" and max_power != meta["native_max_value"]:
+                meta = {**meta, "native_max_value": max_power}
             entities.append(
                 SungrowDispatchNumber(
                     coordinator,

--- a/tests/test_dispatch.py
+++ b/tests/test_dispatch.py
@@ -320,3 +320,53 @@ def test_select_dispatch_device_ignores_non_dispatch_devices():
         {"uuid": "inv", "device_type": DeviceType.INVERTER},
     ]
     assert select_dispatch_device(devices)["uuid"] == "inv"
+
+
+# ---------------------------------------------------------------------------
+# Rated power derived from model code (issue #81)
+# ---------------------------------------------------------------------------
+
+
+def test_rated_power_w_parses_model_codes():
+    """Rated power is parsed from Sungrow model codes; non-inverters return None."""
+    from custom_components.sungrow.number import rated_power_w
+
+    assert rated_power_w({"device_model_code": "SH10RT-V112"}) == 10000
+    assert rated_power_w({"device_model_code": "SG3.6RS"}) == 3600
+    assert rated_power_w({"device_model_code": "SG110CX"}) == 110000
+    assert rated_power_w({"device_model_code": "SBR256"}) is None  # battery
+    assert rated_power_w({"device_model_code": "SGSmartMeter"}) is None  # meter
+    assert rated_power_w({}) is None
+
+
+async def test_charge_power_max_from_model_code(hass: HomeAssistant):
+    """The charge/discharge power slider is sized to the device's rated power."""
+    entry = MockConfigEntry(domain=DOMAIN, data=MOCK_CONFIG_DATA.copy())
+    entry.add_to_hass(hass)
+    devices = [{"uuid": "ess-1", "device_type": DeviceType.ENERGY_STORAGE_SYSTEM, "device_model_code": "SH10RT-V112"}]
+    _setup_entry_data(entry, devices)
+
+    added = []
+    await number_setup_entry(hass, entry, lambda entities: added.extend(entities))
+
+    power = next(e for e in added if e.param == "charge_discharge_power")
+    assert power._attr_native_max_value == 10000
+    # Percentage-based params are unaffected.
+    soc = next(e for e in added if e.param == "soc_upper_limit")
+    assert soc._attr_native_max_value == 100
+
+
+async def test_charge_power_max_falls_back_to_default(hass: HomeAssistant):
+    """An unparseable model code falls back to the default clamp."""
+    from custom_components.sungrow.number import DEFAULT_MAX_DISPATCH_POWER
+
+    entry = MockConfigEntry(domain=DOMAIN, data=MOCK_CONFIG_DATA.copy())
+    entry.add_to_hass(hass)
+    devices = [{"uuid": "ess-1", "device_type": DeviceType.ENERGY_STORAGE_SYSTEM, "device_model_code": "SBR256"}]
+    _setup_entry_data(entry, devices)
+
+    added = []
+    await number_setup_entry(hass, entry, lambda entities: added.extend(entities))
+
+    power = next(e for e in added if e.param == "charge_discharge_power")
+    assert power._attr_native_max_value == DEFAULT_MAX_DISPATCH_POWER


### PR DESCRIPTION
Closes #81.

## Finding (from a live account)
iSolarCloud's `getDeviceListByPsId` returns **no explicit power-rating field** — but the rating is encoded in **`device_model_code`**:

| Model code | Rating |
|---|---|
| `SG3.6RS` | 3.6 kW |
| `SH10RT-V112` | 10 kW |
| `SG110CX` | 110 kW |
| `SBR256` / `SGSmartMeter` / `WiNet-S` | (battery/meter/comms → no match) |

## Change
Parse the model code (`rated_power_w()`) to size the **charge/discharge power** slider to the actual device instead of the fixed 5000 W clamp. Non-inverter devices (and anything unparseable) fall back to `DEFAULT_MAX_DISPATCH_POWER`, so it's safe. The SOC (%) params are untouched.

Grounded in **real device payloads** — verified the parser against `SH10RT-V112`, `SG3.6RS`, `SG110CX`, `SBR256`, `SGSmartMeter`, `WiNet-S`.

Tests: unit test for the parser + integration tests (rated device → derived max; unparseable → default). Suite green (**144**).

*Not auto-merged — yours to review.*

🤖 Generated with [Claude Code](https://claude.com/claude-code)