### PR TITLE
fix: require pysolarcloud 0.6.0 and drop KeyError refresh fallback

### DIFF
--- a/custom_components/sungrow/coordinator.py
+++ b/custom_components/sungrow/coordinator.py
@@ -27,17 +27,13 @@ def is_auth_error(err: Exception) -> bool:
     """Return True if the error means the stored credentials are no longer valid.
 
     A failed token refresh raises ``PySolarCloudException`` (``TokenRefreshError``,
-    error ``token_refresh_failed``) on pysolarcloud>=0.6.0, and explicit auth
-    problems raise ``PySolarCloudException`` with a known error code — both matched
-    via ``AUTH_ERRORS``. All require the user to re-authorize rather than waiting
-    for a transient outage to clear.
+    error ``token_refresh_failed``), and explicit auth problems raise
+    ``PySolarCloudException`` with a known error code — both matched via
+    ``AUTH_ERRORS``. All require the user to re-authorize rather than waiting for a
+    transient outage to clear.
     """
     if isinstance(err, PySolarCloudException):
         return err.error in AUTH_ERRORS
-    if isinstance(err, KeyError):
-        # Legacy path: pysolarcloud<0.6.0 raised a bare KeyError("access_token")
-        # from a refresh with no access token. Drop once the pin is >=0.6.0.
-        return bool(err.args) and err.args[0] == "access_token"
     return False
 
 

--- a/custom_components/sungrow/manifest.json
+++ b/custom_components/sungrow/manifest.json
@@ -17,7 +17,7 @@
   ],
   "quality_scale": "silver",
   "requirements": [
-    "sungrow-isolarcloud==0.5.0"
+    "sungrow-isolarcloud==0.6.0"
   ],
   "version": "2.0.0"
 }

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -10,4 +10,4 @@ ruff==0.15.16
 mypy==2.1.0
 
 # Component dependencies
-sungrow-isolarcloud==0.5.0
+sungrow-isolarcloud==0.6.0

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -30,13 +30,14 @@ def _make_entry(options=None):
 # ---------------------------------------------------------------------------
 
 
-def test_is_auth_error_keyerror():
-    """A KeyError for access_token (failed refresh) is treated as an auth error."""
-    assert is_auth_error(KeyError("access_token")) is True
+def test_is_auth_error_keyerror_is_transient():
+    """A bare KeyError is not an auth error.
 
-
-def test_is_auth_error_unrelated_keyerror():
-    """An unrelated KeyError is not treated as an auth error."""
+    pysolarcloud>=0.6.0 raises the typed TokenRefreshError (error
+    ``token_refresh_failed``) on a failed refresh, so a raw KeyError is no longer
+    an auth signal and is left to retry as a transient failure.
+    """
+    assert is_auth_error(KeyError("access_token")) is False
     assert is_auth_error(KeyError("some_other_key")) is False
 
 
@@ -95,7 +96,7 @@ async def test_update_data_transient_error_raises_update_failed(hass: HomeAssist
 async def test_update_data_auth_error_raises_config_entry_auth_failed(hass: HomeAssistant):
     """A failed token refresh raises ConfigEntryAuthFailed (triggers reauth)."""
     plants = MagicMock()
-    plants.async_get_realtime_data = AsyncMock(side_effect=KeyError("access_token"))
+    plants.async_get_realtime_data = AsyncMock(side_effect=PySolarCloudException({"error": "token_refresh_failed"}))
 
     coordinator = SungrowPlantCoordinator(hass, _make_entry(), plants, "12345", "Test Plant")
     with pytest.raises(ConfigEntryAuthFailed):
@@ -122,8 +123,8 @@ async def test_update_data_pysolarcloud_transient_error_raises_update_failed(has
         await coordinator._async_update_data()
 
 
-async def test_update_data_unrelated_keyerror_raises_update_failed(hass: HomeAssistant):
-    """A KeyError unrelated to tokens is treated as a transient UpdateFailed."""
+async def test_update_data_keyerror_raises_update_failed(hass: HomeAssistant):
+    """A bare KeyError is treated as a transient UpdateFailed, not an auth error."""
     plants = MagicMock()
     plants.async_get_realtime_data = AsyncMock(side_effect=KeyError("some_other_key"))
 

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -239,9 +239,12 @@ async def test_setup_entry_connection_error_is_retried(hass: HomeAssistant, mock
 
 
 async def test_setup_entry_auth_error_triggers_reauth(hass: HomeAssistant, mock_setup_auth, mock_plants_service):
-    """A failed token refresh (KeyError) raises ConfigEntryAuthFailed (reauth)."""
-    # pysolarcloud raises KeyError when the refresh response has no access_token.
-    mock_plants_service.async_get_plants = AsyncMock(side_effect=KeyError("access_token"))
+    """A failed token refresh raises ConfigEntryAuthFailed (reauth)."""
+    # pysolarcloud>=0.6.0 raises TokenRefreshError (error "token_refresh_failed")
+    # when the refresh response has no access_token.
+    mock_plants_service.async_get_plants = AsyncMock(
+        side_effect=pysolarcloud.PySolarCloudException({"error": "token_refresh_failed"})
+    )
 
     entry = MockConfigEntry(domain=DOMAIN, data=MOCK_CONFIG_DATA.copy(), unique_id="test_app_id")
     entry.add_to_hass(hass)


### PR DESCRIPTION
## Summary
`sungrow-isolarcloud` 0.6.0 is now published to PyPI, so this completes the follow-up noted when the typed-error handling landed (#82 / #91):

- **Pin `sungrow-isolarcloud==0.6.0`** in `manifest.json` and `requirements_test.txt` (was `0.5.0`).
- **Drop the legacy `KeyError` branch** in `is_auth_error()`. That was a shim for `pysolarcloud<0.6.0`, which raised a bare `KeyError("access_token")` on a failed token refresh. 0.6.0 raises the typed `TokenRefreshError` (error `token_refresh_failed`), already matched via `AUTH_ERRORS`.
- A raw `KeyError` is now treated as a **transient** failure (`UpdateFailed` → retry) rather than an auth error.

## Behaviour
| Error | Before | After |
| --- | --- | --- |
| Failed refresh (`token_refresh_failed`) | reauth | reauth (unchanged) |
| `PySolarCloudException` in `AUTH_ERRORS` | reauth | reauth (unchanged) |
| bare `KeyError` | reauth (legacy shim) | transient retry |

Failed refreshes still trigger reauth — just via the typed error instead of the string-matched `KeyError`.

## Tests
- `test_coordinator.py` / `test_init.py`: raise the typed `token_refresh_failed` error where they previously raised `KeyError`.
- Replaced the two `KeyError`-as-auth assertions with one documenting that a bare `KeyError` is now transient.
- Full suite: **141 passed**, coverage **97%** (gate 90%).

Closes the pin/cleanup follow-up from #82.

🤖 Generated with [Claude Code](https://claude.com/claude-code)