### PR TITLE
feat: document and alias common measuring points from the official docs

### DIFF
--- a/custom_components/sungrow/sensor.py
+++ b/custom_components/sungrow/sensor.py
@@ -34,14 +34,34 @@ SENSOR_ALIASES: dict[str, str] = {
     "battery_level_soc": "Battery State of Charge",
 }
 
-# Per-issue custom codes that users commonly request. If the point_id is configured
-# via the options flow, the code is used as-is; we also supply a friendly alias here
-# so the UI label is meaningful.
+# Friendly names for the codes users are recommended to assign when requesting the
+# documented iSolarCloud measuring points via the "Extra measure points" option. The
+# point IDs and units come from the official docs (see docs/SENSORS.md for the
+# copy-paste point_id=code pairs). The device/state class is still inferred from the
+# API-reported unit, so these only set the display name.
 EXTRA_CODE_ALIASES: dict[str, str] = {
     "battery_charge_power": "Battery Charge Power",
     "battery_discharge_power": "Battery Discharge Power",
     "ev_charger_power": "EV Charger Power",
     "ev_charger_energy": "EV Charger Energy",
+    # Battery (common battery measuring points)
+    "battery_level": "Battery Level",
+    "battery_soh": "Battery Health (SOH)",
+    "battery_voltage": "Battery Voltage",
+    "battery_current": "Battery Current",
+    "battery_temperature": "Battery Temperature",
+    "battery_total_charge_energy": "Battery Total Charge Energy",
+    "battery_total_discharge_energy": "Battery Total Discharge Energy",
+    # EV charger (common charger measuring points)
+    "ev_charger_max_power": "EV Charger Max Power",
+    "ev_charger_status": "EV Charger Status",
+    # Energy meter (common energy meter measuring points)
+    "meter_forward_active_energy": "Meter Forward Active Energy",
+    "meter_reverse_active_energy": "Meter Reverse Active Energy",
+    "meter_daily_forward_active_energy": "Meter Daily Forward Active Energy",
+    "meter_daily_reverse_active_energy": "Meter Daily Reverse Active Energy",
+    "meter_active_power": "Meter Active Power",
+    "meter_power_factor": "Meter Power Factor",
 }
 
 _LOGGER = logging.getLogger(__name__)

--- a/docs/SENSORS.md
+++ b/docs/SENSORS.md
@@ -49,6 +49,27 @@ You can find the actual point IDs for your hardware by:
 - Running a diagnostics dump from the device page in Home Assistant.
 - Using community tools such as [GoSungrow](https://github.com/MickMake/GoSungrow) to list points for your plant.
 
+### Recommended measure points (from the official docs)
+
+The official iSolarCloud measuring-point catalogs — also served by the [mcp-isolarcloud](https://github.com/KRoperUK/mcp-isolarcloud) docs server — list the point IDs, names and units per device type. The integration ships friendly names for the codes below, so pasting the matching `point_id=code` pairs into **Extra measure points** gives nicely-named, correctly-classified sensors (device/state class is inferred from the reported unit, so the energy points feed the Energy dashboard automatically).
+
+**Battery** (Common Battery Measuring Points):
+```
+58604=battery_level, 58605=battery_soh, 58601=battery_voltage, 58602=battery_current, 58603=battery_temperature, 58606=battery_total_charge_energy, 58607=battery_total_discharge_energy
+```
+
+**EV charger** (Common Charger Measuring Points):
+```
+33708=ev_charger_power, 33723=ev_charger_max_power, 33716=ev_charger_status
+```
+
+**Energy meter** (Common Energy Meter Measuring Points):
+```
+8030=meter_forward_active_energy, 8031=meter_reverse_active_energy, 8062=meter_daily_forward_active_energy, 8063=meter_daily_reverse_active_energy, 8018=meter_active_power, 8014=meter_power_factor
+```
+
+EMS, PCS, combiner-box and microinverter catalogs are available via the docs server too. Point IDs are consistent per device *type* but not guaranteed across every model/firmware, so confirm against your hardware if a point is missing.
+
 ## Dispatch / control entities
 
 If your inverter / ESS supports parameter configuration, the integration also creates **Number** and **Select** entities per plant for dispatch control:
@@ -68,7 +89,7 @@ When you set **Charge/Discharge Command** to *Charge* or *Discharge*, the integr
 
 ## EV charger support
 
-If your EV charger appears as a separate device in iSolarCloud, its point IDs can be requested via the **Extra measure points** option once identified. The integration does not yet auto-discover EV charger devices because the available codes are not consistent across charger models; community contributions of verified point ID lists are welcome.
+If your EV charger appears as a separate device in iSolarCloud, request its points via the **Extra measure points** option (or enable **per-device sensors**, which polls each discovered device). The documented charger point IDs are listed under [Recommended measure points](#recommended-measure-points-from-the-official-docs) above; verified additions from other charger models are welcome.
 
 ## Still missing a sensor?
 

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -91,6 +91,26 @@ class TestSungrowSensor:
 
         assert sensor._attr_name == "Battery Charge Power"
 
+    @pytest.mark.parametrize(
+        ("code", "unit", "name", "device_class"),
+        [
+            ("battery_level", "%", "Battery Level", SensorDeviceClass.BATTERY),
+            ("battery_soh", "%", "Battery Health (SOH)", SensorDeviceClass.BATTERY),
+            ("battery_total_charge_energy", "Wh", "Battery Total Charge Energy", SensorDeviceClass.ENERGY),
+            ("meter_forward_active_energy", "Wh", "Meter Forward Active Energy", SensorDeviceClass.ENERGY),
+            ("meter_active_power", "W", "Meter Active Power", SensorDeviceClass.POWER),
+            ("ev_charger_max_power", "kW", "EV Charger Max Power", SensorDeviceClass.POWER),
+            ("ev_charger_status", "", "EV Charger Status", None),
+        ],
+    )
+    def test_documented_measure_point_aliases(self, code, unit, name, device_class):
+        """Documented measure-point codes get a friendly name; class is inferred from the unit."""
+        coordinator = self._make_coordinator()
+        sensor = SungrowSensor(coordinator, code, "123", "Plant", {"code": code, "value": "1", "unit": unit})
+
+        assert sensor._attr_name == name
+        assert sensor._attr_device_class == device_class
+
     def test_sensor_name_numeric_code_fallback(self):
         """Test sensor with a numeric code falls back to init_data name."""
         coordinator = self._make_coordinator()


### PR DESCRIPTION
Surfaces the official iSolarCloud **measuring-point catalogs** (battery / EV charger / energy meter) as friendly, ready-to-use sensors. The point IDs, names and units are pulled from the official docs — now queryable via the [mcp-isolarcloud](https://github.com/KRoperUK/mcp-isolarcloud) MCP server — so users get nicely-named, correctly-classified sensors instead of opaque numeric codes.

## Changes
- **`sensor.py`** — extend `EXTRA_CODE_ALIASES` with the documented battery / charger / meter codes (battery level, SOH, voltage/current/temp, total charge/discharge energy; EV charger max power + status; meter forward/reverse + daily active energy, active power, power factor). Device/state class is still inferred from the API-reported unit, so the energy points feed the **Energy dashboard** automatically.
- **`docs/SENSORS.md`** — a new **Recommended measure points** section with copy-paste `point_id=code` blocks per device type, and the EV-charger section now links to it.

`Closes #105.`

## Cross-links — this addresses several older reports
- **#31** *"Please add battery charging and discharging power"* — battery charge/discharge power + total charge/discharge energy are now documented and aliased.
- **#18** *"Include EV Charger values"* — the documented EV charger points (power, max power, status) are listed with a copy-paste block.
- **#7** *"Unable to find correct sensor values"* — the catalog + copy-paste blocks tell users exactly which point IDs exist and what to add (this is the one that previously had no clear resolution).
- **#39** *"Battery Level SOC is not an energy entity"* — clarifies Battery Level (`58604`, %) vs the energy points, which are correctly classed as `ENERGY`.

## Tests
Parametrized test asserts the documented codes get the right friendly name **and** the class inferred from unit (energy→ENERGY, battery %→BATTERY, power→POWER, status→text). **170 passed**, `mypy --strict` clean, ruff clean.

> Point IDs are consistent per device *type*; the docs note to confirm against hardware if a point is missing. No live-device dependency — the code is user-assigned via Extra measure points, and the alias just sets the display name.

🤖 Generated with [Claude Code](https://claude.com/claude-code)