### PR TITLE
feat: harden to Gold — address HA docs audit findings

### DIFF
--- a/custom_components/sungrow/__init__.py
+++ b/custom_components/sungrow/__init__.py
@@ -12,10 +12,10 @@ import voluptuous as vol
 from aiohttp import web
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import Platform
-from homeassistant.core import HomeAssistant
+from homeassistant.core import HomeAssistant, callback
 from homeassistant.exceptions import ConfigEntryAuthFailed, ConfigEntryNotReady
+from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
-from homeassistant.helpers.device_registry import DeviceEntry
 from homeassistant.helpers.http import HomeAssistantView
 from pysolarcloud.control import Control
 from pysolarcloud.plants import DeviceType, Plants
@@ -195,6 +195,14 @@ async def async_setup_entry(hass: HomeAssistant, entry: SungrowConfigEntry) -> b
 
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
 
+    # Prune devices that drop out of the API after each refresh (stale-devices).
+    @callback
+    def _prune() -> None:
+        _async_prune_stale_devices(hass, entry)
+
+    for coordinator in coordinators:
+        entry.async_on_unload(coordinator.async_add_listener(_prune))
+
     # Reload the entry when its options (e.g. scan interval) change.
     entry.async_on_unload(entry.add_update_listener(async_reload_entry))
 
@@ -216,23 +224,50 @@ async def async_reload_entry(hass: HomeAssistant, entry: SungrowConfigEntry) -> 
     await hass.config_entries.async_reload(entry.entry_id)
 
 
-async def async_remove_config_entry_device(
-    hass: HomeAssistant, config_entry: SungrowConfigEntry, device_entry: DeviceEntry
-) -> bool:
-    """Allow deletion of a device the API no longer reports (stale-devices).
+def _known_device_ids(entry: SungrowConfigEntry) -> set[tuple[str, str]]:
+    """Return the device-registry identifiers currently reported by the API.
 
-    Returns True (permit removal) only when none of the device's identifiers match
-    a currently-known plant or device across the entry's coordinators, so devices
-    that are still present cannot be removed by accident.
+    One per plant (the plant device) plus one per device the coordinators have
+    seen on their latest poll. Used to distinguish live devices from stale ones.
     """
     known: set[tuple[str, str]] = set()
-    for coordinator in config_entry.runtime_data.coordinators:
+    for coordinator in entry.runtime_data.coordinators:
         known.add((DOMAIN, coordinator.plant_id))
         for device in coordinator.devices:
             uuid = device.get("uuid")
             if uuid:
                 known.add((DOMAIN, str(uuid)))
+    return known
+
+
+async def async_remove_config_entry_device(
+    hass: HomeAssistant, config_entry: SungrowConfigEntry, device_entry: dr.DeviceEntry
+) -> bool:
+    """Allow deletion of a device the API no longer reports (stale-devices).
+
+    Returns True (permit removal) only when none of the device's identifiers match
+    a currently-known plant or device, so devices that are still present cannot be
+    removed by accident.
+    """
+    known = _known_device_ids(config_entry)
     return not any(identifier in known for identifier in device_entry.identifiers)
+
+
+@callback
+def _async_prune_stale_devices(hass: HomeAssistant, entry: SungrowConfigEntry) -> None:
+    """Remove device-registry entries the API no longer reports (stale-devices).
+
+    Runs after each coordinator refresh. A device is removed only when none of its
+    identifiers are in the freshly-fetched device list. Because a failed device
+    fetch keeps the previous list (see the coordinator), a transient API outage
+    can't trigger spurious removals.
+    """
+    known = _known_device_ids(entry)
+    registry = dr.async_get(hass)
+    for device in dr.async_entries_for_config_entry(registry, entry.entry_id):
+        if any(identifier in known for identifier in device.identifiers):
+            continue
+        registry.async_update_device(device.id, remove_config_entry_id=entry.entry_id)
 
 
 async def _stop_heartbeat(heartbeat: tuple[asyncio.Event, asyncio.Task[None]]) -> None:

--- a/custom_components/sungrow/config_flow.py
+++ b/custom_components/sungrow/config_flow.py
@@ -412,6 +412,10 @@ class SungrowConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             data = {**self.init_info, "tokens": tokens}
 
             if self._reauth_entry is not None:
+                # Guard against re-authorizing/reconfiguring onto a different account:
+                # the App ID is the entry's identity, so it must not change.
+                await self.async_set_unique_id(str(self.init_info[CONF_APP_ID]))
+                self._abort_if_unique_id_mismatch(reason="wrong_account")
                 reason = "reconfigure_successful" if self._is_reconfigure else "reauth_successful"
                 return self.async_update_reload_and_abort(self._reauth_entry, data=data, reason=reason)
 

--- a/custom_components/sungrow/manifest.json
+++ b/custom_components/sungrow/manifest.json
@@ -15,7 +15,7 @@
   "loggers": [
     "pysolarcloud"
   ],
-  "quality_scale": "silver",
+  "quality_scale": "gold",
   "requirements": [
     "sungrow-isolarcloud==0.6.0"
   ],

--- a/custom_components/sungrow/number.py
+++ b/custom_components/sungrow/number.py
@@ -6,8 +6,9 @@ import logging
 import re
 from typing import Any
 
-from homeassistant.components.number import NumberDeviceClass, NumberEntity, NumberMode
+from homeassistant.components.number import NumberDeviceClass, NumberEntity, NumberMode, RestoreNumber
 from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import EntityCategory
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.device_registry import DeviceInfo
@@ -73,6 +74,8 @@ DISPATCH_NUMBERS: dict[str, dict[str, Any]] = {
         "native_max_value": 100,
         "native_step": 1,
         "mode": NumberMode.SLIDER,
+        # SOC limits set battery policy rather than actuate — configuration entities.
+        "entity_category": EntityCategory.CONFIG,
     },
     "soc_lower_limit": {
         "device_class": NumberDeviceClass.BATTERY,
@@ -81,6 +84,7 @@ DISPATCH_NUMBERS: dict[str, dict[str, Any]] = {
         "native_max_value": 50,
         "native_step": 1,
         "mode": NumberMode.SLIDER,
+        "entity_category": EntityCategory.CONFIG,
     },
     "forced_charging_target_soc_1": {
         "device_class": NumberDeviceClass.BATTERY,
@@ -89,6 +93,7 @@ DISPATCH_NUMBERS: dict[str, dict[str, Any]] = {
         "native_max_value": 100,
         "native_step": 1,
         "mode": NumberMode.SLIDER,
+        "entity_category": EntityCategory.CONFIG,
     },
 }
 
@@ -145,7 +150,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry, async_add_e
         entry.async_on_unload(coordinator.async_add_listener(_add_new_entities))
 
 
-class SungrowDispatchNumber(CoordinatorEntity[SungrowPlantCoordinator], NumberEntity):
+class SungrowDispatchNumber(CoordinatorEntity[SungrowPlantCoordinator], RestoreNumber):
     """Number entity for a Sungrow dispatch parameter."""
 
     _attr_has_entity_name = True
@@ -180,16 +185,18 @@ class SungrowDispatchNumber(CoordinatorEntity[SungrowPlantCoordinator], NumberEn
         self._attr_native_max_value = meta["native_max_value"]
         self._attr_native_step = meta["native_step"]
         self._attr_mode = meta["mode"]
+        self._attr_entity_category = meta.get("entity_category")
 
-    @property
-    def native_value(self) -> float | None:
-        """Return the current parameter value.
+    async def async_added_to_hass(self) -> None:
+        """Restore the last commanded value across restarts.
 
-        Dispatch parameters are write-only here (not polled back from the API),
-        so there is no meaningful value to report. Availability is inherited from
-        CoordinatorEntity (tracks ``coordinator.last_update_success``).
+        Dispatch parameters are write-only (not polled back from the API), so the
+        last value the user set is restored from state rather than fetched.
         """
-        return None
+        await super().async_added_to_hass()
+        last = await self.async_get_last_number_data()
+        if last is not None and last.native_value is not None:
+            self._attr_native_value = last.native_value
 
     async def async_set_native_value(self, value: float) -> None:
         """Update the dispatch parameter on the inverter."""
@@ -202,6 +209,8 @@ class SungrowDispatchNumber(CoordinatorEntity[SungrowPlantCoordinator], NumberEn
                 translation_key="dispatch_write_failed",
                 translation_placeholders={"param": self.param, "error": str(err)},
             ) from err
+        # Remember the commanded value so the UI reflects it and it survives restarts.
+        self._attr_native_value = value
         # If the user is actively dispatching, ensure a heartbeat is running so the
         # inverter stays in External EMS mode.
         if self.param == "charge_discharge_power":

--- a/custom_components/sungrow/quality_scale.yaml
+++ b/custom_components/sungrow/quality_scale.yaml
@@ -1,9 +1,9 @@
 # Home Assistant Integration Quality Scale — self-assessment.
 #
 # Note: hassfest only *validates* this file for core integrations; for a custom
-# (HACS) integration it is an honest status record and roadmap. The integration
-# currently meets the Bronze and Silver tiers (and already satisfies several Gold
-# and Platinum rules).
+# (HACS) integration it is an honest status record. Every Bronze, Silver and Gold
+# rule is done or exempt, and all three Platinum rules (async-dependency,
+# inject-websession, strict-typing) are met. The manifest declares "gold".
 rules:
   # --- Bronze ---
   action-setup:
@@ -118,12 +118,11 @@ rules:
       and dispatch platforms add entities for devices/points that appear after
       setup via a coordinator listener.
   entity-category:
-    status: exempt
+    status: done
     comment: >-
-      All entities are primary function: plant/device measurements (sensors) and
-      the active dispatch controls (number/select). None are auxiliary config or
-      diagnostic entities, and the sensor set is dynamic from the API, so no
-      entity warrants a config/diagnostic category.
+      The SOC-limit numbers and the forced-charging select are
+      EntityCategory.CONFIG (they set battery policy); the active charge/discharge
+      controls and all plant/device sensors are primary function.
   entity-device-class:
     status: done
   entity-disabled-by-default:
@@ -157,8 +156,9 @@ rules:
   stale-devices:
     status: done
     comment: >-
-      async_remove_config_entry_device lets the user delete a device once the API
-      no longer reports it; devices still present are protected.
+      Devices that disappear from the API are pruned from the device registry
+      automatically after each refresh (_async_prune_stale_devices);
+      async_remove_config_entry_device remains as the manual fallback.
 
   # --- Platinum ---
   async-dependency:

--- a/custom_components/sungrow/select.py
+++ b/custom_components/sungrow/select.py
@@ -7,10 +7,12 @@ from typing import Any
 
 from homeassistant.components.select import SelectEntity
 from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import EntityCategory
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.restore_state import RestoreEntity
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 from pysolarcloud import PySolarCloudException
 from pysolarcloud.control import Control
@@ -38,6 +40,8 @@ DISPATCH_SELECTS: dict[str, dict[str, Any]] = {
             "Disable": Control.FORCED_CHARGING["disable"],
             "Enable": Control.FORCED_CHARGING["enable"],
         },
+        # Enabling/disabling forced charging is a policy setting, not actuation.
+        "entity_category": EntityCategory.CONFIG,
     },
 }
 
@@ -89,7 +93,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry, async_add_e
         entry.async_on_unload(coordinator.async_add_listener(_add_new_entities))
 
 
-class SungrowDispatchSelect(CoordinatorEntity[SungrowPlantCoordinator], SelectEntity):
+class SungrowDispatchSelect(CoordinatorEntity[SungrowPlantCoordinator], RestoreEntity, SelectEntity):
     """Select entity for a Sungrow dispatch parameter."""
 
     _attr_has_entity_name = True
@@ -122,16 +126,18 @@ class SungrowDispatchSelect(CoordinatorEntity[SungrowPlantCoordinator], SelectEn
             via_device=(DOMAIN, coordinator.plant_id),
         )
         self._attr_options = list(self.options_map.keys())
+        self._attr_entity_category = meta.get("entity_category")
 
-    @property
-    def current_option(self) -> str | None:
-        """Return the current option.
+    async def async_added_to_hass(self) -> None:
+        """Restore the last selected option across restarts.
 
         Dispatch commands are write-only (not polled back from the API), so the
-        current option is unknown. Availability is inherited from
-        CoordinatorEntity (tracks ``coordinator.last_update_success``).
+        last option the user chose is restored from state rather than fetched.
         """
-        return None
+        await super().async_added_to_hass()
+        last = await self.async_get_last_state()
+        if last is not None and last.state in self.options_map:
+            self._attr_current_option = last.state
 
     async def async_select_option(self, option: str) -> None:
         """Update the dispatch parameter on the inverter."""
@@ -145,6 +151,8 @@ class SungrowDispatchSelect(CoordinatorEntity[SungrowPlantCoordinator], SelectEn
                 translation_key="dispatch_write_failed",
                 translation_placeholders={"param": self.param, "error": str(err)},
             ) from err
+        # Remember the selected option so the UI reflects it and it survives restarts.
+        self._attr_current_option = option
 
         # Keep the inverter in dispatch mode while actively charging/discharging.
         entry = self.coordinator.config_entry

--- a/custom_components/sungrow/strings.json
+++ b/custom_components/sungrow/strings.json
@@ -53,7 +53,8 @@
       "library_missing": "The pysolarcloud library is not installed. Restart Home Assistant so the integration's requirements are installed, then try again.",
       "missing_code": "Authorization code was not received. Please try again.",
       "reauth_successful": "Re-authentication was successful",
-      "reconfigure_successful": "Reconfiguration was successful"
+      "reconfigure_successful": "Reconfiguration was successful",
+      "wrong_account": "The authorized account does not match this integration's App ID. Use the original developer application."
     }
   },
   "options": {

--- a/custom_components/sungrow/translations/en.json
+++ b/custom_components/sungrow/translations/en.json
@@ -53,7 +53,8 @@
       "library_missing": "The pysolarcloud library is not installed. Restart Home Assistant so the integration's requirements are installed, then try again.",
       "missing_code": "Authorization code was not received. Please try again.",
       "reauth_successful": "Re-authentication was successful",
-      "reconfigure_successful": "Reconfiguration was successful"
+      "reconfigure_successful": "Reconfiguration was successful",
+      "wrong_account": "The authorized account does not match this integration's App ID. Use the original developer application."
     }
   },
   "options": {

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -137,6 +137,25 @@ async def test_reauth_completes_with_manual_code(hass: HomeAssistant, mock_auth)
     assert entry.data["tokens"]["access_token"] == "fresh_token"
 
 
+async def test_reauth_wrong_account_aborts(hass: HomeAssistant, mock_auth):
+    """Re-authorizing when the App ID no longer matches the entry aborts (wrong account)."""
+    # unique_id is the App ID; construct an entry whose stored App ID diverges from it.
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={**MOCK_CONFIG_DATA, CONF_APP_ID: "a_different_app"},
+        unique_id="test_app_id",
+    )
+    entry.add_to_hass(hass)
+    flow_id = await _reauth_to_manual(hass, entry)
+
+    mock_auth.tokens = {"access_token": "t", "refresh_token": "r", "expires_at": 9999999999}
+    result = await hass.config_entries.flow.async_configure(flow_id, user_input={"code": "c"})
+    await hass.async_block_till_done()
+
+    assert result["type"] == data_entry_flow.FlowResultType.ABORT
+    assert result["reason"] == "wrong_account"
+
+
 async def test_reauth_extracts_code_from_url(hass: HomeAssistant, mock_auth):
     """Pasting a full callback URL extracts the code automatically."""
     entry = _hub_entry(hass)

--- a/tests/test_dispatch.py
+++ b/tests/test_dispatch.py
@@ -379,6 +379,88 @@ async def test_charge_power_max_falls_back_to_default(hass: HomeAssistant):
 
 
 # ---------------------------------------------------------------------------
+# Entity categories + state restoration
+# ---------------------------------------------------------------------------
+
+
+async def test_number_config_entities_have_category(hass: HomeAssistant):
+    """SOC / forced-charging numbers are config entities; charge power is primary."""
+    from homeassistant.const import EntityCategory
+
+    entry = MockConfigEntry(domain=DOMAIN, data=MOCK_CONFIG_DATA.copy())
+    entry.add_to_hass(hass)
+    _setup_entry_data(entry, [{"uuid": "ess-1", "device_type": "ENERGY_STORAGE_SYSTEM"}])
+
+    added = []
+    await number_setup_entry(hass, entry, lambda entities: added.extend(entities))
+    cats = {e.param: e._attr_entity_category for e in added}
+
+    assert cats["charge_discharge_power"] is None
+    assert cats["soc_upper_limit"] == EntityCategory.CONFIG
+    assert cats["soc_lower_limit"] == EntityCategory.CONFIG
+    assert cats["forced_charging_target_soc_1"] == EntityCategory.CONFIG
+
+
+async def test_select_forced_charging_is_config(hass: HomeAssistant):
+    """The forced-charging select is a config entity; the command select is primary."""
+    from homeassistant.const import EntityCategory
+
+    entry = MockConfigEntry(domain=DOMAIN, data=MOCK_CONFIG_DATA.copy())
+    entry.add_to_hass(hass)
+    _setup_entry_data(entry, [{"uuid": "ess-1", "device_type": "ENERGY_STORAGE_SYSTEM"}])
+
+    added = []
+    await select_setup_entry(hass, entry, lambda entities: added.extend(entities))
+    cats = {e.param: e._attr_entity_category for e in added}
+
+    assert cats["charge_discharge_command"] is None
+    assert cats["forced_charging"] == EntityCategory.CONFIG
+
+
+async def test_number_restores_last_value(hass: HomeAssistant):
+    """The last commanded number value is restored across a restart."""
+    from types import SimpleNamespace
+
+    from homeassistant.helpers.update_coordinator import CoordinatorEntity
+
+    entry = MockConfigEntry(domain=DOMAIN, data=MOCK_CONFIG_DATA.copy())
+    entry.add_to_hass(hass)
+    _setup_entry_data(entry, [{"uuid": "ess-1", "device_type": "ENERGY_STORAGE_SYSTEM"}])
+
+    added = []
+    await number_setup_entry(hass, entry, lambda entities: added.extend(entities))
+    power = next(e for e in added if e.param == "charge_discharge_power")
+    power.hass = hass
+    power.async_get_last_number_data = AsyncMock(return_value=SimpleNamespace(native_value=1234.0))
+
+    with patch.object(CoordinatorEntity, "async_added_to_hass", new=AsyncMock()):
+        await power.async_added_to_hass()
+
+    assert power.native_value == 1234.0
+
+
+async def test_select_restores_last_option(hass: HomeAssistant):
+    """The last selected option is restored across a restart."""
+    from homeassistant.core import State
+    from homeassistant.helpers.update_coordinator import CoordinatorEntity
+
+    entry = MockConfigEntry(domain=DOMAIN, data=MOCK_CONFIG_DATA.copy())
+    entry.add_to_hass(hass)
+    _setup_entry_data(entry, [{"uuid": "ess-1", "device_type": "ENERGY_STORAGE_SYSTEM"}])
+
+    added = []
+    await select_setup_entry(hass, entry, lambda entities: added.extend(entities))
+    command = next(e for e in added if e.param == "charge_discharge_command")
+    command.hass = hass
+    command.async_get_last_state = AsyncMock(return_value=State("select.x", "Charge"))
+
+    with patch.object(CoordinatorEntity, "async_added_to_hass", new=AsyncMock()):
+        await command.async_added_to_hass()
+
+    assert command.current_option == "Charge"
+
+
+# ---------------------------------------------------------------------------
 # Dynamic devices (dispatch controls appear at runtime)
 # ---------------------------------------------------------------------------
 

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -277,6 +277,32 @@ async def test_async_remove_config_entry_device(hass: HomeAssistant):
     assert await async_remove_config_entry_device(hass, entry, gone) is True
 
 
+async def test_prune_stale_devices(hass: HomeAssistant):
+    """Devices no longer reported by the API are pruned; present ones are kept."""
+    from homeassistant.helpers import device_registry as dr
+
+    from custom_components.sungrow import _async_prune_stale_devices
+
+    entry = MockConfigEntry(domain=DOMAIN, data=MOCK_CONFIG_DATA.copy(), unique_id="test_app_id")
+    entry.add_to_hass(hass)
+    coordinator = MagicMock()
+    coordinator.plant_id = "12345"
+    coordinator.devices = [{"uuid": "live-dev"}]
+    entry.runtime_data = SungrowData(coordinators=[coordinator], control=MagicMock(), devices={})
+
+    registry = dr.async_get(hass)
+    plant = registry.async_get_or_create(config_entry_id=entry.entry_id, identifiers={(DOMAIN, "12345")})
+    live = registry.async_get_or_create(config_entry_id=entry.entry_id, identifiers={(DOMAIN, "live-dev")})
+    stale = registry.async_get_or_create(config_entry_id=entry.entry_id, identifiers={(DOMAIN, "old-dev")})
+
+    _async_prune_stale_devices(hass, entry)
+
+    # Plant device and the live device remain; the stale device is removed.
+    assert registry.async_get(plant.id) is not None
+    assert registry.async_get(live.id) is not None
+    assert registry.async_get(stale.id) is None
+
+
 async def test_options_change_reloads_entry(hass: HomeAssistant, mock_setup_auth, mock_plants_service):
     """Updating options should reload the entry and apply the new scan interval."""
     entry = MockConfigEntry(domain=DOMAIN, data=MOCK_CONFIG_DATA.copy(), unique_id="test_app_id")


### PR DESCRIPTION
## Summary
Follow-up to the Home Assistant developer-docs audit. Implements the four selected findings, bringing the integration to a legitimate **Gold** self-assessment (manifest bumped `silver` → `gold`).

| Finding | Fix |
| --- | --- |
| **Reauth/reconfigure account guard** | `async_step_finish` sets `unique_id` from the re-supplied App ID and calls `_abort_if_unique_id_mismatch(reason="wrong_account")` before updating the entry (required by the reauth & reconfigure rules) |
| **stale-devices auto-prune** | Devices that drop out of the API are pruned from the device registry automatically after each refresh (`_async_prune_stale_devices`); a failed device fetch keeps the previous list, so a transient outage can't trigger spurious removals. Manual removal stays as fallback |
| **RestoreEntity for dispatch** | Number/select restore the last commanded value/option across restarts (the API doesn't echo them back), so the UI isn't blank |
| **entity-category** | SOC-limit numbers + forced-charging select are `EntityCategory.CONFIG`; active charge/discharge controls stay primary |

`quality_scale.yaml`: `entity-category` → done, `stale-devices` comment updated, header refreshed.

## Tests
New coverage for: `wrong_account` abort, stale-device pruning (stale removed / live + plant kept), value & option restoration, and entity categories. Full suite **158 passed**, coverage **97%**, `mypy --strict` clean, ruff clean.

## Tier status
With this merged, **every Bronze/Silver/Gold rule is done or exempt**. All three **Platinum** rules (`async-dependency`, `inject-websession`, `strict-typing`) are also met — so the manifest *could* go to `platinum`. I set it to **`gold`** as the conservative claim; say the word and I'll bump it to `platinum`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)