### PR TITLE
fix: correct dispatch parameter encodings per official API docs

### DIFF
--- a/custom_components/sungrow/icons.json
+++ b/custom_components/sungrow/icons.json
@@ -16,12 +16,6 @@
       "forced_charging_target_soc_2": {
         "default": "mdi:battery-charging-100"
       },
-      "max_charging_power": {
-        "default": "mdi:battery-arrow-up"
-      },
-      "max_discharging_power": {
-        "default": "mdi:battery-arrow-down"
-      },
       "feed_in_limitation_value": {
         "default": "mdi:transmission-tower-export"
       },

--- a/custom_components/sungrow/number.py
+++ b/custom_components/sungrow/number.py
@@ -57,7 +57,15 @@ def rated_power_w(device: dict[str, Any]) -> int | None:
 
 
 # Number parameters exposed as HA Number entities.
-# Keys are canonical Control parameter names; values describe the HA entity.
+#
+# Keys are canonical Control parameter names. "write_scale" converts the entity's
+# displayed value to the raw value the API expects (Appendix 10 of the iSolarCloud
+# OpenAPI docs — the authoritative source):
+#   - power params are sent in WATTS (scale 1): charge_discharge_power 0-5000W+,
+#     feed_in_limitation_value 0-rated;
+#   - SOC upper/lower limits and the ratios are sent as TENTHS of a percent
+#     (scale 10): e.g. 90% -> 900, matching the doc's "700 to 1000 = 70% to 100%";
+#   - forced-charge target SOC is a direct percent (scale 1, "0 to 100").
 DISPATCH_NUMBERS: dict[str, dict[str, Any]] = {
     "charge_discharge_power": {
         "device_class": NumberDeviceClass.POWER,
@@ -66,6 +74,7 @@ DISPATCH_NUMBERS: dict[str, dict[str, Any]] = {
         "native_max_value": DEFAULT_MAX_DISPATCH_POWER,
         "native_step": 100,
         "mode": NumberMode.SLIDER,
+        "write_scale": 1,
     },
     "soc_upper_limit": {
         "device_class": NumberDeviceClass.BATTERY,
@@ -76,6 +85,7 @@ DISPATCH_NUMBERS: dict[str, dict[str, Any]] = {
         "mode": NumberMode.SLIDER,
         # SOC limits set battery policy rather than actuate — configuration entities.
         "entity_category": EntityCategory.CONFIG,
+        "write_scale": 10,
     },
     "soc_lower_limit": {
         "device_class": NumberDeviceClass.BATTERY,
@@ -85,6 +95,7 @@ DISPATCH_NUMBERS: dict[str, dict[str, Any]] = {
         "native_step": 1,
         "mode": NumberMode.SLIDER,
         "entity_category": EntityCategory.CONFIG,
+        "write_scale": 10,
     },
     "forced_charging_target_soc_1": {
         "device_class": NumberDeviceClass.BATTERY,
@@ -94,26 +105,7 @@ DISPATCH_NUMBERS: dict[str, dict[str, Any]] = {
         "native_step": 1,
         "mode": NumberMode.SLIDER,
         "entity_category": EntityCategory.CONFIG,
-    },
-    # Battery power caps: the maximum power the ESS will charge/discharge at. Watts,
-    # same value format as charge_discharge_power, sized to the device's rating.
-    "max_charging_power": {
-        "device_class": NumberDeviceClass.POWER,
-        "native_unit_of_measurement": "W",
-        "native_min_value": 0,
-        "native_max_value": DEFAULT_MAX_DISPATCH_POWER,
-        "native_step": 100,
-        "mode": NumberMode.SLIDER,
-        "entity_category": EntityCategory.CONFIG,
-    },
-    "max_discharging_power": {
-        "device_class": NumberDeviceClass.POWER,
-        "native_unit_of_measurement": "W",
-        "native_min_value": 0,
-        "native_max_value": DEFAULT_MAX_DISPATCH_POWER,
-        "native_step": 100,
-        "mode": NumberMode.SLIDER,
-        "entity_category": EntityCategory.CONFIG,
+        "write_scale": 1,
     },
     # Target SOC for the second forced-charging window (mirrors ..._soc_1).
     "forced_charging_target_soc_2": {
@@ -124,9 +116,10 @@ DISPATCH_NUMBERS: dict[str, dict[str, Any]] = {
         "native_step": 1,
         "mode": NumberMode.SLIDER,
         "entity_category": EntityCategory.CONFIG,
+        "write_scale": 1,
     },
-    # Export (feed-in) limit as an absolute power. Only takes effect when the
-    # feed_in_limitation select is enabled. Watts UI, sent as kW, sized to rating.
+    # Export (feed-in) limit as an absolute power in watts. Only takes effect when
+    # the feed_in_limitation select is enabled. Sized to the device's rating.
     "feed_in_limitation_value": {
         "device_class": NumberDeviceClass.POWER,
         "native_unit_of_measurement": "W",
@@ -135,8 +128,9 @@ DISPATCH_NUMBERS: dict[str, dict[str, Any]] = {
         "native_step": 100,
         "mode": NumberMode.SLIDER,
         "entity_category": EntityCategory.CONFIG,
+        "write_scale": 1,
     },
-    # Export limit as a percentage of rated power (0-100%).
+    # Export limit as a percentage of rated power (API range 0-1000 = 0-100%).
     "feed_in_limitation_ratio": {
         "native_unit_of_measurement": "%",
         "native_min_value": 0,
@@ -144,8 +138,9 @@ DISPATCH_NUMBERS: dict[str, dict[str, Any]] = {
         "native_step": 1,
         "mode": NumberMode.SLIDER,
         "entity_category": EntityCategory.CONFIG,
+        "write_scale": 10,
     },
-    # Active power output cap as a percentage of rated power (0-100%).
+    # Active power output cap as a percentage of rated power (API range 0-1000).
     "active_power_limit_ratio": {
         "native_unit_of_measurement": "%",
         "native_min_value": 0,
@@ -153,14 +148,12 @@ DISPATCH_NUMBERS: dict[str, dict[str, Any]] = {
         "native_step": 1,
         "mode": NumberMode.SLIDER,
         "entity_category": EntityCategory.CONFIG,
+        "write_scale": 10,
     },
 }
 
-# Power parameters: sent to the API in kW (converted from the entities' W), and
-# their slider maximum is sized to the device's rated power.
-_RATED_POWER_PARAMS = frozenset(
-    {"charge_discharge_power", "max_charging_power", "max_discharging_power", "feed_in_limitation_value"}
-)
+# Watt-valued power parameters whose slider maximum is sized to the device's rating.
+_RATED_POWER_PARAMS = frozenset({"charge_discharge_power", "feed_in_limitation_value"})
 
 
 def _build_numbers(coordinator: SungrowPlantCoordinator, control: Control) -> list[NumberEntity]:
@@ -254,6 +247,8 @@ class SungrowDispatchNumber(CoordinatorEntity[SungrowPlantCoordinator], RestoreN
         self._attr_native_step = meta["native_step"]
         self._attr_mode = meta["mode"]
         self._attr_entity_category = meta.get("entity_category")
+        # Factor converting the displayed value to the raw API value (see DISPATCH_NUMBERS).
+        self._write_scale = meta.get("write_scale", 1)
 
     async def async_added_to_hass(self) -> None:
         """Restore the last commanded value across restarts.
@@ -269,10 +264,9 @@ class SungrowDispatchNumber(CoordinatorEntity[SungrowPlantCoordinator], RestoreN
     async def async_set_native_value(self, value: float) -> None:
         """Update the dispatch parameter on the inverter."""
         _LOGGER.debug("Setting %s to %s for %s", self.param, value, self.device_uuid)
-        # The API expects power parameters in kW (the entities present them in W for a
-        # familiar UI), and the client sends the value verbatim — so convert W->kW on
-        # the way out. Percentage/other params are sent as integers.
-        wire_value = str(round(value / 1000, 2)) if self.param in _RATED_POWER_PARAMS else str(int(value))
+        # The client sends the value verbatim, so encode it as the API expects: power
+        # in watts (scale 1), SOC limits and ratios as tenths of a percent (scale 10).
+        wire_value = str(int(round(value * self._write_scale)))
         try:
             await self.control.async_update_parameters(self.device_uuid, {self.param: wire_value})
         except PySolarCloudException as err:

--- a/custom_components/sungrow/strings.json
+++ b/custom_components/sungrow/strings.json
@@ -87,12 +87,6 @@
       "forced_charging_target_soc_2": {
         "name": "Forced Charge Target SOC (Window 2)"
       },
-      "max_charging_power": {
-        "name": "Max Charging Power"
-      },
-      "max_discharging_power": {
-        "name": "Max Discharging Power"
-      },
       "feed_in_limitation_value": {
         "name": "Export Limit (Power)"
       },

--- a/custom_components/sungrow/translations/en.json
+++ b/custom_components/sungrow/translations/en.json
@@ -87,12 +87,6 @@
       "forced_charging_target_soc_2": {
         "name": "Forced Charge Target SOC (Window 2)"
       },
-      "max_charging_power": {
-        "name": "Max Charging Power"
-      },
-      "max_discharging_power": {
-        "name": "Max Discharging Power"
-      },
       "feed_in_limitation_value": {
         "name": "Export Limit (Power)"
       },

--- a/tests/test_dispatch.py
+++ b/tests/test_dispatch.py
@@ -163,8 +163,10 @@ async def test_number_set_value_calls_control(hass: HomeAssistant):
     with patch("custom_components.sungrow.number.async_start_heartbeat", new=AsyncMock()):
         await power.async_set_native_value(2500)
 
-    # The API expects kW; the 2500 W slider value is sent as 2.5 kW.
-    entry_data.control.async_update_parameters.assert_awaited_once_with("dev-uuid-1", {"charge_discharge_power": "2.5"})
+    # Power is sent verbatim in watts.
+    entry_data.control.async_update_parameters.assert_awaited_once_with(
+        "dev-uuid-1", {"charge_discharge_power": "2500"}
+    )
 
 
 async def test_number_starts_heartbeat_for_power_changes(hass: HomeAssistant):
@@ -382,8 +384,8 @@ async def test_charge_power_max_falls_back_to_default(hass: HomeAssistant):
 # ---------------------------------------------------------------------------
 
 
-async def test_power_params_written_in_kw(hass: HomeAssistant):
-    """Power params convert W->kW on write; percentage params are sent as integers."""
+async def test_param_write_encodings(hass: HomeAssistant):
+    """Values are encoded per Appendix 10: power in watts, SOC/ratios as tenths of a %."""
     entry = MockConfigEntry(domain=DOMAIN, data=MOCK_CONFIG_DATA.copy())
     entry.add_to_hass(hass)
     data = _setup_entry_data(entry, [{"uuid": "ess-1", "device_type": "ENERGY_STORAGE_SYSTEM"}])
@@ -392,12 +394,21 @@ async def test_power_params_written_in_kw(hass: HomeAssistant):
     await number_setup_entry(hass, entry, lambda entities: added.extend(entities))
     by_param = {e.param: e for e in added}
 
+    # Power is sent verbatim in watts (not kW).
     with patch("custom_components.sungrow.number.async_start_heartbeat", new=AsyncMock()):
-        await by_param["max_charging_power"].async_set_native_value(3700)
-    data.control.async_update_parameters.assert_awaited_with("ess-1", {"max_charging_power": "3.7"})
+        await by_param["charge_discharge_power"].async_set_native_value(2500)
+    data.control.async_update_parameters.assert_awaited_with("ess-1", {"charge_discharge_power": "2500"})
+
+    # SOC limits and ratios are sent as tenths of a percent (x10).
+    await by_param["soc_upper_limit"].async_set_native_value(90)
+    data.control.async_update_parameters.assert_awaited_with("ess-1", {"soc_upper_limit": "900"})
 
     await by_param["feed_in_limitation_ratio"].async_set_native_value(80)
-    data.control.async_update_parameters.assert_awaited_with("ess-1", {"feed_in_limitation_ratio": "80"})
+    data.control.async_update_parameters.assert_awaited_with("ess-1", {"feed_in_limitation_ratio": "800"})
+
+    # Forced-charge target SOC is a direct percent (x1).
+    await by_param["forced_charging_target_soc_1"].async_set_native_value(75)
+    data.control.async_update_parameters.assert_awaited_with("ess-1", {"forced_charging_target_soc_1": "75"})
 
 
 async def test_new_selects_write_verified_codes(hass: HomeAssistant):
@@ -482,9 +493,8 @@ async def test_number_config_entities_have_category(hass: HomeAssistant):
     assert cats["forced_charging_target_soc_1"] == EntityCategory.CONFIG
 
 
-async def test_power_cap_and_second_window_controls(hass: HomeAssistant):
-    """Max charge/discharge power and the second forced-charge target are exposed."""
-    from homeassistant.components.number import NumberDeviceClass
+async def test_second_forced_charge_window_control(hass: HomeAssistant):
+    """The second forced-charge target SOC is exposed as a config entity (0-100%)."""
     from homeassistant.const import EntityCategory
 
     entry = MockConfigEntry(domain=DOMAIN, data=MOCK_CONFIG_DATA.copy())
@@ -498,15 +508,12 @@ async def test_power_cap_and_second_window_controls(hass: HomeAssistant):
     await number_setup_entry(hass, entry, lambda entities: added.extend(entities))
     by_param = {e.param: e for e in added}
 
-    assert {"max_charging_power", "max_discharging_power", "forced_charging_target_soc_2"} <= by_param.keys()
-    # Power caps are POWER-class config entities, sized to the 10 kW model rating.
-    for p in ("max_charging_power", "max_discharging_power"):
-        assert by_param[p]._attr_device_class == NumberDeviceClass.POWER
-        assert by_param[p]._attr_entity_category == EntityCategory.CONFIG
-        assert by_param[p]._attr_native_max_value == 10000
-    # The second forced-charge target mirrors the first (0-100%).
+    assert "forced_charging_target_soc_2" in by_param
     assert by_param["forced_charging_target_soc_2"]._attr_native_max_value == 100
     assert by_param["forced_charging_target_soc_2"]._attr_entity_category == EntityCategory.CONFIG
+    # The dropped max-charge/discharge-power controls are no longer created.
+    assert "max_charging_power" not in by_param
+    assert "max_discharging_power" not in by_param
 
 
 async def test_select_forced_charging_is_config(hass: HomeAssistant):


### PR DESCRIPTION
## Summary
Cross-checked every dispatch parameter against **Appendix 10 (Control Parameter Definitions)** of the official iSolarCloud OpenAPI docs — the authoritative source for the raw value each parameter expects. The pysolarcloud client sends values verbatim, so the entity must encode them correctly. Several were wrong, including a bug #102 introduced and pre-existing ones.

| Parameter | Was sending | Correct (Appendix 10) |
| --- | --- | --- |
| `charge_discharge_power`, `feed_in_limitation_value` | kW (`value/1000`) ❌ (from #102) | **watts**, verbatim (`0W to 5000W`, `0 to rated`) |
| `soc_upper_limit`, `soc_lower_limit` | percent ❌ (pre-existing) | **tenths of a %** (`700-1000 = 70-100%`) → ×10 |
| `feed_in_limitation_ratio`, `active_power_limit_ratio` | percent ❌ | **tenths of a %** (`0-1000 = 0-100%`) → ×10 |
| `forced_charging_target_soc_1/2` | percent ✅ | direct percent (`0-100`) — unchanged |

**Impact:** before this, the charge/discharge power slider commanded ~1000× too little power, and the SOC limits set 1/10th of the intended value. Encoding is now driven by a per-parameter `write_scale`.

**Also removes `max_charging_power` / `max_discharging_power`** — Appendix 10 defines their range as device-specific (`10 to <upper limit from point 18290> ×100`), which can't be encoded safely without querying that point. They risked bad writes; they can return once the range is derived.

## Verification
The encodings were confirmed against the official docs (now also mirrored in the new [mcp-isolarcloud](https://github.com/KRoperUK/mcp-isolarcloud) doc server). Enum codes (`170/85`, `170/187/204`) were already correct and are unchanged. Full suite **163 passed**, `mypy --strict` clean, coverage 97%.

> ⚠️ These write to real hardware; worth confirming a dispatch on an inverter, but the encodings now match the documented ranges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)