### PR TITLE
fix: don't create sensors for points with no usable reading

### DIFF
--- a/custom_components/sungrow/sensor.py
+++ b/custom_components/sungrow/sensor.py
@@ -39,6 +39,12 @@ def _build_sensors(coordinator: SungrowPlantCoordinator, console_url: str) -> li
     Called both at setup and on every coordinator update, so points/devices that
     appear after setup are surfaced at runtime (dynamic-devices). The caller
     de-duplicates by unique_id, so returning the complete set each time is fine.
+
+    Points with no usable reading are skipped: the cloud returns the *full* measure-
+    point catalogue regardless of installed hardware, so a PV-only plant still gets
+    every battery/EMS/EV point back — as ``null`` or a ``"--"`` placeholder — which
+    would otherwise litter the UI with permanently "Unknown" entities. Because this
+    builder re-runs every poll, a point that later reports real data is added then.
     """
     sensors: list[SungrowSensor] = []
 
@@ -46,11 +52,12 @@ def _build_sensors(coordinator: SungrowPlantCoordinator, console_url: str) -> li
     # The data structure is { "P_CODE": { "code": ..., "value": ..., "unit": ..., "name": ... } }
     if coordinator.data:
         for point_code, point_data in coordinator.data.items():
-            sensors.append(
-                SungrowSensor(
-                    coordinator, point_code, coordinator.plant_id, coordinator.plant_name, point_data, console_url
-                )
+            sensor = SungrowSensor(
+                coordinator, point_code, coordinator.plant_id, coordinator.plant_name, point_data, console_url
             )
+            if sensor.native_value is None:
+                continue
+            sensors.append(sensor)
 
     # Per-device sensors (opt-in, issue #74): surface points reported per device
     # (EV chargers, meters, extra batteries). Points already present at the plant
@@ -68,9 +75,12 @@ def _build_sensors(coordinator: SungrowPlantCoordinator, console_url: str) -> li
             for point_code, point_data in points.items():
                 if point_code in plant_codes:
                     continue
-                sensors.append(
-                    SungrowDeviceSensor(coordinator, point_code, coordinator.plant_id, uuid, device_name, point_data)
+                sensor = SungrowDeviceSensor(
+                    coordinator, point_code, coordinator.plant_id, uuid, device_name, point_data
                 )
+                if sensor.native_value is None:
+                    continue
+                sensors.append(sensor)
 
     return sensors
 

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -355,6 +355,35 @@ async def test_sensor_setup_skips_plant_with_no_data(hass: HomeAssistant):
     assert added == []
 
 
+async def test_sensor_setup_skips_points_with_no_usable_reading(hass: HomeAssistant):
+    """Points that render as Unknown (null / blank / "--" placeholder) are not created.
+
+    The cloud returns the full measure-point catalogue regardless of installed
+    hardware, so a PV-only plant gets battery/EMS points back as null or a "--"
+    placeholder. Those would render permanently "Unknown", so they are skipped.
+    """
+    entry = MockConfigEntry(domain=DOMAIN, data=MOCK_CONFIG_DATA.copy())
+    entry.add_to_hass(hass)
+
+    coordinator = _coordinator_with(
+        "12345",
+        "Plant A",
+        {
+            "total_active_power": {"value": "5.0", "unit": "kW", "name": "Total Active Power"},  # real -> kept
+            "daily_yield": {"value": "0", "unit": "kWh", "name": "Daily Yield"},  # a real zero -> kept
+            "battery_power": {"value": "--", "unit": "W", "name": "Battery Power"},  # placeholder -> skipped
+            "battery_level_soc": {"value": None, "unit": "%", "name": "SOC"},  # null -> skipped
+            "ems_battery_power": {"value": "unknown", "unit": "kW", "name": "EMS"},  # unknown -> skipped
+        },
+    )
+    entry.runtime_data = SungrowData(coordinators=[coordinator], control=MagicMock(), devices={})
+
+    added = []
+    await async_setup_entry(hass, entry, lambda entities: added.extend(entities))
+
+    assert {e.point_code for e in added} == {"total_active_power", "daily_yield"}
+
+
 # ---------------------------------------------------------------------------
 # Per-device sensors (issue #74)
 # ---------------------------------------------------------------------------
@@ -424,6 +453,34 @@ async def test_sensor_dynamic_add_on_new_point(hass: HomeAssistant):
     for cb in listeners:
         cb()
     assert len(added) == 2
+
+
+async def test_sensor_dynamic_add_when_placeholder_becomes_real(hass: HomeAssistant):
+    """A point skipped as Unknown at setup is added once it starts reporting real data."""
+    entry = MockConfigEntry(domain=DOMAIN, data=MOCK_CONFIG_DATA.copy())
+    entry.add_to_hass(hass)
+
+    coordinator = _coordinator_with(
+        "12345",
+        "Plant A",
+        {
+            "total_active_power": {"value": "5.0", "unit": "kW"},
+            "battery_power": {"value": "--", "unit": "W", "name": "Battery Power"},  # skipped at setup
+        },
+    )
+    listeners: list = []
+    coordinator.async_add_listener = lambda cb, *a: listeners.append(cb) or (lambda: None)
+    entry.runtime_data = SungrowData(coordinators=[coordinator], control=MagicMock(), devices={})
+
+    added = []
+    await async_setup_entry(hass, entry, lambda entities: added.extend(entities))
+    assert {e.point_code for e in added} == {"total_active_power"}
+
+    # The battery starts reporting a real value on a later poll.
+    coordinator.data = {**coordinator.data, "battery_power": {"value": "1500", "unit": "W", "name": "Battery Power"}}
+    for cb in listeners:
+        cb()
+    assert {e.point_code for e in added} == {"total_active_power", "battery_power"}
 
 
 async def test_device_sensors_not_created_when_disabled(hass: HomeAssistant):


### PR DESCRIPTION
## Summary

On a PV-only system, the integration created ~40 permanently **"Unknown"** sensors (`Battery *`, `EMS *`, `Ess *`, `Planned Es *`, `Energy Storage *`). The iSolarCloud realtime endpoint returns the **full measure-point catalogue regardless of installed hardware**, so a plant with no battery/EMS/EV still gets all those points back — as `null` or a `"--"` placeholder.

The existing `entity_registry_enabled_default = False` guard only recognised `null` / blank / `"unknown"`, so points returning `"--"` (or any value a classified-numeric sensor can't coerce) slipped through: the entity stayed **enabled**, and `native_value` couldn't parse `"--"` → rendered "Unknown".

## Change

`_build_sensors` now **skips a point when it currently renders as `None`** (`sensor.native_value is None`). This is sentinel-agnostic — it catches `null`, `""`, `"--"`, and non-coercible placeholders alike, i.e. exactly the values that would display as "Unknown". Applied to both plant-level and per-device sensors.

Nothing is lost for systems that *do* have the hardware: the builder already re-runs on every coordinator update (the dynamic-devices listener), so a point that later reports real data is added then. A real `0`/`0.0` is a valid reading and is kept.

## Tests

- `test_sensor_setup_skips_points_with_no_usable_reading` — a mix of real / `--` / `null` / `"unknown"` points yields only the real ones (a real `0` is kept).
- `test_sensor_dynamic_add_when_placeholder_becomes_real` — a `"--"` point skipped at setup is added once it starts reporting a real value.

Full suite green (273 passed), ruff + format + mypy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)