### PR TITLE
feat: runtime device management for Gold (dynamic + stale devices)

### DIFF
--- a/custom_components/sungrow/__init__.py
+++ b/custom_components/sungrow/__init__.py
@@ -14,6 +14,7 @@ from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryAuthFailed, ConfigEntryNotReady
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
+from homeassistant.helpers.device_registry import DeviceEntry
 from pysolarcloud.control import Control
 from pysolarcloud.plants import DeviceType, Plants
 
@@ -211,6 +212,25 @@ async def async_unload_entry(hass: HomeAssistant, entry: SungrowConfigEntry) -> 
 async def async_reload_entry(hass: HomeAssistant, entry: SungrowConfigEntry) -> None:
     """Reload the config entry when its options change."""
     await hass.config_entries.async_reload(entry.entry_id)
+
+
+async def async_remove_config_entry_device(
+    hass: HomeAssistant, config_entry: SungrowConfigEntry, device_entry: DeviceEntry
+) -> bool:
+    """Allow deletion of a device the API no longer reports (stale-devices).
+
+    Returns True (permit removal) only when none of the device's identifiers match
+    a currently-known plant or device across the entry's coordinators, so devices
+    that are still present cannot be removed by accident.
+    """
+    known: set[tuple[str, str]] = set()
+    for coordinator in config_entry.runtime_data.coordinators:
+        known.add((DOMAIN, coordinator.plant_id))
+        for device in coordinator.devices:
+            uuid = device.get("uuid")
+            if uuid:
+                known.add((DOMAIN, str(uuid)))
+    return not any(identifier in known for identifier in device_entry.identifiers)
 
 
 async def _stop_heartbeat(heartbeat: tuple[asyncio.Event, asyncio.Task]) -> None:

--- a/custom_components/sungrow/coordinator.py
+++ b/custom_components/sungrow/coordinator.py
@@ -80,10 +80,25 @@ class SungrowPlantCoordinator(DataUpdateCoordinator):
                 raise ConfigEntryAuthFailed(f"Authentication with iSolarCloud failed: {err}") from err
             raise UpdateFailed(f"Error communicating with iSolarCloud API: {err}") from err
 
+        # Refresh the device list so devices added to the plant after setup are
+        # picked up at runtime (dynamic-devices) and removed ones can be pruned
+        # (stale-devices). Best-effort: keep the previous list on failure.
+        await self._async_refresh_devices()
+
         if self.enable_device_sensors:
             self.device_data = await self._async_fetch_device_data()
 
         return all_plants_data.get(self.plant_id, {})
+
+    async def _async_refresh_devices(self) -> None:
+        """Re-fetch the plant's device list (best effort, non-fatal)."""
+        try:
+            devices = await self.plants_service.async_get_plant_devices(self.plant_id)
+        except Exception as err:  # pylint: disable=broad-except
+            _LOGGER.debug("Could not refresh devices for plant %s: %s", self.plant_id, err)
+            return
+        # Mutate in place so holders of this list (runtime_data.devices) see updates.
+        self.devices[:] = list(devices or [])
 
     async def _async_fetch_device_data(self) -> dict[str, dict]:
         """Fetch per-device realtime for each distinct device type (best effort).

--- a/custom_components/sungrow/number.py
+++ b/custom_components/sungrow/number.py
@@ -7,7 +7,7 @@ import re
 
 from homeassistant.components.number import NumberDeviceClass, NumberEntity, NumberMode
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.core import HomeAssistant
+from homeassistant.core import HomeAssistant, callback
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.entity import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
@@ -92,43 +92,56 @@ DISPATCH_NUMBERS: dict[str, dict] = {
 }
 
 
+def _build_numbers(coordinator, control) -> list[NumberEntity]:
+    """Build the dispatch number entities for a coordinator's target device.
+
+    Returns an empty list when no dispatch-capable device is present. Reads the
+    coordinator's live device list so a dispatchable device that appears after
+    setup gets its controls at runtime (dynamic-devices).
+    """
+    # Prefer the ESS device if present, otherwise fall back to an inverter.
+    target = select_dispatch_device(coordinator.devices)
+    if target is None:
+        return []
+    device_uuid = target.get("uuid")
+    if not device_uuid:
+        return []
+    device_name = target.get("device_name") or coordinator.plant_name
+    # Size the charge/discharge power slider to the device's rated power when it
+    # can be derived from the model code; otherwise use the conservative default.
+    max_power = rated_power_w(target) or DEFAULT_MAX_DISPATCH_POWER
+    entities: list[NumberEntity] = []
+    for param, meta in DISPATCH_NUMBERS.items():
+        if param == "charge_discharge_power" and max_power != meta["native_max_value"]:
+            meta = {**meta, "native_max_value": max_power}
+        entities.append(SungrowDispatchNumber(coordinator, control, device_uuid, device_name, param, meta))
+    return entities
+
+
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry, async_add_entities: AddEntitiesCallback) -> None:
     """Set up Sungrow dispatch number entities."""
     data = entry.runtime_data
     control = data.control
-    devices_by_plant = data.devices
     coordinators = data.coordinators
 
-    entities: list[NumberEntity] = []
-    for coordinator in coordinators:
-        plant_id = coordinator.plant_id
-        devices = devices_by_plant.get(plant_id, [])
-        # Prefer the ESS device if present, otherwise fall back to the first device.
-        target = select_dispatch_device(devices)
-        if target is None:
-            continue
-        device_uuid = target.get("uuid")
-        if not device_uuid:
-            continue
-        device_name = target.get("device_name") or coordinator.plant_name
-        # Size the charge/discharge power slider to the device's rated power when it
-        # can be derived from the model code; otherwise use the conservative default.
-        max_power = rated_power_w(target) or DEFAULT_MAX_DISPATCH_POWER
-        for param, meta in DISPATCH_NUMBERS.items():
-            if param == "charge_discharge_power" and max_power != meta["native_max_value"]:
-                meta = {**meta, "native_max_value": max_power}
-            entities.append(
-                SungrowDispatchNumber(
-                    coordinator,
-                    control,
-                    device_uuid,
-                    device_name,
-                    param,
-                    meta,
-                )
-            )
+    known_unique_ids: set[str] = set()
 
-    async_add_entities(entities)
+    @callback
+    def _add_new_entities() -> None:
+        new_entities: list[NumberEntity] = []
+        for coordinator in coordinators:
+            for entity in _build_numbers(coordinator, control):
+                uid = entity.unique_id
+                if uid is None or uid in known_unique_ids:
+                    continue
+                known_unique_ids.add(uid)
+                new_entities.append(entity)
+        if new_entities:
+            async_add_entities(new_entities)
+
+    _add_new_entities()
+    for coordinator in coordinators:
+        entry.async_on_unload(coordinator.async_add_listener(_add_new_entities))
 
 
 class SungrowDispatchNumber(CoordinatorEntity[SungrowPlantCoordinator], NumberEntity):

--- a/custom_components/sungrow/quality_scale.yaml
+++ b/custom_components/sungrow/quality_scale.yaml
@@ -112,7 +112,11 @@ rules:
     status: done
     comment: README "Use cases" describes monitoring, time-of-use battery control and alerting.
   dynamic-devices:
-    status: todo
+    status: done
+    comment: >-
+      The coordinator refreshes each plant's device list every poll; the sensor
+      and dispatch platforms add entities for devices/points that appear after
+      setup via a coordinator listener.
   entity-category:
     status: exempt
     comment: >-
@@ -146,7 +150,10 @@ rules:
   repair-issues:
     status: todo
   stale-devices:
-    status: todo
+    status: done
+    comment: >-
+      async_remove_config_entry_device lets the user delete a device once the API
+      no longer reports it; devices still present are protected.
 
   # --- Platinum ---
   async-dependency:

--- a/custom_components/sungrow/select.py
+++ b/custom_components/sungrow/select.py
@@ -6,7 +6,7 @@ import logging
 
 from homeassistant.components.select import SelectEntity
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.core import HomeAssistant
+from homeassistant.core import HomeAssistant, callback
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.entity import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
@@ -41,38 +41,51 @@ DISPATCH_SELECTS: dict[str, dict] = {
 }
 
 
+def _build_selects(coordinator, control) -> list[SelectEntity]:
+    """Build the dispatch select entities for a coordinator's target device.
+
+    Returns an empty list when no dispatch-capable device is present. Reads the
+    coordinator's live device list so a dispatchable device that appears after
+    setup gets its controls at runtime (dynamic-devices).
+    """
+    # Prefer the ESS device if present, otherwise fall back to an inverter.
+    target = select_dispatch_device(coordinator.devices)
+    if target is None:
+        return []
+    device_uuid = target.get("uuid")
+    if not device_uuid:
+        return []
+    device_name = target.get("device_name") or coordinator.plant_name
+    return [
+        SungrowDispatchSelect(coordinator, control, device_uuid, device_name, param, meta)
+        for param, meta in DISPATCH_SELECTS.items()
+    ]
+
+
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry, async_add_entities: AddEntitiesCallback) -> None:
     """Set up Sungrow dispatch select entities."""
     data = entry.runtime_data
     control = data.control
-    devices_by_plant = data.devices
     coordinators = data.coordinators
 
-    entities: list[SelectEntity] = []
-    for coordinator in coordinators:
-        plant_id = coordinator.plant_id
-        devices = devices_by_plant.get(plant_id, [])
-        # Prefer the ESS device if present, otherwise fall back to the first device.
-        target = select_dispatch_device(devices)
-        if target is None:
-            continue
-        device_uuid = target.get("uuid")
-        if not device_uuid:
-            continue
-        device_name = target.get("device_name") or coordinator.plant_name
-        for param, meta in DISPATCH_SELECTS.items():
-            entities.append(
-                SungrowDispatchSelect(
-                    coordinator,
-                    control,
-                    device_uuid,
-                    device_name,
-                    param,
-                    meta,
-                )
-            )
+    known_unique_ids: set[str] = set()
 
-    async_add_entities(entities)
+    @callback
+    def _add_new_entities() -> None:
+        new_entities: list[SelectEntity] = []
+        for coordinator in coordinators:
+            for entity in _build_selects(coordinator, control):
+                uid = entity.unique_id
+                if uid is None or uid in known_unique_ids:
+                    continue
+                known_unique_ids.add(uid)
+                new_entities.append(entity)
+        if new_entities:
+            async_add_entities(new_entities)
+
+    _add_new_entities()
+    for coordinator in coordinators:
+        entry.async_on_unload(coordinator.async_add_listener(_add_new_entities))
 
 
 class SungrowDispatchSelect(CoordinatorEntity[SungrowPlantCoordinator], SelectEntity):

--- a/custom_components/sungrow/sensor.py
+++ b/custom_components/sungrow/sensor.py
@@ -4,7 +4,7 @@ import logging
 
 from homeassistant.components.sensor import SensorDeviceClass, SensorEntity, SensorStateClass
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.core import HomeAssistant
+from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.device_registry import DeviceEntryType
 from homeassistant.helpers.entity import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
@@ -111,50 +111,74 @@ def infer_device_class(unit: str | None, point_code: str) -> tuple[SensorDeviceC
     return None, None
 
 
+def _build_sensors(coordinator, console_url) -> list[SungrowSensor]:
+    """Build the full set of sensors the coordinator currently warrants.
+
+    Called both at setup and on every coordinator update, so points/devices that
+    appear after setup are surfaced at runtime (dynamic-devices). The caller
+    de-duplicates by unique_id, so returning the complete set each time is fine.
+    """
+    sensors: list[SungrowSensor] = []
+
+    # Plant-level sensors.
+    # The data structure is { "P_CODE": { "code": ..., "value": ..., "unit": ..., "name": ... } }
+    if coordinator.data:
+        for point_code, point_data in coordinator.data.items():
+            sensors.append(
+                SungrowSensor(
+                    coordinator, point_code, coordinator.plant_id, coordinator.plant_name, point_data, console_url
+                )
+            )
+
+    # Per-device sensors (opt-in, issue #74): surface points reported per device
+    # (EV chargers, meters, extra batteries). Points already present at the plant
+    # level are skipped so enabling this doesn't just duplicate every plant sensor
+    # under the inverter.
+    if coordinator.enable_device_sensors and coordinator.device_data:
+        plant_codes = set(coordinator.data or {})
+        device_names = {
+            str(d.get("uuid")): (d.get("device_name") or d.get("device_model_name") or coordinator.plant_name)
+            for d in coordinator.devices
+            if d.get("uuid")
+        }
+        for uuid, points in coordinator.device_data.items():
+            device_name = device_names.get(uuid, f"Device {uuid}")
+            for point_code, point_data in points.items():
+                if point_code in plant_codes:
+                    continue
+                sensors.append(
+                    SungrowDeviceSensor(coordinator, point_code, coordinator.plant_id, uuid, device_name, point_data)
+                )
+
+    return sensors
+
+
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry, async_add_entities: AddEntitiesCallback) -> None:
     """Set up Sungrow sensors from the coordinators created during entry setup."""
     coordinators = entry.runtime_data.coordinators
-    devices_by_plant = entry.runtime_data.devices
     # Point the device "Visit" link at the region's iSolarCloud web console.
     console_url = GATEWAY_CONSOLE_URLS.get(entry.data.get(CONF_GATEWAY, ""), DEFAULT_CONSOLE_URL)
 
-    entities: list[SungrowSensor] = []
+    known_unique_ids: set[str] = set()
+
+    @callback
+    def _add_new_entities() -> None:
+        """Add entities for any plant points / devices not seen yet."""
+        new_entities: list[SungrowSensor] = []
+        for coordinator in coordinators:
+            for entity in _build_sensors(coordinator, console_url):
+                uid = entity.unique_id
+                if uid is None or uid in known_unique_ids:
+                    continue
+                known_unique_ids.add(uid)
+                new_entities.append(entity)
+        if new_entities:
+            async_add_entities(new_entities)
+
+    # Add the initial set, then keep watching each coordinator for new devices.
+    _add_new_entities()
     for coordinator in coordinators:
-        # Plant-level sensors.
-        # The data structure is { "P_CODE": { "code": ..., "value": ..., "unit": ..., "name": ... } }
-        if coordinator.data:
-            for point_code, point_data in coordinator.data.items():
-                entities.append(
-                    SungrowSensor(
-                        coordinator, point_code, coordinator.plant_id, coordinator.plant_name, point_data, console_url
-                    )
-                )
-        else:
-            _LOGGER.warning("No data received for plant %s", coordinator.plant_name)
-
-        # Per-device sensors (opt-in, issue #74): surface points reported per device
-        # (EV chargers, meters, extra batteries). Points already present at the plant
-        # level are skipped so enabling this doesn't just duplicate every plant sensor
-        # under the inverter.
-        if coordinator.enable_device_sensors and coordinator.device_data:
-            plant_codes = set(coordinator.data or {})
-            device_names = {
-                str(d.get("uuid")): (d.get("device_name") or d.get("device_model_name") or coordinator.plant_name)
-                for d in devices_by_plant.get(coordinator.plant_id, [])
-                if d.get("uuid")
-            }
-            for uuid, points in coordinator.device_data.items():
-                device_name = device_names.get(uuid, f"Device {uuid}")
-                for point_code, point_data in points.items():
-                    if point_code in plant_codes:
-                        continue
-                    entities.append(
-                        SungrowDeviceSensor(
-                            coordinator, point_code, coordinator.plant_id, uuid, device_name, point_data
-                        )
-                    )
-
-    async_add_entities(entities)
+        entry.async_on_unload(coordinator.async_add_listener(_add_new_entities))
 
 
 class SungrowSensor(CoordinatorEntity, SensorEntity):

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -134,6 +134,37 @@ async def test_update_data_keyerror_raises_update_failed(hass: HomeAssistant):
 
 
 # ---------------------------------------------------------------------------
+# Device list refresh (dynamic / stale devices)
+# ---------------------------------------------------------------------------
+
+
+async def test_refresh_devices_updates_list(hass: HomeAssistant):
+    """Each poll refreshes the plant's device list so new devices are picked up."""
+    plants = MagicMock()
+    plants.async_get_realtime_data = AsyncMock(return_value={"12345": {}})
+    plants.async_get_plant_devices = AsyncMock(return_value=[{"uuid": "new-dev"}])
+
+    coordinator = SungrowPlantCoordinator(hass, _make_entry(), plants, "12345", "Test Plant", devices=[])
+    await coordinator._async_update_data()
+
+    assert coordinator.devices == [{"uuid": "new-dev"}]
+
+
+async def test_refresh_devices_failure_keeps_previous_list(hass: HomeAssistant):
+    """A device-list fetch failure keeps the previous list (best effort, non-fatal)."""
+    plants = MagicMock()
+    plants.async_get_realtime_data = AsyncMock(return_value={"12345": {}})
+    plants.async_get_plant_devices = AsyncMock(side_effect=ConnectionError("boom"))
+
+    coordinator = SungrowPlantCoordinator(
+        hass, _make_entry(), plants, "12345", "Test Plant", devices=[{"uuid": "keep"}]
+    )
+    await coordinator._async_update_data()
+
+    assert coordinator.devices == [{"uuid": "keep"}]
+
+
+# ---------------------------------------------------------------------------
 # scan interval from options
 # ---------------------------------------------------------------------------
 

--- a/tests/test_dispatch.py
+++ b/tests/test_dispatch.py
@@ -36,8 +36,11 @@ def _setup_entry_data(entry, devices) -> SungrowData:
     control.async_update_parameters = AsyncMock(return_value=[])
     control.async_heartbeat = AsyncMock()
     control.heartbeat_loop = AsyncMock()
+    coordinator = _coordinator_with("12345", "Test Plant")
+    # Dispatch platforms read the live device list from the coordinator.
+    coordinator.devices = devices
     data = SungrowData(
-        coordinators=[_coordinator_with("12345", "Test Plant")],
+        coordinators=[coordinator],
         control=control,
         devices={"12345": devices},
     )
@@ -373,6 +376,38 @@ async def test_charge_power_max_falls_back_to_default(hass: HomeAssistant):
 
     power = next(e for e in added if e.param == "charge_discharge_power")
     assert power._attr_native_max_value == DEFAULT_MAX_DISPATCH_POWER
+
+
+# ---------------------------------------------------------------------------
+# Dynamic devices (dispatch controls appear at runtime)
+# ---------------------------------------------------------------------------
+
+
+async def test_number_dynamic_add_when_device_appears(hass: HomeAssistant):
+    """A dispatchable device appearing after setup gets its number entities."""
+    entry = MockConfigEntry(domain=DOMAIN, data=MOCK_CONFIG_DATA.copy())
+    entry.add_to_hass(hass)
+    data = _setup_entry_data(entry, [])  # no dispatchable device yet
+    coordinator = data.coordinators[0]
+    listeners: list = []
+    coordinator.async_add_listener = lambda cb, *a: listeners.append(cb) or (lambda: None)
+
+    added = []
+    await number_setup_entry(hass, entry, lambda entities: added.extend(entities))
+    assert added == []  # nothing dispatchable at setup
+
+    # An ESS appears on a later poll; the coordinator notifies its listeners.
+    coordinator.devices = [{"uuid": "ess-1", "device_type": "ENERGY_STORAGE_SYSTEM"}]
+    for cb in listeners:
+        cb()
+
+    assert len(added) == len(DISPATCH_NUMBERS)
+    assert all(e.device_uuid == "ess-1" for e in added)
+
+    # Firing again must not duplicate the controls.
+    for cb in listeners:
+        cb()
+    assert len(added) == len(DISPATCH_NUMBERS)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -13,6 +13,7 @@ from pytest_homeassistant_custom_component.common import MockConfigEntry
 from custom_components.sungrow import (
     SungrowAuthCallbackView,
     SungrowData,
+    async_remove_config_entry_device,
     async_setup,
     async_start_heartbeat,
     async_stop_heartbeat,
@@ -253,6 +254,27 @@ async def test_setup_entry_auth_error_triggers_reauth(hass: HomeAssistant, mock_
     await hass.async_block_till_done()
 
     assert entry.state is ConfigEntryState.SETUP_ERROR
+
+
+async def test_async_remove_config_entry_device(hass: HomeAssistant):
+    """Stale devices can be removed from the UI; present ones are protected."""
+    from types import SimpleNamespace
+
+    entry = MockConfigEntry(domain=DOMAIN, data=MOCK_CONFIG_DATA.copy())
+    coordinator = MagicMock()
+    coordinator.plant_id = "12345"
+    coordinator.devices = [{"uuid": "dev-1"}, {"uuid": "dev-2"}]
+    entry.runtime_data = SungrowData(coordinators=[coordinator], control=MagicMock(), devices={})
+
+    # The plant device and a present device are still known -> not removable.
+    plant = SimpleNamespace(identifiers={(DOMAIN, "12345")})
+    present = SimpleNamespace(identifiers={(DOMAIN, "dev-1")})
+    assert await async_remove_config_entry_device(hass, entry, plant) is False
+    assert await async_remove_config_entry_device(hass, entry, present) is False
+
+    # A device the API no longer reports -> removable.
+    gone = SimpleNamespace(identifiers={(DOMAIN, "old-device")})
+    assert await async_remove_config_entry_device(hass, entry, gone) is True
 
 
 async def test_options_change_reloads_entry(hass: HomeAssistant, mock_setup_auth, mock_plants_service):

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -290,6 +290,8 @@ async def test_device_sensors_created_when_enabled(hass: HomeAssistant):
 
     coordinator = _coordinator_with("12345", "Plant A", {"total_active_power": {"value": "5.0", "unit": "kW"}})
     coordinator.enable_device_sensors = True
+    # The platform reads the live device list from the coordinator for naming.
+    coordinator.devices = [{"uuid": "chg-1", "device_name": "AC011E", "device_type": 999}]
     coordinator.device_data = {
         "chg-1": {
             "ev_charger_power": {"code": "ev_charger_power", "value": "7.2", "unit": "kW"},
@@ -300,7 +302,7 @@ async def test_device_sensors_created_when_enabled(hass: HomeAssistant):
     entry.runtime_data = SungrowData(
         coordinators=[coordinator],
         control=MagicMock(),
-        devices={"12345": [{"uuid": "chg-1", "device_name": "AC011E", "device_type": 999}]},
+        devices={"12345": coordinator.devices},
     )
 
     added = []
@@ -312,10 +314,39 @@ async def test_device_sensors_created_when_enabled(hass: HomeAssistant):
     assert sensor.point_code == "ev_charger_power"
     assert sensor.device_uuid == "chg-1"
     assert sensor._attr_unique_id == "12345_chg-1_ev_charger_power"
+    # Name is derived from the coordinator's device metadata.
+    assert sensor._attr_device_info["name"] == "AC011E"
     assert (DOMAIN, "chg-1") in sensor._attr_device_info["identifiers"]
     assert sensor._attr_device_info["via_device"] == (DOMAIN, "12345")
     # Reads its value from the coordinator's per-device data.
     assert sensor.native_value == 7.2
+
+
+async def test_sensor_dynamic_add_on_new_point(hass: HomeAssistant):
+    """A plant point that appears after setup is added at runtime (dynamic-devices)."""
+    entry = MockConfigEntry(domain=DOMAIN, data=MOCK_CONFIG_DATA.copy())
+    entry.add_to_hass(hass)
+
+    coordinator = _coordinator_with("12345", "Plant A", {"total_active_power": {"value": "5.0", "unit": "kW"}})
+    listeners: list = []
+    coordinator.async_add_listener = lambda cb, *a: listeners.append(cb) or (lambda: None)
+    entry.runtime_data = SungrowData(coordinators=[coordinator], control=MagicMock(), devices={})
+
+    added = []
+    await async_setup_entry(hass, entry, lambda entities: added.extend(entities))
+    assert len(added) == 1
+
+    # A new point appears on a later poll; the coordinator notifies its listeners.
+    coordinator.data = {**coordinator.data, "daily_energy": {"value": "12.0", "unit": "kWh"}}
+    for cb in listeners:
+        cb()
+    assert len(added) == 2
+    assert any(e.point_code == "daily_energy" for e in added)
+
+    # Firing again with nothing new must not re-add existing sensors.
+    for cb in listeners:
+        cb()
+    assert len(added) == 2
 
 
 async def test_device_sensors_not_created_when_disabled(hass: HomeAssistant):


### PR DESCRIPTION
## Summary
Third Gold quality-scale bucket — **runtime devices**. Resolves two rules:

| Rule | How |
| --- | --- |
| `dynamic-devices` | The coordinator re-fetches each plant's device list every poll; sensor and dispatch platforms add entities for devices/points appearing after setup, via a coordinator listener (de-duped by `unique_id`) — no reload needed |
| `stale-devices` | `async_remove_config_entry_device` lets the user delete a device the API no longer reports; devices still present are protected |

## Changes
- **`coordinator.py`** — `_async_refresh_devices()` refreshes `self.devices` each poll (best-effort; keeps the previous list on failure).
- **`sensor.py` / `number.py` / `select.py`** — build entities via a helper and register a `coordinator.async_add_listener` callback that adds newly-appeared entities; platforms now read the **live** device list from the coordinator instead of the setup-time snapshot.
- **`__init__.py`** — `async_remove_config_entry_device`.
- **`quality_scale.yaml`** — both rules marked done.

## Tests
- Device refresh: success updates the list; failure keeps the previous list.
- Dynamic add: a new plant point → new sensor; a dispatchable device appearing later → dispatch controls; both de-dupe on repeat.
- Stale removal: known plant/device → not removable; unreported device → removable.
- Full suite: **152 passed**, coverage **97%** (`sensor.py` 100%).

After this, only `repair-issues` and `strict-typing` remain — both in the final PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)