### PR TITLE
fix: match the typed token-refresh error instead of a bare KeyError (#82)

### DIFF
--- a/custom_components/sungrow/auth.py
+++ b/custom_components/sungrow/auth.py
@@ -22,7 +22,9 @@ _LOGGER = logging.getLogger(__name__)
 
 # Errors raised by pysolarcloud that indicate the stored credentials/tokens are no
 # longer usable and the user must re-authorize (as opposed to a transient outage).
-AUTH_ERRORS = frozenset({"auth_not_initialised", "invalid_grant", "invalid_token"})
+# "token_refresh_failed" is the code on pysolarcloud>=0.6.0's TokenRefreshError
+# (a PySolarCloudException), raised when a refresh returns no access token.
+AUTH_ERRORS = frozenset({"auth_not_initialised", "invalid_grant", "invalid_token", "token_refresh_failed"})
 
 
 class SungrowAuth(Auth):

--- a/custom_components/sungrow/coordinator.py
+++ b/custom_components/sungrow/coordinator.py
@@ -26,16 +26,19 @@ _LOGGER = logging.getLogger(__name__)
 def is_auth_error(err: Exception) -> bool:
     """Return True if the error means the stored credentials are no longer valid.
 
-    A failed token refresh surfaces as a ``KeyError`` from pysolarcloud (the refresh
-    response has no ``access_token``), while explicit auth problems raise
-    ``PySolarCloudException`` with a known error code. Both require the user to
-    re-authorize rather than waiting for a transient outage to clear.
+    A failed token refresh raises ``PySolarCloudException`` (``TokenRefreshError``,
+    error ``token_refresh_failed``) on pysolarcloud>=0.6.0, and explicit auth
+    problems raise ``PySolarCloudException`` with a known error code — both matched
+    via ``AUTH_ERRORS``. All require the user to re-authorize rather than waiting
+    for a transient outage to clear.
     """
+    if isinstance(err, PySolarCloudException):
+        return err.error in AUTH_ERRORS
     if isinstance(err, KeyError):
-        # pysolarcloud raises KeyError("access_token") when a refresh response has
-        # no access token. Match on the key itself rather than the repr string.
+        # Legacy path: pysolarcloud<0.6.0 raised a bare KeyError("access_token")
+        # from a refresh with no access token. Drop once the pin is >=0.6.0.
         return bool(err.args) and err.args[0] == "access_token"
-    return isinstance(err, PySolarCloudException) and err.error in AUTH_ERRORS
+    return False
 
 
 class SungrowPlantCoordinator(DataUpdateCoordinator):

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -46,6 +46,11 @@ def test_is_auth_error_known_pysolarcloud_error():
     assert is_auth_error(PySolarCloudException({"error": "auth_not_initialised"})) is True
 
 
+def test_is_auth_error_token_refresh_failed():
+    """The typed token_refresh_failed error (pysolarcloud>=0.6 TokenRefreshError) is an auth error."""
+    assert is_auth_error(PySolarCloudException({"error": "token_refresh_failed"})) is True
+
+
 def test_is_auth_error_transient():
     """Transient errors are not auth errors."""
     assert is_auth_error(ConnectionError("boom")) is False


### PR DESCRIPTION
Closes #82. Integration side of the change; the library side is **KRoperUK/pysolarcloud#1**.

## Change
`pysolarcloud>=0.6.0` now raises a **typed `TokenRefreshError`** (a `PySolarCloudException`, `error` = `"token_refresh_failed"`) when a refresh returns no access token, instead of a bare `KeyError`.

- `is_auth_error` now checks `PySolarCloudException` first and classifies `token_refresh_failed` via `AUTH_ERRORS`, like every other auth failure — no more inspecting `KeyError.args`.
- The `KeyError("access_token")` match is kept as a **clearly-labelled legacy fallback** so the integration keeps working with the currently-pinned `sungrow-isolarcloud==0.5.0`.

## Rollout
This is forward-compatible now (works with 0.5.0 via the legacy path and 0.6.0 via the typed error). Once **pysolarcloud#1** is released and the manifest pin moves to `>=0.6.0`, the `KeyError` branch can be dropped.

Test added: a `token_refresh_failed` `PySolarCloudException` is treated as an auth error. Suite green (**142**).

*Not auto-merged — yours to review (and it pairs with pysolarcloud#1).*

🤖 Generated with [Claude Code](https://claude.com/claude-code)