### PR TITLE
feat: verified dispatch controls + fix kW power unit bug (#101)

### DIFF
--- a/custom_components/sungrow/__init__.py
+++ b/custom_components/sungrow/__init__.py
@@ -81,6 +81,23 @@ def select_dispatch_device(devices: list[dict[str, Any]]) -> dict[str, Any] | No
     return inverters[0] if inverters else None
 
 
+async def _async_dispatch_supported(control: Control, devices: list[dict[str, Any]]) -> bool:
+    """Return whether the plant's dispatch device accepts parameter writes.
+
+    Fail-open: returns True unless the API explicitly reports the device does not
+    support updates, so a transient check failure — or a dispatch device that only
+    appears after setup — never hides working controls.
+    """
+    target = select_dispatch_device(devices)
+    if target is None or not target.get("uuid"):
+        return True
+    try:
+        return bool(await control.async_check_update_support(str(target["uuid"])))
+    except Exception as err:  # pylint: disable=broad-except
+        _LOGGER.debug("Could not check dispatch support for %s: %s", target.get("uuid"), err)
+        return True
+
+
 class IterableSchema(vol.Schema):
     """A Schema that can be iterated over (yielding nothing) to satisfy HA's checks."""
 
@@ -185,6 +202,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: SungrowConfigEntry) -> b
         coordinator = SungrowPlantCoordinator(hass, entry, plants_service, plant_id, plant_name, devices)
         # Raises ConfigEntryNotReady / ConfigEntryAuthFailed as classified by the coordinator.
         await coordinator.async_config_entry_first_refresh()
+        coordinator.dispatch_update_supported = await _async_dispatch_supported(control_service, devices)
         coordinators.append(coordinator)
 
     entry.runtime_data = SungrowData(

--- a/custom_components/sungrow/coordinator.py
+++ b/custom_components/sungrow/coordinator.py
@@ -67,6 +67,10 @@ class SungrowPlantCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         self.enable_device_sensors: bool = bool(config_entry.options.get(CONF_ENABLE_DEVICE_SENSORS, False))
         # uuid -> { code: point } for per-device realtime (populated when enabled).
         self.device_data: dict[str, dict[str, Any]] = {}
+        # Whether the dispatch device accepts parameter writes. Checked once at
+        # setup; defaults True (fail-open) so an unavailable/unknown check never
+        # hides working controls.
+        self.dispatch_update_supported: bool = True
 
     async def _async_update_data(self) -> dict[str, Any]:
         """Fetch data from the API for this plant."""

--- a/custom_components/sungrow/icons.json
+++ b/custom_components/sungrow/icons.json
@@ -21,6 +21,15 @@
       },
       "max_discharging_power": {
         "default": "mdi:battery-arrow-down"
+      },
+      "feed_in_limitation_value": {
+        "default": "mdi:transmission-tower-export"
+      },
+      "feed_in_limitation_ratio": {
+        "default": "mdi:transmission-tower-export"
+      },
+      "active_power_limit_ratio": {
+        "default": "mdi:speedometer"
       }
     },
     "select": {
@@ -29,6 +38,15 @@
       },
       "forced_charging": {
         "default": "mdi:battery-lock"
+      },
+      "feed_in_limitation": {
+        "default": "mdi:transmission-tower-export"
+      },
+      "limited_power_switch": {
+        "default": "mdi:speedometer"
+      },
+      "battery_first": {
+        "default": "mdi:battery-heart-variant"
       }
     }
   }

--- a/custom_components/sungrow/number.py
+++ b/custom_components/sungrow/number.py
@@ -125,10 +125,42 @@ DISPATCH_NUMBERS: dict[str, dict[str, Any]] = {
         "mode": NumberMode.SLIDER,
         "entity_category": EntityCategory.CONFIG,
     },
+    # Export (feed-in) limit as an absolute power. Only takes effect when the
+    # feed_in_limitation select is enabled. Watts UI, sent as kW, sized to rating.
+    "feed_in_limitation_value": {
+        "device_class": NumberDeviceClass.POWER,
+        "native_unit_of_measurement": "W",
+        "native_min_value": 0,
+        "native_max_value": DEFAULT_MAX_DISPATCH_POWER,
+        "native_step": 100,
+        "mode": NumberMode.SLIDER,
+        "entity_category": EntityCategory.CONFIG,
+    },
+    # Export limit as a percentage of rated power (0-100%).
+    "feed_in_limitation_ratio": {
+        "native_unit_of_measurement": "%",
+        "native_min_value": 0,
+        "native_max_value": 100,
+        "native_step": 1,
+        "mode": NumberMode.SLIDER,
+        "entity_category": EntityCategory.CONFIG,
+    },
+    # Active power output cap as a percentage of rated power (0-100%).
+    "active_power_limit_ratio": {
+        "native_unit_of_measurement": "%",
+        "native_min_value": 0,
+        "native_max_value": 100,
+        "native_step": 1,
+        "mode": NumberMode.SLIDER,
+        "entity_category": EntityCategory.CONFIG,
+    },
 }
 
-# Power parameters whose slider maximum is sized to the device's rated power.
-_RATED_POWER_PARAMS = frozenset({"charge_discharge_power", "max_charging_power", "max_discharging_power"})
+# Power parameters: sent to the API in kW (converted from the entities' W), and
+# their slider maximum is sized to the device's rated power.
+_RATED_POWER_PARAMS = frozenset(
+    {"charge_discharge_power", "max_charging_power", "max_discharging_power", "feed_in_limitation_value"}
+)
 
 
 def _build_numbers(coordinator: SungrowPlantCoordinator, control: Control) -> list[NumberEntity]:
@@ -138,6 +170,9 @@ def _build_numbers(coordinator: SungrowPlantCoordinator, control: Control) -> li
     coordinator's live device list so a dispatchable device that appears after
     setup gets its controls at runtime (dynamic-devices).
     """
+    # Skip entirely if the device reported that it doesn't accept parameter writes.
+    if not coordinator.dispatch_update_supported:
+        return []
     # Prefer the ESS device if present, otherwise fall back to an inverter.
     target = select_dispatch_device(coordinator.devices)
     if target is None:
@@ -234,8 +269,12 @@ class SungrowDispatchNumber(CoordinatorEntity[SungrowPlantCoordinator], RestoreN
     async def async_set_native_value(self, value: float) -> None:
         """Update the dispatch parameter on the inverter."""
         _LOGGER.debug("Setting %s to %s for %s", self.param, value, self.device_uuid)
+        # The API expects power parameters in kW (the entities present them in W for a
+        # familiar UI), and the client sends the value verbatim — so convert W->kW on
+        # the way out. Percentage/other params are sent as integers.
+        wire_value = str(round(value / 1000, 2)) if self.param in _RATED_POWER_PARAMS else str(int(value))
         try:
-            await self.control.async_update_parameters(self.device_uuid, {self.param: str(int(value))})
+            await self.control.async_update_parameters(self.device_uuid, {self.param: wire_value})
         except PySolarCloudException as err:
             raise HomeAssistantError(
                 translation_domain=DOMAIN,

--- a/custom_components/sungrow/select.py
+++ b/custom_components/sungrow/select.py
@@ -43,6 +43,21 @@ DISPATCH_SELECTS: dict[str, dict[str, Any]] = {
         # Enabling/disabling forced charging is a policy setting, not actuation.
         "entity_category": EntityCategory.CONFIG,
     },
+    # Sungrow enable/disable enum (device-verified): Enable=170, Disable=85.
+    "feed_in_limitation": {
+        "options_map": {"Disable": "85", "Enable": "170"},
+        "entity_category": EntityCategory.CONFIG,
+    },
+    "limited_power_switch": {
+        "options_map": {"Disable": "85", "Enable": "170"},
+        "entity_category": EntityCategory.CONFIG,
+    },
+    # Battery-first mode (hybrid inverters only; a graceful write error is raised
+    # on devices that don't support it).
+    "battery_first": {
+        "options_map": {"Disable": "85", "Enable": "170"},
+        "entity_category": EntityCategory.CONFIG,
+    },
 }
 
 
@@ -53,6 +68,9 @@ def _build_selects(coordinator: SungrowPlantCoordinator, control: Control) -> li
     coordinator's live device list so a dispatchable device that appears after
     setup gets its controls at runtime (dynamic-devices).
     """
+    # Skip entirely if the device reported that it doesn't accept parameter writes.
+    if not coordinator.dispatch_update_supported:
+        return []
     # Prefer the ESS device if present, otherwise fall back to an inverter.
     target = select_dispatch_device(coordinator.devices)
     if target is None:

--- a/custom_components/sungrow/strings.json
+++ b/custom_components/sungrow/strings.json
@@ -92,6 +92,15 @@
       },
       "max_discharging_power": {
         "name": "Max Discharging Power"
+      },
+      "feed_in_limitation_value": {
+        "name": "Export Limit (Power)"
+      },
+      "feed_in_limitation_ratio": {
+        "name": "Export Limit (%)"
+      },
+      "active_power_limit_ratio": {
+        "name": "Active Power Limit"
       }
     },
     "select": {
@@ -100,6 +109,15 @@
       },
       "forced_charging": {
         "name": "Forced Charging"
+      },
+      "feed_in_limitation": {
+        "name": "Export Limitation"
+      },
+      "limited_power_switch": {
+        "name": "Active Power Limiting"
+      },
+      "battery_first": {
+        "name": "Battery First Mode"
       }
     }
   },

--- a/custom_components/sungrow/translations/en.json
+++ b/custom_components/sungrow/translations/en.json
@@ -92,6 +92,15 @@
       },
       "max_discharging_power": {
         "name": "Max Discharging Power"
+      },
+      "feed_in_limitation_value": {
+        "name": "Export Limit (Power)"
+      },
+      "feed_in_limitation_ratio": {
+        "name": "Export Limit (%)"
+      },
+      "active_power_limit_ratio": {
+        "name": "Active Power Limit"
       }
     },
     "select": {
@@ -100,6 +109,15 @@
       },
       "forced_charging": {
         "name": "Forced Charging"
+      },
+      "feed_in_limitation": {
+        "name": "Export Limitation"
+      },
+      "limited_power_switch": {
+        "name": "Active Power Limiting"
+      },
+      "battery_first": {
+        "name": "Battery First Mode"
       }
     }
   },

--- a/tests/test_dispatch.py
+++ b/tests/test_dispatch.py
@@ -163,9 +163,8 @@ async def test_number_set_value_calls_control(hass: HomeAssistant):
     with patch("custom_components.sungrow.number.async_start_heartbeat", new=AsyncMock()):
         await power.async_set_native_value(2500)
 
-    entry_data.control.async_update_parameters.assert_awaited_once_with(
-        "dev-uuid-1", {"charge_discharge_power": "2500"}
-    )
+    # The API expects kW; the 2500 W slider value is sent as 2.5 kW.
+    entry_data.control.async_update_parameters.assert_awaited_once_with("dev-uuid-1", {"charge_discharge_power": "2.5"})
 
 
 async def test_number_starts_heartbeat_for_power_changes(hass: HomeAssistant):
@@ -376,6 +375,88 @@ async def test_charge_power_max_falls_back_to_default(hass: HomeAssistant):
 
     power = next(e for e in added if e.param == "charge_discharge_power")
     assert power._attr_native_max_value == DEFAULT_MAX_DISPATCH_POWER
+
+
+# ---------------------------------------------------------------------------
+# kW unit conversion + additional controls (device-verified formats)
+# ---------------------------------------------------------------------------
+
+
+async def test_power_params_written_in_kw(hass: HomeAssistant):
+    """Power params convert W->kW on write; percentage params are sent as integers."""
+    entry = MockConfigEntry(domain=DOMAIN, data=MOCK_CONFIG_DATA.copy())
+    entry.add_to_hass(hass)
+    data = _setup_entry_data(entry, [{"uuid": "ess-1", "device_type": "ENERGY_STORAGE_SYSTEM"}])
+
+    added = []
+    await number_setup_entry(hass, entry, lambda entities: added.extend(entities))
+    by_param = {e.param: e for e in added}
+
+    with patch("custom_components.sungrow.number.async_start_heartbeat", new=AsyncMock()):
+        await by_param["max_charging_power"].async_set_native_value(3700)
+    data.control.async_update_parameters.assert_awaited_with("ess-1", {"max_charging_power": "3.7"})
+
+    await by_param["feed_in_limitation_ratio"].async_set_native_value(80)
+    data.control.async_update_parameters.assert_awaited_with("ess-1", {"feed_in_limitation_ratio": "80"})
+
+
+async def test_new_selects_write_verified_codes(hass: HomeAssistant):
+    """Feed-in / battery-first selects write the device-verified enable/disable codes."""
+    from homeassistant.const import EntityCategory
+
+    entry = MockConfigEntry(domain=DOMAIN, data=MOCK_CONFIG_DATA.copy())
+    entry.add_to_hass(hass)
+    data = _setup_entry_data(entry, [{"uuid": "ess-1", "device_type": "ENERGY_STORAGE_SYSTEM"}])
+
+    added = []
+    await select_setup_entry(hass, entry, lambda entities: added.extend(entities))
+    by_param = {e.param: e for e in added}
+
+    assert {"feed_in_limitation", "limited_power_switch", "battery_first"} <= by_param.keys()
+    await by_param["feed_in_limitation"].async_select_option("Enable")
+    data.control.async_update_parameters.assert_awaited_with("ess-1", {"feed_in_limitation": "170"})
+    await by_param["battery_first"].async_select_option("Disable")
+    data.control.async_update_parameters.assert_awaited_with("ess-1", {"battery_first": "85"})
+    assert by_param["battery_first"]._attr_entity_category == EntityCategory.CONFIG
+
+
+# ---------------------------------------------------------------------------
+# Dispatch support gating
+# ---------------------------------------------------------------------------
+
+
+async def test_no_controls_when_updates_unsupported(hass: HomeAssistant):
+    """No number/select controls are created when the device rejects writes."""
+    entry = MockConfigEntry(domain=DOMAIN, data=MOCK_CONFIG_DATA.copy())
+    entry.add_to_hass(hass)
+    data = _setup_entry_data(entry, [{"uuid": "ess-1", "device_type": "ENERGY_STORAGE_SYSTEM"}])
+    data.coordinators[0].dispatch_update_supported = False
+
+    numbers: list = []
+    await number_setup_entry(hass, entry, lambda entities: numbers.extend(entities))
+    selects: list = []
+    await select_setup_entry(hass, entry, lambda entities: selects.extend(entities))
+
+    assert numbers == []
+    assert selects == []
+
+
+async def test_dispatch_supported_check_fails_open():
+    """_async_dispatch_supported only returns False on an explicit API 'no'."""
+    from custom_components.sungrow import _async_dispatch_supported
+
+    ess = [{"uuid": "ess-1", "device_type": "ENERGY_STORAGE_SYSTEM"}]
+    control = MagicMock()
+
+    control.async_check_update_support = AsyncMock(return_value=False)
+    assert await _async_dispatch_supported(control, ess) is False
+
+    # No dispatch device yet -> unknown -> fail open (a later device still gets controls).
+    assert await _async_dispatch_supported(control, []) is True
+
+    # A failing check must not hide working controls.
+    control.async_check_update_support = AsyncMock(side_effect=Exception("boom"))
+    assert await _async_dispatch_supported(control, ess) is True
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
**Stacked on #100** — until #100 merges, this PR also shows #100's commit; the diff auto-cleans once #100 lands (or merge this and close #100, since this supersedes and corrects it).

Closes #101. Grounded against **two real inverters** (SG3.6RS, SH10RT) by reading each device's own parameter metadata (units, precision, enum codes) via `Control.async_read_parameters`.

## 🐛 Fix: power params are kW, not watts
The API declares `charge_discharge_power` / `feed_in_limitation_value` / `max_*` in **kW** (precision 0.01) and the client sends the value **verbatim**. The old `str(int(watts))` sent e.g. `"5000"` as **5000 kW** → clamped to the inverter max, so the power slider effectively didn't work. Entities keep a familiar **W** UI and now convert W→kW on write (`5000 W → "5.0"`). This also corrects #100's `max_charging/discharging_power`.

## ✨ New controls (device-verified)
Export Limitation (`feed_in_limitation`, select), Export Limit Power/% (`feed_in_limitation_value` W→kW / `feed_in_limitation_ratio` %), Active Power Limit (`active_power_limit_ratio` %), Active Power Limiting (`limited_power_switch`, select), Battery First (`battery_first`, select — hybrid-only). Enable/Disable selects use the verified `{Enable:170, Disable:85}`. All `CONFIG` with translations + icons. `power_on` is **never** exposed.

## 🛡️ Robustness
Dispatch creation gated on `async_check_update_support` (fail-open — only skipped on an explicit "no").

## Tests
kW conversion, verified enum codes, support-gating. **163 passed**, `mypy --strict` clean, coverage 97%.

## ⚠️ Verify on hardware
The write **round-trip** wasn't live-confirmed (the safe inert test param stayed put) — the kW conclusion rests on the device-declared unit + verbatim send. Some params are hybrid-only (graceful error otherwise).

🤖 Generated with [Claude Code](https://claude.com/claude-code)