### PR TITLE
fix: anonymise device uuid keys in diagnostics per-device realtime

### DIFF
--- a/custom_components/sungrow/diagnostics.py
+++ b/custom_components/sungrow/diagnostics.py
@@ -27,6 +27,26 @@ PROBE_TIMEOUT = 30
 TO_REDACT = {"app_id", "uuid", "ps_key", "dev_sn", "sn", "device_sn"}
 
 
+def _anonymise_device_keys(realtime: Any, uuid_map: dict[str, str]) -> Any:
+    """Replace device-uuid keys in a per-device realtime dict with stable placeholders.
+
+    ``async_get_device_realtime`` returns ``{device_uuid: {...points...}}`` — the device
+    uuids are dict *keys*, not values named ``uuid``, so ``async_redact_data`` (which only
+    scrubs values under known key names) can't reach them and they would otherwise leak
+    into a diagnostics download (#122). Map each uuid to a stable ``device_N`` placeholder,
+    sharing ``uuid_map`` across device types within a plant so the same device keeps the
+    same label. Non-dict payloads (e.g. an ``{"error": ...}`` capture) pass through
+    untouched — their keys are not uuids.
+    """
+    if not isinstance(realtime, dict):
+        return realtime
+    anonymised: dict[str, Any] = {}
+    for uuid, payload in realtime.items():
+        placeholder = uuid_map.setdefault(str(uuid), f"device_{len(uuid_map) + 1}")
+        anonymised[placeholder] = payload
+    return anonymised
+
+
 def _jsonable(obj: Any) -> Any:
     """Make API payloads JSON-serialisable for the diagnostics download.
 
@@ -65,6 +85,9 @@ async def _probe_plant_devices(service: Any, plant_id: str) -> tuple[list[dict[s
 
     device_realtime: dict[str, Any] = {}
     seen_types: set[Any] = set()
+    # Shared across device types so a given device uuid always maps to the same
+    # ``device_N`` placeholder within this plant's per-device realtime section (#122).
+    uuid_map: dict[str, str] = {}
     for device in all_devices:
         if not isinstance(device, dict):
             continue
@@ -78,7 +101,7 @@ async def _probe_plant_devices(service: Any, plant_id: str) -> tuple[list[dict[s
         try:
             async with asyncio.timeout(PROBE_TIMEOUT):
                 realtime = await service.async_get_device_realtime(plant_id, device_type)
-            device_realtime[str(type_id)] = _jsonable(realtime)
+            device_realtime[str(type_id)] = _anonymise_device_keys(_jsonable(realtime), uuid_map)
         except Exception as err:  # pylint: disable=broad-except
             _LOGGER.debug("Diagnostics: device realtime failed for type %s: %s", type_id, err)
             device_realtime[str(type_id)] = {"error": str(err)}

--- a/tests/test_diagnostics.py
+++ b/tests/test_diagnostics.py
@@ -82,8 +82,10 @@ async def test_config_entry_diagnostics(hass: HomeAssistant):
     assert charger["uuid"] == "**REDACTED**"
     ess = next(d for d in plant["all_devices"] if d["device_name"] == "Inverter")
     assert ess["device_type"] == "ENERGY_STORAGE_SYSTEM (14)"
-    # Per-device realtime is captured, keyed by device type id.
-    assert plant["device_realtime"]["999"]["chg-1"]["ev_charger_power"]["value"] == "7.2"
+    # Per-device realtime is captured, keyed by device type id; the per-device
+    # uuid key is anonymised to a stable device_N placeholder (#122).
+    assert "chg-1" not in plant["device_realtime"]["999"]
+    assert plant["device_realtime"]["999"]["device_1"]["ev_charger_power"]["value"] == "7.2"
 
     # The whole payload must be JSON-serialisable (no leftover enums).
     json.dumps(diag)
@@ -144,6 +146,56 @@ async def test_diagnostics_per_device_realtime_failure_is_captured(hass: HomeAss
 
     assert diag["plants"]["1"]["device_realtime"]["999"] == {"error": "nope"}
     json.dumps(diag)
+
+
+async def test_diagnostics_anonymises_device_realtime_uuid_keys(hass: HomeAssistant):
+    """Per-device realtime is keyed by device uuid; those uuid keys must not leak (#122).
+
+    ``async_redact_data`` only scrubs values under known key names, so device uuids used
+    as dict *keys* need explicit anonymisation to stable ``device_N`` placeholders.
+    """
+    entry = MagicMock()
+    entry.entry_id = "e"
+    entry.data = {"gateway": "Europe", "app_id": "a"}
+    entry.options = {}
+
+    service = MagicMock()
+    service.async_get_plant_devices = AsyncMock(
+        return_value=[
+            {"uuid": "ess-aaaa", "device_name": "ESS", "device_type": DeviceType.ENERGY_STORAGE_SYSTEM},
+            {"uuid": "chg-bbbb", "device_name": "Charger", "device_type": 999},
+        ]
+    )
+
+    async def _fake_realtime(plant_id, device_type):
+        if getattr(device_type, "value", device_type) == DeviceType.ENERGY_STORAGE_SYSTEM.value:
+            # Two batteries of the same type -> two distinct uuid keys.
+            return {
+                "ess-aaaa": {"battery_level_soc": {"code": "battery_level_soc", "value": "55"}},
+                "batt-cccc": {"battery_level_soc": {"code": "battery_level_soc", "value": "60"}},
+            }
+        return {"chg-bbbb": {"ev_charger_power": {"code": "ev_charger_power", "value": "7.2"}}}
+
+    service.async_get_device_realtime = AsyncMock(side_effect=_fake_realtime)
+    coordinator = _make_coordinator("1", "P", {}, plants_service=service)
+    entry.runtime_data = SungrowData(coordinators=[coordinator], control=MagicMock(), devices={})
+
+    diag = await async_get_config_entry_diagnostics(hass, entry)
+    realtime = diag["plants"]["1"]["device_realtime"]
+
+    # No raw device uuid appears anywhere in the serialised diagnostics payload.
+    dumped = json.dumps(diag)
+    for raw in ("ess-aaaa", "batt-cccc", "chg-bbbb"):
+        assert raw not in dumped
+
+    ess_type = str(DeviceType.ENERGY_STORAGE_SYSTEM.value)
+    # Both same-type devices get distinct stable placeholders; their points survive.
+    assert set(realtime[ess_type]) == {"device_1", "device_2"}
+    soc_values = {realtime[ess_type][k]["battery_level_soc"]["value"] for k in realtime[ess_type]}
+    assert soc_values == {"55", "60"}
+    # A device of a different type continues the same counter (no collision).
+    assert list(realtime["999"]) == ["device_3"]
+    assert realtime["999"]["device_3"]["ev_charger_power"]["value"] == "7.2"
 
 
 async def test_diagnostics_redacts_hardware_identifiers(hass: HomeAssistant):


### PR DESCRIPTION
## Summary

Follow-up gap from #114. The diagnostics `device_realtime` section maps each device type to the per-device realtime payload from `async_get_device_realtime`, which is **keyed by device uuid**. Because those uuids are dict *keys* (not values under a `uuid` key), `async_redact_data` could not reach them and they leaked into a pasted diagnostics dump.

## Change

- Add `_anonymise_device_keys()` which replaces each device-uuid key with a stable `device_N` placeholder, sharing the map across device types within a plant so a given device keeps the same label.
- Wire it into the success path of `_probe_plant_devices`. Non-dict payloads (e.g. an `{"error": ...}` capture) pass through untouched — their keys are not uuids.

## Tests

- New `test_diagnostics_anonymises_device_realtime_uuid_keys`: two same-type devices get `device_1`/`device_2`, a different-type device continues the counter (`device_3`), point data survives, and no raw uuid appears anywhere in the serialised payload.
- Updated the existing realtime assertion (it previously baked in the leaked `chg-1` uuid key).

Full suite green (271 passed), ruff + format + mypy clean.

Closes #122

🤖 Generated with [Claude Code](https://claude.com/claude-code)