### PR TITLE
docs: data updates, use cases and example automations (Gold)

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,16 @@ Custom component that integrates Sungrow inverters via the iSolarCloud API into 
 - **Token persistence & re-auth** — refreshed tokens are saved automatically, so entities stay available across restarts; if credentials expire you're prompted to re-authorize in place (no delete & re-add).
 - **Configurable polling interval** — tune how often data is fetched via the integration options.
 
+## Use cases
+
+Typical things people use this integration for:
+
+- **Monitor your solar system in Home Assistant** — live generation, house consumption, grid import/export and battery state of charge as sensors, with the correct device/state classes so they feed straight into the **Energy dashboard** and long-term statistics.
+- **Time-of-use battery control** — combine the dispatch **number**/**select** entities with automations to charge the battery from the grid when electricity is cheap and discharge it during peak-price periods (see [Example automations](#example-automations)).
+- **Force-charge before high demand** — top the battery up ahead of a known heavy-usage window (e.g. before cooking or an EV charge session) using the forced-charging entities.
+- **EV charger & meter visibility** — enable per-device sensors to surface EV charger power/energy and meter readings alongside the plant data.
+- **Alerting** — notify on low battery SOC, a plant going unavailable, or a fault, using standard Home Assistant automations on the sensors this integration creates.
+
 ## Installation
 
 ### HACS (Recommended)
@@ -88,6 +98,69 @@ the code). Your iSolarCloud account and developer application are unaffected.
 ### Sensor mapping
 
 Not sure which sensor corresponds to which value in the iSolarCloud app? See [docs/SENSORS.md](docs/SENSORS.md).
+
+## How data updates
+
+This is a **cloud-polling** integration — it does not talk to the inverter locally.
+
+- **Polling.** Home Assistant polls the iSolarCloud API on a fixed interval using one data update coordinator **per plant**. Every sensor for a plant refreshes together on each poll.
+- **Interval.** The default is **5 minutes**. Change it under **Configure → Polling interval** (minimum 10 seconds). Lower intervals update sooner but use more of your API quota (the free developer plan allows ~2000 calls/hour); enabling per-device sensors adds a call per device type each poll.
+- **Availability.** Entity state reflects the last successful poll. If a poll fails (network/API outage), entities go **unavailable** and Home Assistant retries on the next interval — no restart needed.
+- **Authentication.** Access tokens are refreshed automatically and the rotated tokens are persisted, so entities stay available across restarts. If your credentials are revoked or expire, the integration triggers a **re-authorization** prompt rather than silently failing.
+- **Dispatch controls are write-only.** The dispatch **number**/**select** entities send commands to the inverter; iSolarCloud does not report their current value back, so they act as controls (their state is not polled). While actively charging/discharging, the integration keeps the inverter in External EMS mode via a background heartbeat.
+
+## Example automations
+
+Entity IDs depend on your device name — check **Settings → Devices & Services → Sungrow** for the exact IDs. The examples below assume a device called `inverter`.
+
+**Charge the battery overnight (cheap tariff), then let it discharge during the peak:**
+
+```yaml
+automation:
+  - alias: "Battery: charge overnight"
+    triggers:
+      - trigger: time
+        at: "00:30:00"
+    actions:
+      - action: select.select_option
+        target:
+          entity_id: select.inverter_charge_discharge_command
+        data:
+          option: "Charge"
+      - action: number.set_value
+        target:
+          entity_id: number.inverter_charge_discharge_power
+        data:
+          value: 3000
+
+  - alias: "Battery: stop forced charge at peak start"
+    triggers:
+      - trigger: time
+        at: "05:30:00"
+    actions:
+      - action: select.select_option
+        target:
+          entity_id: select.inverter_charge_discharge_command
+        data:
+          option: "Stop"
+```
+
+**Notify when the battery gets low:**
+
+```yaml
+automation:
+  - alias: "Battery: low SOC alert"
+    triggers:
+      - trigger: numeric_state
+        entity_id: sensor.my_plant_battery_state_of_charge
+        below: 15
+    actions:
+      - action: notify.notify
+        data:
+          message: "Home battery is below 15%."
+```
+
+> Selecting **Charge**/**Discharge** (or setting charge/discharge power) automatically starts the EMS heartbeat; selecting **Stop** ends it.
 
 ## Supported devices & regions
 

--- a/custom_components/sungrow/quality_scale.yaml
+++ b/custom_components/sungrow/quality_scale.yaml
@@ -95,9 +95,11 @@ rules:
     status: exempt
     comment: No network discovery.
   docs-data-update:
-    status: todo
+    status: done
+    comment: README "How data updates" documents cloud polling, interval and availability.
   docs-examples:
-    status: todo
+    status: done
+    comment: README "Example automations" gives battery dispatch and low-SOC alert examples.
   docs-known-limitations:
     status: done
   docs-supported-devices:
@@ -107,7 +109,8 @@ rules:
   docs-troubleshooting:
     status: done
   docs-use-cases:
-    status: todo
+    status: done
+    comment: README "Use cases" describes monitoring, time-of-use battery control and alerting.
   dynamic-devices:
     status: todo
   entity-category:


### PR DESCRIPTION
## Summary
Second Gold quality-scale bucket — **docs**. Adds three README sections that resolve the remaining docs rules:

| Rule | Section |
| --- | --- |
| `docs-use-cases` | **Use cases** — monitoring/Energy dashboard, time-of-use battery control, force-charge, EV/meter visibility, alerting |
| `docs-data-update` | **How data updates** — per-plant cloud polling, interval, availability on failure, token refresh/reauth, write-only dispatch |
| `docs-examples` | **Example automations** — overnight battery charge + peak stop, low-SOC alert (YAML) |

`quality_scale.yaml` marks all three `done`.

Docs-only; no code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)