### PR TITLE
feat: battery power-cap + second forced-charge target controls

### DIFF
--- a/custom_components/sungrow/icons.json
+++ b/custom_components/sungrow/icons.json
@@ -12,6 +12,15 @@
       },
       "forced_charging_target_soc_1": {
         "default": "mdi:battery-charging-100"
+      },
+      "forced_charging_target_soc_2": {
+        "default": "mdi:battery-charging-100"
+      },
+      "max_charging_power": {
+        "default": "mdi:battery-arrow-up"
+      },
+      "max_discharging_power": {
+        "default": "mdi:battery-arrow-down"
       }
     },
     "select": {

--- a/custom_components/sungrow/number.py
+++ b/custom_components/sungrow/number.py
@@ -95,7 +95,40 @@ DISPATCH_NUMBERS: dict[str, dict[str, Any]] = {
         "mode": NumberMode.SLIDER,
         "entity_category": EntityCategory.CONFIG,
     },
+    # Battery power caps: the maximum power the ESS will charge/discharge at. Watts,
+    # same value format as charge_discharge_power, sized to the device's rating.
+    "max_charging_power": {
+        "device_class": NumberDeviceClass.POWER,
+        "native_unit_of_measurement": "W",
+        "native_min_value": 0,
+        "native_max_value": DEFAULT_MAX_DISPATCH_POWER,
+        "native_step": 100,
+        "mode": NumberMode.SLIDER,
+        "entity_category": EntityCategory.CONFIG,
+    },
+    "max_discharging_power": {
+        "device_class": NumberDeviceClass.POWER,
+        "native_unit_of_measurement": "W",
+        "native_min_value": 0,
+        "native_max_value": DEFAULT_MAX_DISPATCH_POWER,
+        "native_step": 100,
+        "mode": NumberMode.SLIDER,
+        "entity_category": EntityCategory.CONFIG,
+    },
+    # Target SOC for the second forced-charging window (mirrors ..._soc_1).
+    "forced_charging_target_soc_2": {
+        "device_class": NumberDeviceClass.BATTERY,
+        "native_unit_of_measurement": "%",
+        "native_min_value": 0,
+        "native_max_value": 100,
+        "native_step": 1,
+        "mode": NumberMode.SLIDER,
+        "entity_category": EntityCategory.CONFIG,
+    },
 }
+
+# Power parameters whose slider maximum is sized to the device's rated power.
+_RATED_POWER_PARAMS = frozenset({"charge_discharge_power", "max_charging_power", "max_discharging_power"})
 
 
 def _build_numbers(coordinator: SungrowPlantCoordinator, control: Control) -> list[NumberEntity]:
@@ -113,12 +146,12 @@ def _build_numbers(coordinator: SungrowPlantCoordinator, control: Control) -> li
     if not device_uuid:
         return []
     device_name = target.get("device_name") or coordinator.plant_name
-    # Size the charge/discharge power slider to the device's rated power when it
-    # can be derived from the model code; otherwise use the conservative default.
+    # Size the power sliders to the device's rated power when it can be derived
+    # from the model code; otherwise use the conservative default.
     max_power = rated_power_w(target) or DEFAULT_MAX_DISPATCH_POWER
     entities: list[NumberEntity] = []
     for param, meta in DISPATCH_NUMBERS.items():
-        if param == "charge_discharge_power" and max_power != meta["native_max_value"]:
+        if param in _RATED_POWER_PARAMS and max_power != meta["native_max_value"]:
             meta = {**meta, "native_max_value": max_power}
         entities.append(SungrowDispatchNumber(coordinator, control, device_uuid, device_name, param, meta))
     return entities

--- a/custom_components/sungrow/strings.json
+++ b/custom_components/sungrow/strings.json
@@ -82,7 +82,16 @@
         "name": "SOC Lower Limit"
       },
       "forced_charging_target_soc_1": {
-        "name": "Forced Charge Target SOC"
+        "name": "Forced Charge Target SOC (Window 1)"
+      },
+      "forced_charging_target_soc_2": {
+        "name": "Forced Charge Target SOC (Window 2)"
+      },
+      "max_charging_power": {
+        "name": "Max Charging Power"
+      },
+      "max_discharging_power": {
+        "name": "Max Discharging Power"
       }
     },
     "select": {

--- a/custom_components/sungrow/translations/en.json
+++ b/custom_components/sungrow/translations/en.json
@@ -82,7 +82,16 @@
         "name": "SOC Lower Limit"
       },
       "forced_charging_target_soc_1": {
-        "name": "Forced Charge Target SOC"
+        "name": "Forced Charge Target SOC (Window 1)"
+      },
+      "forced_charging_target_soc_2": {
+        "name": "Forced Charge Target SOC (Window 2)"
+      },
+      "max_charging_power": {
+        "name": "Max Charging Power"
+      },
+      "max_discharging_power": {
+        "name": "Max Discharging Power"
       }
     },
     "select": {

--- a/tests/test_dispatch.py
+++ b/tests/test_dispatch.py
@@ -401,6 +401,33 @@ async def test_number_config_entities_have_category(hass: HomeAssistant):
     assert cats["forced_charging_target_soc_1"] == EntityCategory.CONFIG
 
 
+async def test_power_cap_and_second_window_controls(hass: HomeAssistant):
+    """Max charge/discharge power and the second forced-charge target are exposed."""
+    from homeassistant.components.number import NumberDeviceClass
+    from homeassistant.const import EntityCategory
+
+    entry = MockConfigEntry(domain=DOMAIN, data=MOCK_CONFIG_DATA.copy())
+    entry.add_to_hass(hass)
+    _setup_entry_data(
+        entry,
+        [{"uuid": "ess-1", "device_type": "ENERGY_STORAGE_SYSTEM", "device_model_code": "SH10RT-V112"}],
+    )
+
+    added = []
+    await number_setup_entry(hass, entry, lambda entities: added.extend(entities))
+    by_param = {e.param: e for e in added}
+
+    assert {"max_charging_power", "max_discharging_power", "forced_charging_target_soc_2"} <= by_param.keys()
+    # Power caps are POWER-class config entities, sized to the 10 kW model rating.
+    for p in ("max_charging_power", "max_discharging_power"):
+        assert by_param[p]._attr_device_class == NumberDeviceClass.POWER
+        assert by_param[p]._attr_entity_category == EntityCategory.CONFIG
+        assert by_param[p]._attr_native_max_value == 10000
+    # The second forced-charge target mirrors the first (0-100%).
+    assert by_param["forced_charging_target_soc_2"]._attr_native_max_value == 100
+    assert by_param["forced_charging_target_soc_2"]._attr_entity_category == EntityCategory.CONFIG
+
+
 async def test_select_forced_charging_is_config(hass: HomeAssistant):
     """The forced-charging select is a config entity; the command select is primary."""
     from homeassistant.const import EntityCategory


### PR DESCRIPTION
## Summary
Expands the dispatch controls with three more parameters from the pysolarcloud `Control.config_parameters` map, as Number entities:

| Entity | Unit | Notes |
| --- | --- | --- |
| **Max Charging Power** (`max_charging_power`) | W | caps battery charge power; slider sized to model rating |
| **Max Discharging Power** (`max_discharging_power`) | W | caps battery discharge power; slider sized to model rating |
| **Forced Charge Target SOC (Window 2)** (`forced_charging_target_soc_2`) | % | second forced-charge window, mirrors window 1 |

All three are `EntityCategory.CONFIG` with translations + icons. Rated-power sizing (previously only `charge_discharge_power`) now applies to all three power params. `..._soc_1` relabelled "(Window 1)".

## Scope discipline (important)
These **write to real inverter hardware**. I only added parameters whose value format is grounded in the already-validated controls (watts like `charge_discharge_power`; % like `..._soc_1`). Parameters with an **uncertain API contract** — feed-in/export limiting, boolean mode switches (`battery_first`, `limited_power_switch`), power-factor/reactive settings — are **intentionally deferred** (tracked in a follow-up issue) rather than shipped with guessed value codes/units.

> ⚠️ **Please test against your inverter before relying on these** — I can't verify the write path against real hardware, though it's identical to the existing validated controls.

## Tests
New test asserts the three controls exist, power caps are `POWER`/`CONFIG` and sized to a 10 kW model, and the second SOC target is 0–100%. Full suite **159 passed**, `mypy --strict` clean, ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)