### PR TITLE
refactor: encode dispatch values via pysolarcloud 0.7.0 specs

### DIFF
--- a/custom_components/sungrow/__init__.py
+++ b/custom_components/sungrow/__init__.py
@@ -170,7 +170,8 @@ async def async_setup_entry(hass: HomeAssistant, entry: SungrowConfigEntry) -> b
         token_updater=_save_tokens,
     )
     # Restore previously stored tokens (a copy so we never mutate entry.data in place).
-    auth.tokens = dict(entry.data["tokens"])
+    # pysolarcloud annotates Auth.tokens as None, but it holds a dict at runtime.
+    auth.tokens = dict(entry.data["tokens"])  # type: ignore[assignment]
 
     plants_service = Plants(auth)
     control_service = Control(auth)

--- a/custom_components/sungrow/auth.py
+++ b/custom_components/sungrow/auth.py
@@ -15,7 +15,7 @@ from __future__ import annotations
 
 import logging
 from collections.abc import Callable
-from typing import Any, cast
+from typing import Any
 
 from pysolarcloud import Auth
 
@@ -28,7 +28,7 @@ _LOGGER = logging.getLogger(__name__)
 AUTH_ERRORS = frozenset({"auth_not_initialised", "invalid_grant", "invalid_token", "token_refresh_failed"})
 
 
-class SungrowAuth(Auth):  # type: ignore[misc]  # pysolarcloud.Auth is untyped (Any); subclassing it is the intended boundary
+class SungrowAuth(Auth):
     """``pysolarcloud.Auth`` that persists rotated tokens via a callback.
 
     ``token_updater`` is invoked with the new ``tokens`` dict whenever the upstream
@@ -54,8 +54,7 @@ class SungrowAuth(Auth):  # type: ignore[misc]  # pysolarcloud.Auth is untyped (
         call.
         """
         previous = self.tokens
-        # pysolarcloud is untyped, so the upstream method returns Any.
-        token = cast(str, await super().async_get_access_token())
+        token = await super().async_get_access_token()
         if self._token_updater is not None and self.tokens is not previous:
             _LOGGER.debug("Access token refreshed; persisting rotated tokens")
             self._token_updater(self.tokens)

--- a/custom_components/sungrow/config_flow.py
+++ b/custom_components/sungrow/config_flow.py
@@ -32,9 +32,8 @@ from .const import (
 try:
     from pysolarcloud import Auth
 except ImportError:
-    Auth = None
-    # For local development if pysolarcloud is not installed but in path or similar
-    # In a real environment, it should be installed via requirements.
+    # Optional import for local dev; production always has it via requirements.
+    Auth = None  # type: ignore[assignment,misc]
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/custom_components/sungrow/manifest.json
+++ b/custom_components/sungrow/manifest.json
@@ -17,7 +17,7 @@
   ],
   "quality_scale": "gold",
   "requirements": [
-    "sungrow-isolarcloud==0.6.0"
+    "sungrow-isolarcloud==0.7.0"
   ],
   "version": "2.0.0"
 }

--- a/custom_components/sungrow/number.py
+++ b/custom_components/sungrow/number.py
@@ -56,16 +56,12 @@ def rated_power_w(device: dict[str, Any]) -> int | None:
     return int(round(kw * 1000))
 
 
-# Number parameters exposed as HA Number entities.
-#
-# Keys are canonical Control parameter names. "write_scale" converts the entity's
-# displayed value to the raw value the API expects (Appendix 10 of the iSolarCloud
-# OpenAPI docs — the authoritative source):
-#   - power params are sent in WATTS (scale 1): charge_discharge_power 0-5000W+,
-#     feed_in_limitation_value 0-rated;
-#   - SOC upper/lower limits and the ratios are sent as TENTHS of a percent
-#     (scale 10): e.g. 90% -> 900, matching the doc's "700 to 1000 = 70% to 100%";
-#   - forced-charge target SOC is a direct percent (scale 1, "0 to 100").
+# Number parameters exposed as HA Number entities. Keys are canonical Control
+# parameter names. The entities present values in their natural unit (watts,
+# percent); the raw value the API expects is produced by pysolarcloud's
+# Control.encode_parameter (which knows, from the docs' Appendix 10, that power is
+# watts, SOC/ratios are tenths of a percent, etc.) — so the encoding lives in one
+# place instead of being duplicated here.
 DISPATCH_NUMBERS: dict[str, dict[str, Any]] = {
     "charge_discharge_power": {
         "device_class": NumberDeviceClass.POWER,
@@ -74,7 +70,6 @@ DISPATCH_NUMBERS: dict[str, dict[str, Any]] = {
         "native_max_value": DEFAULT_MAX_DISPATCH_POWER,
         "native_step": 100,
         "mode": NumberMode.SLIDER,
-        "write_scale": 1,
     },
     "soc_upper_limit": {
         "device_class": NumberDeviceClass.BATTERY,
@@ -85,7 +80,6 @@ DISPATCH_NUMBERS: dict[str, dict[str, Any]] = {
         "mode": NumberMode.SLIDER,
         # SOC limits set battery policy rather than actuate — configuration entities.
         "entity_category": EntityCategory.CONFIG,
-        "write_scale": 10,
     },
     "soc_lower_limit": {
         "device_class": NumberDeviceClass.BATTERY,
@@ -95,7 +89,6 @@ DISPATCH_NUMBERS: dict[str, dict[str, Any]] = {
         "native_step": 1,
         "mode": NumberMode.SLIDER,
         "entity_category": EntityCategory.CONFIG,
-        "write_scale": 10,
     },
     "forced_charging_target_soc_1": {
         "device_class": NumberDeviceClass.BATTERY,
@@ -105,7 +98,6 @@ DISPATCH_NUMBERS: dict[str, dict[str, Any]] = {
         "native_step": 1,
         "mode": NumberMode.SLIDER,
         "entity_category": EntityCategory.CONFIG,
-        "write_scale": 1,
     },
     # Target SOC for the second forced-charging window (mirrors ..._soc_1).
     "forced_charging_target_soc_2": {
@@ -116,7 +108,6 @@ DISPATCH_NUMBERS: dict[str, dict[str, Any]] = {
         "native_step": 1,
         "mode": NumberMode.SLIDER,
         "entity_category": EntityCategory.CONFIG,
-        "write_scale": 1,
     },
     # Export (feed-in) limit as an absolute power in watts. Only takes effect when
     # the feed_in_limitation select is enabled. Sized to the device's rating.
@@ -128,7 +119,6 @@ DISPATCH_NUMBERS: dict[str, dict[str, Any]] = {
         "native_step": 100,
         "mode": NumberMode.SLIDER,
         "entity_category": EntityCategory.CONFIG,
-        "write_scale": 1,
     },
     # Export limit as a percentage of rated power (API range 0-1000 = 0-100%).
     "feed_in_limitation_ratio": {
@@ -138,7 +128,6 @@ DISPATCH_NUMBERS: dict[str, dict[str, Any]] = {
         "native_step": 1,
         "mode": NumberMode.SLIDER,
         "entity_category": EntityCategory.CONFIG,
-        "write_scale": 10,
     },
     # Active power output cap as a percentage of rated power (API range 0-1000).
     "active_power_limit_ratio": {
@@ -148,7 +137,6 @@ DISPATCH_NUMBERS: dict[str, dict[str, Any]] = {
         "native_step": 1,
         "mode": NumberMode.SLIDER,
         "entity_category": EntityCategory.CONFIG,
-        "write_scale": 10,
     },
 }
 
@@ -247,8 +235,6 @@ class SungrowDispatchNumber(CoordinatorEntity[SungrowPlantCoordinator], RestoreN
         self._attr_native_step = meta["native_step"]
         self._attr_mode = meta["mode"]
         self._attr_entity_category = meta.get("entity_category")
-        # Factor converting the displayed value to the raw API value (see DISPATCH_NUMBERS).
-        self._write_scale = meta.get("write_scale", 1)
 
     async def async_added_to_hass(self) -> None:
         """Restore the last commanded value across restarts.
@@ -264,9 +250,9 @@ class SungrowDispatchNumber(CoordinatorEntity[SungrowPlantCoordinator], RestoreN
     async def async_set_native_value(self, value: float) -> None:
         """Update the dispatch parameter on the inverter."""
         _LOGGER.debug("Setting %s to %s for %s", self.param, value, self.device_uuid)
-        # The client sends the value verbatim, so encode it as the API expects: power
-        # in watts (scale 1), SOC limits and ratios as tenths of a percent (scale 10).
-        wire_value = str(int(round(value * self._write_scale)))
+        # Encode the displayed value into the raw value the API expects (watts,
+        # tenths-of-a-percent, etc.) using pysolarcloud's authoritative specs.
+        wire_value = Control.encode_parameter(self.param, value)
         try:
             await self.control.async_update_parameters(self.device_uuid, {self.param: wire_value})
         except PySolarCloudException as err:

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -10,4 +10,4 @@ ruff==0.15.16
 mypy==2.1.0
 
 # Component dependencies
-sungrow-isolarcloud==0.6.0
+sungrow-isolarcloud==0.7.0


### PR DESCRIPTION
Follow-up to #103 (which fixed the dispatch encodings with a local per-parameter scale). **pysolarcloud 0.7.0** now ships the authoritative `Control.PARAMETER_SPECS` + `encode_parameter`, so this delegates to it — the encoding (watts, tenths-of-a-percent, enum codes) lives in **one place** and can't drift between the client and the integration.

## Changes
- Pin **`sungrow-isolarcloud==0.7.0`**.
- `number.py` encodes via `Control.encode_parameter(param, value)` and drops the `write_scale` metadata.
- 0.7.0 ships **`py.typed`**, so drop the `# type: ignore` on subclassing `Auth` and a now-redundant `cast`. Two narrow ignores remain at the pysolarcloud typing boundary (the optional-import fallback, and `Auth.tokens` being annotated `None` upstream).

## No behaviour change
The wire values are identical to #103 (e.g. `soc_upper_limit` 90% → `"900"`, `charge_discharge_power` 2500 W → `"2500"`), so the existing tests are unchanged and still pass. **163 passed**, `mypy --strict` clean, ruff clean.

> Note: `Auth.tokens` being typed `None` upstream is a small pysolarcloud gap worth fixing in a future release (would remove the last ignore).

🤖 Generated with [Claude Code](https://claude.com/claude-code)