### PR TITLE
fix: audit cleanups — sensor coercion, attributes, reauth helper

### DIFF
--- a/custom_components/sungrow/config_flow.py
+++ b/custom_components/sungrow/config_flow.py
@@ -70,7 +70,7 @@ class SungrowConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
     async def async_step_reauth(self, entry_data: dict[str, Any]) -> ConfigFlowResult:
         """Handle re-authentication when the stored tokens are no longer valid."""
-        self._reauth_entry = self.hass.config_entries.async_get_entry(self.context["entry_id"])
+        self._reauth_entry = self._get_reauth_entry()
         # Reuse the credentials already stored on the entry; only the tokens are stale.
         self.init_info = {k: v for k, v in entry_data.items() if k != "tokens"}
         return await self.async_step_reauth_confirm()

--- a/custom_components/sungrow/sensor.py
+++ b/custom_components/sungrow/sensor.py
@@ -265,17 +265,18 @@ class SungrowSensor(CoordinatorEntity, SensorEntity):
         if point is None:
             return None
         val: Any = point.get("value")
-        # Convert to float if it looks numeric but is a string.
+        if val is None:
+            return None
+        # Only coerce to a number for sensors classified as numeric (a device or
+        # state class). Unclassified text/status points are left as strings so a
+        # status like "1" or a boolean isn't silently turned into a float.
+        if self._attr_device_class is None and self._attr_state_class is None:
+            return str(val)
         try:
             return float(val)
         except (ValueError, TypeError):
             # point payload values are untyped (Any) upstream.
             return cast("str | None", val)
-
-    @property
-    def extra_state_attributes(self) -> dict[str, Any]:
-        """Return attributes."""
-        return self._current_point() or {}
 
 
 class SungrowDeviceSensor(SungrowSensor):

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -209,20 +209,23 @@ class TestSungrowSensor:
 
         assert sensor.native_value is None
 
-    def test_extra_state_attributes(self):
-        """Test extra_state_attributes returns the full data point dict."""
+    def test_native_value_unclassified_numeric_stays_string(self):
+        """A numeric-looking status point without a class is not coerced to a float."""
+        data = {"status": {"code": "status", "value": "1", "unit": "", "name": "Status"}}
+        coordinator = self._make_coordinator(data)
+        sensor = SungrowSensor(coordinator, "status", "123", "Plant", data["status"])
+
+        # No unit -> no device/state class -> left as a string, not 1.0.
+        assert sensor.native_value == "1"
+        assert isinstance(sensor.native_value, str)
+
+    def test_no_raw_extra_state_attributes(self):
+        """The raw API point payload is not exposed as state attributes (recorder bloat)."""
         point_data = {"code": "power", "value": "5.0", "unit": "kW", "name": "Power"}
         coordinator = self._make_coordinator({"power": point_data})
         sensor = SungrowSensor(coordinator, "power", "123", "Plant", point_data)
 
-        assert sensor.extra_state_attributes == point_data
-
-    def test_extra_state_attributes_empty_when_missing(self):
-        """Test extra_state_attributes returns {} when data is missing."""
-        coordinator = self._make_coordinator({})
-        sensor = SungrowSensor(coordinator, "x", "123", "Plant", {"value": "0"})
-
-        assert sensor.extra_state_attributes == {}
+        assert sensor.extra_state_attributes is None
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
The three non-blocking polish items from the HA docs audit. **Closes #98.**

- **`native_value` coercion guard** — no longer `float()`-coerces points that have neither a device class nor a state class. Plain text/status points (e.g. a status `"1"`, or a boolean) stay strings instead of becoming `1.0`. Classified/numeric sensors are unchanged.
- **Drop `extra_state_attributes`** — it dumped the whole raw API point payload (the API's non-English `name`, internal `code`/`unit`) as state attributes, duplicating the state and bloating the recorder. Removed.
- **`_get_reauth_entry()` helper** — `async_step_reauth` uses it instead of reading `self.context["entry_id"]` directly (documented idiom, matches how reconfigure already works).

## Tests
- New: unclassified numeric point stays a string; entities expose no raw state attributes.
- Replaced the two obsolete `extra_state_attributes` tests.
- Full suite **158 passed**, coverage **97%**, `mypy --strict` clean, ruff clean.

> ⚠️ Minor behaviour change: templates referencing raw point attributes (`state_attr('sensor.x', 'code')`) or relying on unitless status points being floats would be affected — but those raw API fields were undocumented/unstable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)