### PR TITLE
feat: add Welsh, German, French, and Spanish translations (#123–#126)

### DIFF
--- a/custom_components/sungrow/translations/cy.json
+++ b/custom_components/sungrow/translations/cy.json
@@ -1,0 +1,123 @@
+{
+  "config": {
+    "step": {
+      "user": {
+        "title": "Cysylltu ag iSolarCloud",
+        "description": "Rhowch eich manylion mynediad API iSolarCloud. Gallwch ddod o hyd iddynt yma: [iSolarCloud]({url})\n\nAr ôl i chi gyflwyno, caiff yr hyb ei greu a bydd Home Assistant yn gofyn i chi ei awdurdodi yn eich porwr.",
+        "data": {
+          "gateway": "Rhanbarth y Porth",
+          "app_key": "AppKey",
+          "app_secret": "App Secret",
+          "app_id": "App ID",
+          "redirect_uri": "URI Ailgyfeirio"
+        },
+        "data_description": {
+          "app_key": "AppKey o Blatfform Datblygwyr iSolarCloud.",
+          "app_secret": "AppSecret o Blatfform Datblygwyr iSolarCloud.",
+          "app_id": "App ID o Blatfform Datblygwyr iSolarCloud. I ddod o hyd i hwn, ewch i'ch cymhwysiad a chwiliwch am 'id' o fewn yr URL fel hyn: {app_id_url}."
+        }
+      },
+      "auth_callback": {
+        "title": "Yn aros am awdurdodiad",
+        "description": "Agorwch y ddolen isod i awdurdodi'r cymhwysiad:\n\n{auth_url}\n\nAr ôl i chi fewngofnodi a chymeradwyo'r ap, cewch eich ailgyfeirio yn ôl a bydd y sgrin hon yn diweddaru'n awtomatig.\n\nOs na fydd yr ailgyfeirio'n cwblhau (er enghraifft mae'r dudalen yn dangos gwall), arhoswch am eiliad a byddwch yn gallu gludo'r cod â llaw."
+      },
+      "auth_manual": {
+        "title": "Rhowch y Cod Awdurdodi",
+        "description": "Ni chwblhaodd yr ailgyfeirio awtomatig. Gorffennwch awdurdodi â llaw:\n\n{auth_url}\n\n**Cyfarwyddiadau:**\n1. Ewch i'r ddolen uchod a mewngofnodi (hepgorwch os ydych eisoes wedi gwneud hynny).\n2. Cewch eich ailgyfeirio (efallai y bydd y dudalen yn dangos gwall).\n3. Copïwch y paramedr **code** o'r bar cyfeiriad URL.\n4. Gludwch y cod — neu'r URL ailgyfeirio llawn — isod.",
+        "data": {
+          "code": "Cod Awdurdodi neu URL ailgyfeirio llawn"
+        }
+      },
+      "reconfigure": {
+        "title": "Ailgyflunio iSolarCloud",
+        "description": "Diweddarwch eich rhanbarth neu fanylion mynediad API (mae'r App ID yn aros yr un fath). Gofynnir i chi awdurdodi eto yn eich porwr, gan fod manylion mynediad newydd neu ranbarth newydd yn gofyn am docynnau ffres.",
+        "data": {
+          "app_key": "AppKey",
+          "app_secret": "App Secret",
+          "gateway": "Rhanbarth y Porth",
+          "redirect_uri": "URI Ailgyfeirio"
+        }
+      }
+    },
+    "progress": {
+      "wait_for_callback": "Yn aros am awdurdodiad. Agorwch y ddolen yn eich porwr i gymeradwyo'r cymhwysiad:\n\n{auth_url}\n\nMae'r sgrin hon yn diweddaru'n awtomatig unwaith y cewch eich ailgyfeirio yn ôl."
+    },
+    "error": {
+      "cannot_connect": "Methwyd â chysylltu",
+      "invalid_auth": "Dilysiad annilys",
+      "invalid_extra_measure_points": "Rhaid i bwyntiau mesur ychwanegol fod ar ffurf point_id=code, wedi'u gwahanu gan atalnodau",
+      "unknown": "Gwall annisgwyl"
+    },
+    "abort": {
+      "already_configured": "Mae'r ddyfais eisoes wedi'i ffurfweddu",
+      "library_missing": "Nid yw'r llyfrgell pysolarcloud wedi'i gosod. Ailgychwynnwch Home Assistant fel bod gofynion yr integreiddiad wedi'u gosod, yna rhowch gynnig arall arni.",
+      "missing_code": "Ni dderbyniwyd y cod awdurdodi. Rhowch gynnig arall arni.",
+      "reauth_successful": "Roedd yr ail-ddilysiad yn llwyddiannus",
+      "reconfigure_successful": "Roedd yr ailgyflunio'n llwyddiannus",
+      "wrong_account": "Nid yw'r cyfrif awdurdodedig yn cyfateb i App ID yr integreiddiad hwn. Defnyddiwch y cymhwysiad datblygwr gwreiddiol."
+    }
+  },
+  "options": {
+    "step": {
+      "init": {
+        "title": "Opsiynau Sungrow",
+        "description": "Addaswch pa mor aml y mae Home Assistant yn holi iSolarCloud. Mae gwerthoedd is yn diweddaru'n amlach ond yn defnyddio mwy o'ch cwota API. Mae'r cynllun am ddim yn caniatáu ~2000 galwad yr awr; y lleiafswm yw 10 eiliad.",
+        "data": {
+          "scan_interval": "Cyfwng holi (eiliadau)",
+          "extra_measure_points": "Pwyntiau mesur ychwanegol (point_id=code, wedi'u gwahanu gan atalnodau)",
+          "enable_device_sensors": "Creu synwyryddion fesul dyfais (gwefrwyr EV, mesuryddion, batris ychwanegol)"
+        }
+      }
+    }
+  },
+  "entity": {
+    "number": {
+      "charge_discharge_power": {
+        "name": "Pŵer Gwefru/Dadwefru"
+      },
+      "soc_upper_limit": {
+        "name": "Terfyn Uchaf SOC"
+      },
+      "soc_lower_limit": {
+        "name": "Terfyn Isaf SOC"
+      },
+      "forced_charging_target_soc_1": {
+        "name": "SOC Targed Gwefru Gorfodol (Ffenestr 1)"
+      },
+      "forced_charging_target_soc_2": {
+        "name": "SOC Targed Gwefru Gorfodol (Ffenestr 2)"
+      },
+      "feed_in_limitation_value": {
+        "name": "Terfyn Allforio (Pŵer)"
+      },
+      "feed_in_limitation_ratio": {
+        "name": "Terfyn Allforio (%)"
+      },
+      "active_power_limit_ratio": {
+        "name": "Terfyn Pŵer Actif"
+      }
+    },
+    "select": {
+      "charge_discharge_command": {
+        "name": "Gorchymyn Gwefru/Dadwefru"
+      },
+      "forced_charging": {
+        "name": "Gwefru Gorfodol"
+      },
+      "feed_in_limitation": {
+        "name": "Cyfyngiad Allforio"
+      },
+      "limited_power_switch": {
+        "name": "Cyfyngu Pŵer Actif"
+      },
+      "battery_first": {
+        "name": "Modd Batri yn Gyntaf"
+      }
+    }
+  },
+  "exceptions": {
+    "dispatch_write_failed": {
+      "message": "Methwyd â diweddaru {param} ar y gwrthdröydd: {error}"
+    }
+  }
+}

--- a/custom_components/sungrow/translations/de.json
+++ b/custom_components/sungrow/translations/de.json
@@ -1,0 +1,123 @@
+{
+  "config": {
+    "step": {
+      "user": {
+        "title": "Mit iSolarCloud verbinden",
+        "description": "Geben Sie Ihre iSolarCloud-API-Zugangsdaten ein. Sie finden diese hier: [iSolarCloud]({url})\n\nNach dem Absenden wird der Hub erstellt und Home Assistant fordert Sie auf, ihn in Ihrem Browser zu autorisieren.",
+        "data": {
+          "gateway": "Gateway-Region",
+          "app_key": "AppKey",
+          "app_secret": "App Secret",
+          "app_id": "App ID",
+          "redirect_uri": "Weiterleitungs-URI"
+        },
+        "data_description": {
+          "app_key": "AppKey aus der iSolarCloud-Entwicklerplattform.",
+          "app_secret": "AppSecret aus der iSolarCloud-Entwicklerplattform.",
+          "app_id": "App ID aus der iSolarCloud-Entwicklerplattform. Um diese zu finden, öffnen Sie Ihre Anwendung und suchen Sie in der URL nach 'id', wie hier: {app_id_url}."
+        }
+      },
+      "auth_callback": {
+        "title": "Warten auf Autorisierung",
+        "description": "Öffnen Sie den folgenden Link, um die Anwendung zu autorisieren:\n\n{auth_url}\n\nNachdem Sie sich angemeldet und die App genehmigt haben, werden Sie zurückgeleitet und diese Ansicht aktualisiert sich automatisch.\n\nFalls die Weiterleitung nicht abgeschlossen wird (zum Beispiel, wenn die Seite einen Fehler anzeigt), warten Sie einen Moment und Sie können den Code manuell einfügen."
+      },
+      "auth_manual": {
+        "title": "Autorisierungscode eingeben",
+        "description": "Die automatische Weiterleitung wurde nicht abgeschlossen. Schließen Sie die Autorisierung manuell ab:\n\n{auth_url}\n\n**Anleitung:**\n1. Öffnen Sie den obigen Link und melden Sie sich an (überspringen, falls bereits geschehen).\n2. Sie werden weitergeleitet (die Seite zeigt möglicherweise einen Fehler an).\n3. Kopieren Sie den Parameter **code** aus der URL-Adressleiste.\n4. Fügen Sie den Code — oder die vollständige Weiterleitungs-URL — unten ein.",
+        "data": {
+          "code": "Autorisierungscode oder vollständige Weiterleitungs-URL"
+        }
+      },
+      "reconfigure": {
+        "title": "iSolarCloud neu konfigurieren",
+        "description": "Aktualisieren Sie Ihre Region oder Ihre API-Zugangsdaten (die App ID bleibt gleich). Sie werden erneut aufgefordert, sich in Ihrem Browser zu autorisieren, da neue Zugangsdaten oder eine neue Region frische Tokens erfordern.",
+        "data": {
+          "app_key": "AppKey",
+          "app_secret": "App Secret",
+          "gateway": "Gateway-Region",
+          "redirect_uri": "Weiterleitungs-URI"
+        }
+      }
+    },
+    "progress": {
+      "wait_for_callback": "Warten auf Autorisierung. Öffnen Sie den Link in Ihrem Browser, um die Anwendung zu genehmigen:\n\n{auth_url}\n\nDiese Ansicht aktualisiert sich automatisch, sobald Sie zurückgeleitet werden."
+    },
+    "error": {
+      "cannot_connect": "Verbindung fehlgeschlagen",
+      "invalid_auth": "Ungültige Authentifizierung",
+      "invalid_extra_measure_points": "Zusätzliche Messpunkte müssen im Format point_id=code, durch Kommata getrennt, angegeben werden",
+      "unknown": "Unerwarteter Fehler"
+    },
+    "abort": {
+      "already_configured": "Das Gerät ist bereits konfiguriert",
+      "library_missing": "Die Bibliothek pysolarcloud ist nicht installiert. Starten Sie Home Assistant neu, damit die Anforderungen der Integration installiert werden, und versuchen Sie es dann erneut.",
+      "missing_code": "Der Autorisierungscode wurde nicht empfangen. Bitte versuchen Sie es erneut.",
+      "reauth_successful": "Die erneute Authentifizierung war erfolgreich",
+      "reconfigure_successful": "Die Neukonfiguration war erfolgreich",
+      "wrong_account": "Das autorisierte Konto stimmt nicht mit der App ID dieser Integration überein. Verwenden Sie die ursprüngliche Entwickleranwendung."
+    }
+  },
+  "options": {
+    "step": {
+      "init": {
+        "title": "Sungrow-Optionen",
+        "description": "Legen Sie fest, wie oft Home Assistant iSolarCloud abfragt. Niedrigere Werte aktualisieren häufiger, verbrauchen aber mehr Ihres API-Kontingents. Der kostenlose Tarif erlaubt ~2000 Aufrufe/Stunde; das Minimum beträgt 10 Sekunden.",
+        "data": {
+          "scan_interval": "Abfrageintervall (Sekunden)",
+          "extra_measure_points": "Zusätzliche Messpunkte (point_id=code, durch Kommata getrennt)",
+          "enable_device_sensors": "Sensoren pro Gerät erstellen (EV-Ladegeräte, Zähler, zusätzliche Batterien)"
+        }
+      }
+    }
+  },
+  "entity": {
+    "number": {
+      "charge_discharge_power": {
+        "name": "Lade-/Entladeleistung"
+      },
+      "soc_upper_limit": {
+        "name": "SOC-Obergrenze"
+      },
+      "soc_lower_limit": {
+        "name": "SOC-Untergrenze"
+      },
+      "forced_charging_target_soc_1": {
+        "name": "Ziel-SOC für erzwungenes Laden (Fenster 1)"
+      },
+      "forced_charging_target_soc_2": {
+        "name": "Ziel-SOC für erzwungenes Laden (Fenster 2)"
+      },
+      "feed_in_limitation_value": {
+        "name": "Einspeisegrenze (Leistung)"
+      },
+      "feed_in_limitation_ratio": {
+        "name": "Einspeisegrenze (%)"
+      },
+      "active_power_limit_ratio": {
+        "name": "Wirkleistungsbegrenzung"
+      }
+    },
+    "select": {
+      "charge_discharge_command": {
+        "name": "Lade-/Entladebefehl"
+      },
+      "forced_charging": {
+        "name": "Erzwungenes Laden"
+      },
+      "feed_in_limitation": {
+        "name": "Einspeisebegrenzung"
+      },
+      "limited_power_switch": {
+        "name": "Wirkleistungsbegrenzung aktiv"
+      },
+      "battery_first": {
+        "name": "Batterie-zuerst-Modus"
+      }
+    }
+  },
+  "exceptions": {
+    "dispatch_write_failed": {
+      "message": "{param} konnte auf dem Wechselrichter nicht aktualisiert werden: {error}"
+    }
+  }
+}

--- a/custom_components/sungrow/translations/es.json
+++ b/custom_components/sungrow/translations/es.json
@@ -1,0 +1,123 @@
+{
+  "config": {
+    "step": {
+      "user": {
+        "title": "Conectar con iSolarCloud",
+        "description": "Introduzca sus credenciales de la API de iSolarCloud. Puede encontrarlas aquí: [iSolarCloud]({url})\n\nDespués de enviarlas, se crea el concentrador y Home Assistant le pedirá que lo autorice en su navegador.",
+        "data": {
+          "gateway": "Región de la pasarela",
+          "app_key": "AppKey",
+          "app_secret": "App Secret",
+          "app_id": "App ID",
+          "redirect_uri": "URI de redirección"
+        },
+        "data_description": {
+          "app_key": "AppKey de la plataforma para desarrolladores de iSolarCloud.",
+          "app_secret": "AppSecret de la plataforma para desarrolladores de iSolarCloud.",
+          "app_id": "App ID de la plataforma para desarrolladores de iSolarCloud. Para encontrarlo, vaya a su aplicación y busque «id» dentro de la URL, de esta forma: {app_id_url}."
+        }
+      },
+      "auth_callback": {
+        "title": "Esperando la autorización",
+        "description": "Abra el enlace siguiente para autorizar la aplicación:\n\n{auth_url}\n\nDespués de iniciar sesión y aprobar la aplicación, será redirigido de vuelta y esta pantalla se actualizará automáticamente.\n\nSi la redirección no se completa (por ejemplo, si la página muestra un error), espere un momento y podrá pegar el código manualmente."
+      },
+      "auth_manual": {
+        "title": "Introducir el código de autorización",
+        "description": "La redirección automática no se completó. Finalice la autorización manualmente:\n\n{auth_url}\n\n**Instrucciones:**\n1. Abra el enlace anterior e inicie sesión (omita este paso si ya lo hizo).\n2. Será redirigido (la página puede mostrar un error).\n3. Copie el parámetro **code** de la barra de direcciones de la URL.\n4. Pegue el código —o la URL de redirección completa— a continuación.",
+        "data": {
+          "code": "Código de autorización o URL de redirección completa"
+        }
+      },
+      "reconfigure": {
+        "title": "Reconfigurar iSolarCloud",
+        "description": "Actualice su región o sus credenciales de la API (el App ID no cambia). Se le pedirá que vuelva a autorizar en su navegador, ya que unas credenciales nuevas o una región nueva requieren tokens nuevos.",
+        "data": {
+          "app_key": "AppKey",
+          "app_secret": "App Secret",
+          "gateway": "Región de la pasarela",
+          "redirect_uri": "URI de redirección"
+        }
+      }
+    },
+    "progress": {
+      "wait_for_callback": "Esperando la autorización. Abra el enlace en su navegador para aprobar la aplicación:\n\n{auth_url}\n\nEsta pantalla se actualiza automáticamente en cuanto sea redirigido de vuelta."
+    },
+    "error": {
+      "cannot_connect": "No se pudo conectar",
+      "invalid_auth": "Autenticación no válida",
+      "invalid_extra_measure_points": "Los puntos de medición adicionales deben tener el formato point_id=code, separados por comas",
+      "unknown": "Error inesperado"
+    },
+    "abort": {
+      "already_configured": "El dispositivo ya está configurado",
+      "library_missing": "La biblioteca pysolarcloud no está instalada. Reinicie Home Assistant para que se instalen las dependencias de la integración y vuelva a intentarlo.",
+      "missing_code": "No se recibió el código de autorización. Vuelva a intentarlo.",
+      "reauth_successful": "La reautenticación se realizó correctamente",
+      "reconfigure_successful": "La reconfiguración se realizó correctamente",
+      "wrong_account": "La cuenta autorizada no coincide con el App ID de esta integración. Use la aplicación de desarrollador original."
+    }
+  },
+  "options": {
+    "step": {
+      "init": {
+        "title": "Opciones de Sungrow",
+        "description": "Ajuste la frecuencia con la que Home Assistant consulta iSolarCloud. Los valores más bajos actualizan con más frecuencia, pero consumen más de su cuota de la API. El plan gratuito permite unas 2000 llamadas/hora; el mínimo es de 10 segundos.",
+        "data": {
+          "scan_interval": "Intervalo de sondeo (segundos)",
+          "extra_measure_points": "Puntos de medición adicionales (point_id=code, separados por comas)",
+          "enable_device_sensors": "Crear sensores por dispositivo (cargadores de VE, contadores, baterías adicionales)"
+        }
+      }
+    }
+  },
+  "entity": {
+    "number": {
+      "charge_discharge_power": {
+        "name": "Potencia de carga/descarga"
+      },
+      "soc_upper_limit": {
+        "name": "Límite superior del SOC"
+      },
+      "soc_lower_limit": {
+        "name": "Límite inferior del SOC"
+      },
+      "forced_charging_target_soc_1": {
+        "name": "SOC objetivo de carga forzada (Ventana 1)"
+      },
+      "forced_charging_target_soc_2": {
+        "name": "SOC objetivo de carga forzada (Ventana 2)"
+      },
+      "feed_in_limitation_value": {
+        "name": "Límite de exportación (Potencia)"
+      },
+      "feed_in_limitation_ratio": {
+        "name": "Límite de exportación (%)"
+      },
+      "active_power_limit_ratio": {
+        "name": "Límite de potencia activa"
+      }
+    },
+    "select": {
+      "charge_discharge_command": {
+        "name": "Comando de carga/descarga"
+      },
+      "forced_charging": {
+        "name": "Carga forzada"
+      },
+      "feed_in_limitation": {
+        "name": "Limitación de exportación"
+      },
+      "limited_power_switch": {
+        "name": "Limitación de potencia activa"
+      },
+      "battery_first": {
+        "name": "Modo Batería primero"
+      }
+    }
+  },
+  "exceptions": {
+    "dispatch_write_failed": {
+      "message": "No se pudo actualizar {param} en el inversor: {error}"
+    }
+  }
+}

--- a/custom_components/sungrow/translations/fr.json
+++ b/custom_components/sungrow/translations/fr.json
@@ -1,0 +1,123 @@
+{
+  "config": {
+    "step": {
+      "user": {
+        "title": "Se connecter à iSolarCloud",
+        "description": "Saisissez vos identifiants d'API iSolarCloud. Vous pouvez les trouver ici : [iSolarCloud]({url})\n\nAprès validation, le hub est créé et Home Assistant vous invitera à l'autoriser dans votre navigateur.",
+        "data": {
+          "gateway": "Région de la passerelle",
+          "app_key": "AppKey",
+          "app_secret": "App Secret",
+          "app_id": "App ID",
+          "redirect_uri": "URI de redirection"
+        },
+        "data_description": {
+          "app_key": "AppKey depuis la plateforme développeur iSolarCloud.",
+          "app_secret": "AppSecret depuis la plateforme développeur iSolarCloud.",
+          "app_id": "App ID depuis la plateforme développeur iSolarCloud. Pour la trouver, ouvrez votre application et recherchez « id » dans l'URL, comme ceci : {app_id_url}."
+        }
+      },
+      "auth_callback": {
+        "title": "En attente de l'autorisation",
+        "description": "Ouvrez le lien ci-dessous pour autoriser l'application :\n\n{auth_url}\n\nUne fois connecté et après avoir approuvé l'application, vous serez redirigé et cet écran se mettra à jour automatiquement.\n\nSi la redirection ne se termine pas (par exemple si la page affiche une erreur), patientez un instant et vous pourrez coller le code manuellement."
+      },
+      "auth_manual": {
+        "title": "Saisir le code d'autorisation",
+        "description": "La redirection automatique ne s'est pas terminée. Terminez l'autorisation manuellement :\n\n{auth_url}\n\n**Instructions :**\n1. Ouvrez le lien ci-dessus et connectez-vous (ignorez cette étape si c'est déjà fait).\n2. Vous serez redirigé (la page peut afficher une erreur).\n3. Copiez le paramètre **code** depuis la barre d'adresse de l'URL.\n4. Collez le code — ou l'URL de redirection complète — ci-dessous.",
+        "data": {
+          "code": "Code d'autorisation ou URL de redirection complète"
+        }
+      },
+      "reconfigure": {
+        "title": "Reconfigurer iSolarCloud",
+        "description": "Mettez à jour votre région ou vos identifiants d'API (l'App ID reste identique). Vous serez de nouveau invité à autoriser l'accès dans votre navigateur, car de nouveaux identifiants ou une nouvelle région nécessitent de nouveaux jetons.",
+        "data": {
+          "app_key": "AppKey",
+          "app_secret": "App Secret",
+          "gateway": "Région de la passerelle",
+          "redirect_uri": "URI de redirection"
+        }
+      }
+    },
+    "progress": {
+      "wait_for_callback": "En attente de l'autorisation. Ouvrez le lien dans votre navigateur pour approuver l'application :\n\n{auth_url}\n\nCet écran se met à jour automatiquement une fois que vous êtes redirigé."
+    },
+    "error": {
+      "cannot_connect": "Échec de la connexion",
+      "invalid_auth": "Authentification non valide",
+      "invalid_extra_measure_points": "Les points de mesure supplémentaires doivent être au format point_id=code, séparés par des virgules",
+      "unknown": "Erreur inattendue"
+    },
+    "abort": {
+      "already_configured": "L'appareil est déjà configuré",
+      "library_missing": "La bibliothèque pysolarcloud n'est pas installée. Redémarrez Home Assistant pour que les dépendances de l'intégration soient installées, puis réessayez.",
+      "missing_code": "Le code d'autorisation n'a pas été reçu. Veuillez réessayer.",
+      "reauth_successful": "La ré-authentification a réussi",
+      "reconfigure_successful": "La reconfiguration a réussi",
+      "wrong_account": "Le compte autorisé ne correspond pas à l'App ID de cette intégration. Utilisez l'application développeur d'origine."
+    }
+  },
+  "options": {
+    "step": {
+      "init": {
+        "title": "Options Sungrow",
+        "description": "Ajustez la fréquence à laquelle Home Assistant interroge iSolarCloud. Des valeurs plus basses actualisent plus souvent mais consomment davantage de votre quota d'API. Le forfait gratuit autorise environ 2000 appels/heure ; le minimum est de 10 secondes.",
+        "data": {
+          "scan_interval": "Intervalle d'interrogation (secondes)",
+          "extra_measure_points": "Points de mesure supplémentaires (point_id=code, séparés par des virgules)",
+          "enable_device_sensors": "Créer des capteurs par appareil (bornes de recharge EV, compteurs, batteries supplémentaires)"
+        }
+      }
+    }
+  },
+  "entity": {
+    "number": {
+      "charge_discharge_power": {
+        "name": "Puissance de charge/décharge"
+      },
+      "soc_upper_limit": {
+        "name": "Limite supérieure du SOC"
+      },
+      "soc_lower_limit": {
+        "name": "Limite inférieure du SOC"
+      },
+      "forced_charging_target_soc_1": {
+        "name": "SOC cible de charge forcée (Fenêtre 1)"
+      },
+      "forced_charging_target_soc_2": {
+        "name": "SOC cible de charge forcée (Fenêtre 2)"
+      },
+      "feed_in_limitation_value": {
+        "name": "Limite d'injection (Puissance)"
+      },
+      "feed_in_limitation_ratio": {
+        "name": "Limite d'injection (%)"
+      },
+      "active_power_limit_ratio": {
+        "name": "Limite de puissance active"
+      }
+    },
+    "select": {
+      "charge_discharge_command": {
+        "name": "Commande de charge/décharge"
+      },
+      "forced_charging": {
+        "name": "Charge forcée"
+      },
+      "feed_in_limitation": {
+        "name": "Limitation d'injection"
+      },
+      "limited_power_switch": {
+        "name": "Limitation de puissance active"
+      },
+      "battery_first": {
+        "name": "Mode Batterie prioritaire"
+      }
+    }
+  },
+  "exceptions": {
+    "dispatch_write_failed": {
+      "message": "Impossible de mettre à jour {param} sur l'onduleur : {error}"
+    }
+  }
+}


### PR DESCRIPTION
Adds UI translations for four languages, one commit each.

| Lang | Code | File | Issue |
|---|---|---|---|
| Welsh | `cy` | `translations/cy.json` | Closes #123 |
| German | `de` | `translations/de.json` | Closes #124 |
| French | `fr` | `translations/fr.json` | Closes #125 |
| Spanish | `es` | `translations/es.json` | Closes #126 |

Each file mirrors `strings.json` exactly (all four verified: **identical 86-key nested structure**), covering the config flow (user + OAuth callback/manual + reconfigure), options flow, errors/aborts, entity names (dispatch numbers/selects), and the dispatch exception message. All `{placeholders}`, markdown, and brand/technical terms (iSolarCloud, SOC, AppKey, …) are preserved verbatim; only human-readable prose is translated.

## ⚠️ Machine-translated — native review welcome
These are AI-generated to give each locale a complete, structurally-correct starting point. They read naturally and use the right domain terms (e.g. *Wechselrichter*/*onduleur*, *Einspeisung*/*injection*, formal register), but a **native speaker review is encouraged** — especially **Welsh**. Small choices flagged for reviewers:
- **EV chargers**: `es` uses the native acronym **VE** (vehículo eléctrico); `fr`/`de` keep **EV**. Pick one convention if you prefer consistency.
- A few PV/energy terms (feed-in/export, gateway region, "Battery First") have defensible alternatives noted per-language in the commit discussion.

HA falls back to English for any key, so these are purely additive and low-risk.

Verification: ruff + mypy + `test_strings.py` green; structural parity checked for all five locale files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)