### PR TITLE
feat: strict typing (Platinum) + ship py.typed

### DIFF
--- a/custom_components/sungrow/__init__.py
+++ b/custom_components/sungrow/__init__.py
@@ -4,17 +4,19 @@ from __future__ import annotations
 
 import asyncio
 import logging
+from collections.abc import Iterator
 from dataclasses import dataclass, field
+from typing import Any
 
 import voluptuous as vol
 from aiohttp import web
-from homeassistant.components.http import HomeAssistantView
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryAuthFailed, ConfigEntryNotReady
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.device_registry import DeviceEntry
+from homeassistant.helpers.http import HomeAssistantView
 from pysolarcloud.control import Control
 from pysolarcloud.plants import DeviceType, Plants
 
@@ -46,15 +48,15 @@ class SungrowData:
 
     coordinators: list[SungrowPlantCoordinator]
     control: Control
-    devices: dict[str, list[dict]]
+    devices: dict[str, list[dict[str, Any]]]
     # plant_id -> (stop_event, task) for the running EMS heartbeat loops.
-    heartbeats: dict[str, tuple[asyncio.Event, asyncio.Task]] = field(default_factory=dict)
+    heartbeats: dict[str, tuple[asyncio.Event, asyncio.Task[None]]] = field(default_factory=dict)
 
 
 type SungrowConfigEntry = ConfigEntry[SungrowData]
 
 
-def _matches_device_type(device: dict, target: DeviceType) -> bool:
+def _matches_device_type(device: dict[str, Any], target: DeviceType) -> bool:
     """Return True if a discovered device is of ``target`` type.
 
     pysolarcloud converts a *known* device type to a ``DeviceType`` enum, but the
@@ -65,7 +67,7 @@ def _matches_device_type(device: dict, target: DeviceType) -> bool:
     return dt in (target, target.value, target.name)
 
 
-def select_dispatch_device(devices: list[dict]) -> dict | None:
+def select_dispatch_device(devices: list[dict[str, Any]]) -> dict[str, Any] | None:
     """Pick the device to attach dispatch (number/select) entities to.
 
     Only inverters and energy-storage systems accept charge/discharge dispatch, so
@@ -82,11 +84,11 @@ def select_dispatch_device(devices: list[dict]) -> dict | None:
 class IterableSchema(vol.Schema):
     """A Schema that can be iterated over (yielding nothing) to satisfy HA's checks."""
 
-    def __iter__(self):
+    def __iter__(self) -> Iterator[Any]:
         """Return an empty iterator."""
         return iter([])
 
-    def __contains__(self, item):
+    def __contains__(self, item: object) -> bool:
         """Return False for any item check."""
         return False
 
@@ -112,7 +114,7 @@ def _ensure_callback_view_registered(hass: HomeAssistant) -> None:
     domain_data["callback_view_registered"] = True
 
 
-async def async_setup(hass: HomeAssistant, config: dict) -> bool:
+async def async_setup(hass: HomeAssistant, config: dict[str, Any]) -> bool:
     """Set up the Sungrow iSolarCloud component."""
     _ensure_callback_view_registered(hass)
     return True
@@ -138,7 +140,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: SungrowConfigEntry) -> b
     session = async_get_clientsession(hass)
     host = GATEWAYS.get(entry.data[CONF_GATEWAY], DEFAULT_HOST)
 
-    def _save_tokens(tokens: dict) -> None:
+    def _save_tokens(tokens: dict[str, Any]) -> None:
         """Persist refreshed/rotated tokens back to the config entry."""
         hass.config_entries.async_update_entry(entry, data={**entry.data, "tokens": tokens})
 
@@ -164,7 +166,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: SungrowConfigEntry) -> b
         raise ConfigEntryNotReady(f"Unable to fetch plants from iSolarCloud: {err}") from err
 
     coordinators: list[SungrowPlantCoordinator] = []
-    devices_by_plant: dict[str, list[dict]] = {}
+    devices_by_plant: dict[str, list[dict[str, Any]]] = {}
     for plant_info in plant_list:
         plant_id = str(plant_info["ps_id"])
         plant_name = plant_info["ps_name"]
@@ -233,7 +235,7 @@ async def async_remove_config_entry_device(
     return not any(identifier in known for identifier in device_entry.identifiers)
 
 
-async def _stop_heartbeat(heartbeat: tuple[asyncio.Event, asyncio.Task]) -> None:
+async def _stop_heartbeat(heartbeat: tuple[asyncio.Event, asyncio.Task[None]]) -> None:
     """Signal a heartbeat loop to stop and wait for it to actually exit."""
     stop_event, task = heartbeat
     stop_event.set()

--- a/custom_components/sungrow/auth.py
+++ b/custom_components/sungrow/auth.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 
 import logging
 from collections.abc import Callable
+from typing import Any, cast
 
 from pysolarcloud import Auth
 
@@ -27,7 +28,7 @@ _LOGGER = logging.getLogger(__name__)
 AUTH_ERRORS = frozenset({"auth_not_initialised", "invalid_grant", "invalid_token", "token_refresh_failed"})
 
 
-class SungrowAuth(Auth):
+class SungrowAuth(Auth):  # type: ignore[misc]  # pysolarcloud.Auth is untyped (Any); subclassing it is the intended boundary
     """``pysolarcloud.Auth`` that persists rotated tokens via a callback.
 
     ``token_updater`` is invoked with the new ``tokens`` dict whenever the upstream
@@ -37,9 +38,9 @@ class SungrowAuth(Auth):
 
     def __init__(
         self,
-        *args,
-        token_updater: Callable[[dict], None] | None = None,
-        **kwargs,
+        *args: Any,
+        token_updater: Callable[[dict[str, Any]], None] | None = None,
+        **kwargs: Any,
     ) -> None:
         """Initialize the auth client with an optional token-persistence callback."""
         super().__init__(*args, **kwargs)
@@ -53,7 +54,8 @@ class SungrowAuth(Auth):
         call.
         """
         previous = self.tokens
-        token = await super().async_get_access_token()
+        # pysolarcloud is untyped, so the upstream method returns Any.
+        token = cast(str, await super().async_get_access_token())
         if self._token_updater is not None and self.tokens is not previous:
             _LOGGER.debug("Access token refreshed; persisting rotated tokens")
             self._token_updater(self.tokens)

--- a/custom_components/sungrow/config_flow.py
+++ b/custom_components/sungrow/config_flow.py
@@ -2,12 +2,12 @@
 
 import asyncio
 import logging
-from typing import Any
+from typing import Any, cast
 
 import voluptuous as vol
 from aiohttp import ClientError
 from homeassistant import config_entries, data_entry_flow
-from homeassistant.config_entries import ConfigEntry
+from homeassistant.config_entries import ConfigEntry, ConfigFlowResult
 from homeassistant.core import callback
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.network import get_url
@@ -50,7 +50,7 @@ class SungrowConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
     VERSION = 2
 
-    def __init__(self):
+    def __init__(self) -> None:
         """Initialize the config flow."""
         self.init_info: dict[str, Any] = {}
         self.auth_client: Any = None
@@ -68,18 +68,18 @@ class SungrowConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         """Return the options flow handler."""
         return SungrowOptionsFlow()
 
-    async def async_step_reauth(self, entry_data: dict[str, Any]):
+    async def async_step_reauth(self, entry_data: dict[str, Any]) -> ConfigFlowResult:
         """Handle re-authentication when the stored tokens are no longer valid."""
         self._reauth_entry = self.hass.config_entries.async_get_entry(self.context["entry_id"])
         # Reuse the credentials already stored on the entry; only the tokens are stale.
         self.init_info = {k: v for k, v in entry_data.items() if k != "tokens"}
         return await self.async_step_reauth_confirm()
 
-    async def async_step_reauth_confirm(self, user_input: dict[str, Any] | None = None):
+    async def async_step_reauth_confirm(self, user_input: dict[str, Any] | None = None) -> ConfigFlowResult:
         """Confirm re-authentication by re-running the authorization step."""
         return await self.async_step_auth(user_input)
 
-    async def async_step_reconfigure(self, user_input: dict[str, Any] | None = None):
+    async def async_step_reconfigure(self, user_input: dict[str, Any] | None = None) -> ConfigFlowResult:
         """Change the gateway / credentials of an existing entry, then re-authorize.
 
         The App ID is the entry's identity (unique_id) so it stays fixed; everything
@@ -114,7 +114,7 @@ class SungrowConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             ),
         )
 
-    async def async_step_user(self, user_input: dict[str, Any] | None = None):
+    async def async_step_user(self, user_input: dict[str, Any] | None = None) -> ConfigFlowResult:
         """Handle the initial step."""
         # Do not log user_input — it contains the app secret.
         _LOGGER.debug("async_step_user called (user_input provided: %s)", user_input is not None)
@@ -207,7 +207,8 @@ class SungrowConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         broke the token exchange, which uses the bare URI, with "invalid
         authentication".
         """
-        return self.init_info[CONF_REDIRECT_URI].rstrip("/")
+        # init_info is a dict[str, Any], so the redirect URI is typed as Any.
+        return cast(str, self.init_info[CONF_REDIRECT_URI]).rstrip("/")
 
     def _auth_url(self) -> str:
         """Build the iSolarCloud authorization URL for the canonical redirect URI.
@@ -218,9 +219,10 @@ class SungrowConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         per-flow ``flow_id`` that could go stale, so it stays valid for the whole
         flow and each visit yields a fresh authorization code from iSolarCloud.
         """
-        return self.auth_client.auth_url(self._redirect_uri())
+        # auth_client is the untyped pysolarcloud Auth, so auth_url returns Any.
+        return cast(str, self.auth_client.auth_url(self._redirect_uri()))
 
-    async def async_step_auth(self, user_input: dict[str, Any] | None = None):
+    async def async_step_auth(self, user_input: dict[str, Any] | None = None) -> ConfigFlowResult:
         """Begin authorization by automatically waiting for the OAuth redirect.
 
         No menu is shown: the callback listener starts immediately so the user
@@ -237,7 +239,7 @@ class SungrowConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         _ensure_callback_view_registered(self.hass)
         return await self.async_step_auth_callback()
 
-    async def async_step_auth_callback(self, user_input: dict[str, Any] | None = None):
+    async def async_step_auth_callback(self, user_input: dict[str, Any] | None = None) -> ConfigFlowResult:
         """Wait for iSolarCloud to redirect back to the callback endpoint.
 
         The callback view extracts the authorization code and calls
@@ -264,7 +266,7 @@ class SungrowConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             description_placeholders={"auth_url": auth_url},
         )
 
-    def _arm_callback_wait(self, *, fall_back_to_manual: bool) -> asyncio.Task:
+    def _arm_callback_wait(self, *, fall_back_to_manual: bool) -> asyncio.Task[None]:
         """Register a callback future and spawn a task that resumes the flow.
 
         Used by both the automatic progress step and the manual-entry form, so a
@@ -315,7 +317,7 @@ class SungrowConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         if isinstance(flows, dict):
             flows.pop(self.flow_id, None)
 
-    async def async_step_auth_manual(self, user_input: dict[str, Any] | None = None):
+    async def async_step_auth_manual(self, user_input: dict[str, Any] | None = None) -> ConfigFlowResult:
         """Handle manual entry of the authorization code or full redirect URL.
 
         Reached as a fallback when the automatic redirect does not complete, or
@@ -367,7 +369,7 @@ class SungrowConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             errors=errors,
         )
 
-    def _finish_error_result(self, error_key: str):
+    def _finish_error_result(self, error_key: str) -> ConfigFlowResult:
         """Return the manual code-entry form with an error so the user can retry.
 
         Both the automatic and manual paths land here on failure; showing the
@@ -381,7 +383,7 @@ class SungrowConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             errors={"base": error_key},
         )
 
-    async def async_step_finish(self, user_input: dict[str, Any] | None = None):
+    async def async_step_finish(self, user_input: dict[str, Any] | None = None) -> ConfigFlowResult:
         """Exchange the authorization code for tokens and create the config entry."""
 
         if not self._ensure_auth_client():
@@ -455,7 +457,7 @@ def _parse_extra_measure_points(raw: str | None) -> dict[str, str]:
 class SungrowOptionsFlow(config_entries.OptionsFlow):
     """Handle Sungrow integration options (e.g. polling interval)."""
 
-    async def async_step_init(self, user_input: dict[str, Any] | None = None):
+    async def async_step_init(self, user_input: dict[str, Any] | None = None) -> ConfigFlowResult:
         """Manage the integration options."""
         errors: dict[str, str] = {}
         if user_input is not None:

--- a/custom_components/sungrow/coordinator.py
+++ b/custom_components/sungrow/coordinator.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import logging
 from datetime import timedelta
+from typing import Any, cast
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
@@ -37,7 +38,7 @@ def is_auth_error(err: Exception) -> bool:
     return False
 
 
-class SungrowPlantCoordinator(DataUpdateCoordinator):
+class SungrowPlantCoordinator(DataUpdateCoordinator[dict[str, Any]]):
     """Coordinator to manage fetching data from a single plant."""
 
     def __init__(
@@ -47,7 +48,7 @@ class SungrowPlantCoordinator(DataUpdateCoordinator):
         plants_service: Plants,
         plant_id: str,
         plant_name: str,
-        devices: list[dict] | None = None,
+        devices: list[dict[str, Any]] | None = None,
     ) -> None:
         """Initialize the coordinator."""
         scan_seconds = config_entry.options.get(CONF_SCAN_INTERVAL, DEFAULT_SCAN_INTERVAL)
@@ -61,13 +62,13 @@ class SungrowPlantCoordinator(DataUpdateCoordinator):
         self.plants_service = plants_service
         self.plant_id = plant_id
         self.plant_name = plant_name
-        self.devices: list[dict] = list(devices or [])
+        self.devices: list[dict[str, Any]] = list(devices or [])
         self.extra_measure_points: dict[str, str] = dict(config_entry.options.get(CONF_EXTRA_MEASURE_POINTS, {}))
         self.enable_device_sensors: bool = bool(config_entry.options.get(CONF_ENABLE_DEVICE_SENSORS, False))
         # uuid -> { code: point } for per-device realtime (populated when enabled).
-        self.device_data: dict[str, dict] = {}
+        self.device_data: dict[str, dict[str, Any]] = {}
 
-    async def _async_update_data(self):
+    async def _async_update_data(self) -> dict[str, Any]:
         """Fetch data from the API for this plant."""
         try:
             # async_get_realtime_data returns a dict of plants keyed by plant_id:
@@ -88,7 +89,8 @@ class SungrowPlantCoordinator(DataUpdateCoordinator):
         if self.enable_device_sensors:
             self.device_data = await self._async_fetch_device_data()
 
-        return all_plants_data.get(self.plant_id, {})
+        # pysolarcloud is untyped, so the realtime payload is Any.
+        return cast("dict[str, Any]", all_plants_data.get(self.plant_id, {}))
 
     async def _async_refresh_devices(self) -> None:
         """Re-fetch the plant's device list (best effort, non-fatal)."""
@@ -100,7 +102,7 @@ class SungrowPlantCoordinator(DataUpdateCoordinator):
         # Mutate in place so holders of this list (runtime_data.devices) see updates.
         self.devices[:] = list(devices or [])
 
-    async def _async_fetch_device_data(self) -> dict[str, dict]:
+    async def _async_fetch_device_data(self) -> dict[str, dict[str, Any]]:
         """Fetch per-device realtime for each distinct device type (best effort).
 
         The plant realtime endpoint only returns the plant-level points, so devices
@@ -110,8 +112,8 @@ class SungrowPlantCoordinator(DataUpdateCoordinator):
         extra measure points are requested here too, so newly identified charger/meter
         point IDs surface without a code change.
         """
-        merged: dict[str, dict] = {}
-        seen_types: set = set()
+        merged: dict[str, dict[str, Any]] = {}
+        seen_types: set[Any] = set()
         for device in self.devices:
             device_type = device.get("device_type")
             if device_type is None:

--- a/custom_components/sungrow/diagnostics.py
+++ b/custom_components/sungrow/diagnostics.py
@@ -31,7 +31,7 @@ def _jsonable(obj: Any) -> Any:
     return obj
 
 
-async def _probe_plant_devices(service: Any, plant_id: str) -> tuple[list, dict]:
+async def _probe_plant_devices(service: Any, plant_id: str) -> tuple[list[dict[str, Any]], dict[str, Any]]:
     """Best-effort capture of every device and its per-device realtime data.
 
     Returns ``(all_devices, device_realtime)``. The plant realtime endpoint only
@@ -49,7 +49,7 @@ async def _probe_plant_devices(service: Any, plant_id: str) -> tuple[list, dict]
         return [{"error": str(err)}], {}
 
     device_realtime: dict[str, Any] = {}
-    seen_types: set = set()
+    seen_types: set[Any] = set()
     for device in all_devices:
         if not isinstance(device, dict):
             continue
@@ -84,7 +84,7 @@ async def async_get_config_entry_diagnostics(hass: HomeAssistant, entry: Sungrow
     for coordinator in coordinators:
         plant_id = coordinator.plant_id
         service = getattr(coordinator, "plants_service", None)
-        all_devices: list = []
+        all_devices: list[dict[str, Any]] = []
         device_realtime: dict[str, Any] = {}
         if service is not None:
             all_devices, device_realtime = await _probe_plant_devices(service, plant_id)

--- a/custom_components/sungrow/number.py
+++ b/custom_components/sungrow/number.py
@@ -4,12 +4,13 @@ from __future__ import annotations
 
 import logging
 import re
+from typing import Any
 
 from homeassistant.components.number import NumberDeviceClass, NumberEntity, NumberMode
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.exceptions import HomeAssistantError
-from homeassistant.helpers.entity import DeviceInfo
+from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 from pysolarcloud import PySolarCloudException
@@ -36,7 +37,7 @@ DEFAULT_MAX_DISPATCH_POWER = 5000
 _MODEL_POWER_RE = re.compile(r"S[GH](\d+(?:\.\d+)?)", re.IGNORECASE)
 
 
-def rated_power_w(device: dict) -> int | None:
+def rated_power_w(device: dict[str, Any]) -> int | None:
     """Best-effort rated power in watts parsed from a device's model code.
 
     Returns ``None`` when no rating can be parsed, so callers fall back to the
@@ -56,7 +57,7 @@ def rated_power_w(device: dict) -> int | None:
 
 # Number parameters exposed as HA Number entities.
 # Keys are canonical Control parameter names; values describe the HA entity.
-DISPATCH_NUMBERS: dict[str, dict] = {
+DISPATCH_NUMBERS: dict[str, dict[str, Any]] = {
     "charge_discharge_power": {
         "device_class": NumberDeviceClass.POWER,
         "native_unit_of_measurement": "W",
@@ -92,7 +93,7 @@ DISPATCH_NUMBERS: dict[str, dict] = {
 }
 
 
-def _build_numbers(coordinator, control) -> list[NumberEntity]:
+def _build_numbers(coordinator: SungrowPlantCoordinator, control: Control) -> list[NumberEntity]:
     """Build the dispatch number entities for a coordinator's target device.
 
     Returns an empty list when no dispatch-capable device is present. Reads the
@@ -156,7 +157,7 @@ class SungrowDispatchNumber(CoordinatorEntity[SungrowPlantCoordinator], NumberEn
         device_uuid: str,
         device_name: str,
         param: str,
-        meta: dict,
+        meta: dict[str, Any],
     ) -> None:
         """Initialize the dispatch number."""
         super().__init__(coordinator)

--- a/custom_components/sungrow/quality_scale.yaml
+++ b/custom_components/sungrow/quality_scale.yaml
@@ -148,7 +148,12 @@ rules:
   reconfiguration-flow:
     status: done
   repair-issues:
-    status: todo
+    status: exempt
+    comment: >-
+      The only user-actionable failure is invalid/expired credentials, which is
+      surfaced through the reauthentication flow (ConfigEntryAuthFailed ->
+      async_step_reauth). No other persistent, user-fixable condition exists that
+      a separate repair issue would address.
   stale-devices:
     status: done
     comment: >-
@@ -163,5 +168,7 @@ rules:
     status: done
     comment: The Home Assistant aiohttp client session is injected into the API client.
   strict-typing:
-    status: todo
-    comment: mypy runs in CI (check_untyped_defs) but not yet in strict mode.
+    status: done
+    comment: >-
+      mypy runs in --strict mode (strict = true in pyproject) and the package
+      ships a py.typed marker.

--- a/custom_components/sungrow/select.py
+++ b/custom_components/sungrow/select.py
@@ -3,12 +3,13 @@
 from __future__ import annotations
 
 import logging
+from typing import Any
 
 from homeassistant.components.select import SelectEntity
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.exceptions import HomeAssistantError
-from homeassistant.helpers.entity import DeviceInfo
+from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 from pysolarcloud import PySolarCloudException
@@ -24,7 +25,7 @@ _LOGGER = logging.getLogger(__name__)
 PARALLEL_UPDATES = 1
 
 # Select parameters exposed as HA Select entities.
-DISPATCH_SELECTS: dict[str, dict] = {
+DISPATCH_SELECTS: dict[str, dict[str, Any]] = {
     "charge_discharge_command": {
         "options_map": {
             "Stop": Control.CHARGE_DISCHARGE_COMMANDS["stop"],
@@ -41,7 +42,7 @@ DISPATCH_SELECTS: dict[str, dict] = {
 }
 
 
-def _build_selects(coordinator, control) -> list[SelectEntity]:
+def _build_selects(coordinator: SungrowPlantCoordinator, control: Control) -> list[SelectEntity]:
     """Build the dispatch select entities for a coordinator's target device.
 
     Returns an empty list when no dispatch-capable device is present. Reads the
@@ -100,7 +101,7 @@ class SungrowDispatchSelect(CoordinatorEntity[SungrowPlantCoordinator], SelectEn
         device_uuid: str,
         device_name: str,
         param: str,
-        meta: dict,
+        meta: dict[str, Any],
     ) -> None:
         """Initialize the dispatch select."""
         super().__init__(coordinator)

--- a/custom_components/sungrow/sensor.py
+++ b/custom_components/sungrow/sensor.py
@@ -1,16 +1,17 @@
 from __future__ import annotations
 
 import logging
+from typing import Any, cast
 
 from homeassistant.components.sensor import SensorDeviceClass, SensorEntity, SensorStateClass
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant, callback
-from homeassistant.helpers.device_registry import DeviceEntryType
-from homeassistant.helpers.entity import DeviceInfo
+from homeassistant.helpers.device_registry import DeviceEntryType, DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from .const import CONF_GATEWAY, DEFAULT_CONSOLE_URL, DOMAIN, GATEWAY_CONSOLE_URLS
+from .coordinator import SungrowPlantCoordinator
 
 # Sensors are read-only and updated in bulk by the coordinator, so no per-entity
 # write parallelism limit is needed.
@@ -111,7 +112,7 @@ def infer_device_class(unit: str | None, point_code: str) -> tuple[SensorDeviceC
     return None, None
 
 
-def _build_sensors(coordinator, console_url) -> list[SungrowSensor]:
+def _build_sensors(coordinator: SungrowPlantCoordinator, console_url: str) -> list[SungrowSensor]:
     """Build the full set of sensors the coordinator currently warrants.
 
     Called both at setup and on every coordinator update, so points/devices that
@@ -186,7 +187,15 @@ class SungrowSensor(CoordinatorEntity, SensorEntity):
 
     has_entity_name = True
 
-    def __init__(self, coordinator, point_code, plant_id, plant_name, init_data, console_url=DEFAULT_CONSOLE_URL):
+    def __init__(
+        self,
+        coordinator: SungrowPlantCoordinator,
+        point_code: str,
+        plant_id: str,
+        plant_name: str,
+        init_data: dict[str, Any],
+        console_url: str = DEFAULT_CONSOLE_URL,
+    ) -> None:
         """Initialize the sensor."""
         super().__init__(coordinator)
         self.point_code = point_code
@@ -203,7 +212,7 @@ class SungrowSensor(CoordinatorEntity, SensorEntity):
         )
         self._apply_point_metadata(point_code, init_data, plant_name)
 
-    def _apply_point_metadata(self, point_code, init_data, label):
+    def _apply_point_metadata(self, point_code: str, init_data: dict[str, Any], label: str) -> None:
         """Set the name, unit and device/state class from a point payload.
 
         Shared by plant-level and per-device sensors so both name and classify points
@@ -241,28 +250,30 @@ class SungrowSensor(CoordinatorEntity, SensorEntity):
         # the solar panel icon only for unclassified sensors.
         self._attr_icon = None if device_class else "mdi:solar-power-variant"
 
-    def _current_point(self):
+    def _current_point(self) -> dict[str, Any] | None:
         """Return the current point payload for this sensor (plant-level source)."""
         data = self.coordinator.data
         if data and self.point_code in data:
-            return data[self.point_code]
+            point: dict[str, Any] = data[self.point_code]
+            return point
         return None
 
     @property
-    def native_value(self):
+    def native_value(self) -> float | str | None:
         """Return the state of the sensor."""
         point = self._current_point()
         if point is None:
             return None
-        val = point.get("value")
+        val: Any = point.get("value")
         # Convert to float if it looks numeric but is a string.
         try:
             return float(val)
         except (ValueError, TypeError):
-            return val
+            # point payload values are untyped (Any) upstream.
+            return cast("str | None", val)
 
     @property
-    def extra_state_attributes(self):
+    def extra_state_attributes(self) -> dict[str, Any]:
         """Return attributes."""
         return self._current_point() or {}
 
@@ -274,7 +285,15 @@ class SungrowDeviceSensor(SungrowSensor):
     device, linked to the plant device via ``via_device`` (issue #74).
     """
 
-    def __init__(self, coordinator, point_code, plant_id, device_uuid, device_name, init_data):
+    def __init__(
+        self,
+        coordinator: SungrowPlantCoordinator,
+        point_code: str,
+        plant_id: str,
+        device_uuid: str,
+        device_name: str,
+        init_data: dict[str, Any],
+    ) -> None:
         """Initialize a device-scoped sensor."""
         # Skip SungrowSensor.__init__ (it builds the plant device); reuse the shared
         # metadata helper but with a device-scoped identity and data source.
@@ -291,7 +310,8 @@ class SungrowDeviceSensor(SungrowSensor):
         )
         self._apply_point_metadata(point_code, init_data, device_name)
 
-    def _current_point(self):
+    def _current_point(self) -> dict[str, Any] | None:
         """Return the current point payload from the coordinator's per-device data."""
         device_data = getattr(self.coordinator, "device_data", None) or {}
-        return device_data.get(self.device_uuid, {}).get(self.point_code)
+        point: dict[str, Any] | None = device_data.get(self.device_uuid, {}).get(self.point_code)
+        return point

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,6 +45,7 @@ ignore = ["E501"]
 
 [tool.mypy]
 python_version = "3.13"
+strict = true
 ignore_missing_imports = true
 check_untyped_defs = true
 # Scope to our own package; Home Assistant is imported for types only.


### PR DESCRIPTION
## Summary
Final quality-scale bucket — **strict-typing** (Platinum).

- **`mypy --strict` now passes** (64 findings cleared, annotations only — no behaviour change). Enabled via `strict = true` in `pyproject.toml` `[tool.mypy]`, so the existing CI `mypy` step runs strict automatically.
- **Ships `py.typed`** so the package is distributed as typed.
- Annotated entity classes, the coordinator (`DataUpdateCoordinator[dict[str, Any]]`), config flow, diagnostics, auth and `__init__`; filled generic type args; `cast` at the untyped `pysolarcloud` boundary; imported `DeviceInfo`/`HomeAssistantView` from their canonical export modules (verified same runtime classes).

Self-assessment flips:
- `strict-typing` → **done**
- `repair-issues` → **exempt** (only user-actionable failure is bad credentials, handled by the reauth flow)

## Verification
```
mypy --strict   Success: no issues found in 9 source files
mypy (CI)       Success: no issues found in 9 source files
ruff check      All checks passed!
ruff format     21 files already formatted
pytest          152 passed, 2 deselected
```

> Note: `manifest.json` stays at `quality_scale: silver` for now — a follow-up will address the audit findings below before declaring Gold.

## ⚠️ Not included — audit follow-ups
A separate review against the HA developer docs surfaced items to address before bumping the manifest to Gold (reauth account-mismatch guard, stale-device auto-pruning, entity-category on config controls, RestoreEntity for dispatch). Tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)