### PR TITLE
feat: clearer log messages for iSolarCloud whitelist rejections (E918/E919)

### DIFF
--- a/custom_components/sungrow/__init__.py
+++ b/custom_components/sungrow/__init__.py
@@ -31,7 +31,7 @@ from .const import (
     DOMAIN,
     GATEWAYS,
 )
-from .coordinator import SungrowPlantCoordinator, is_auth_error
+from .coordinator import SungrowPlantCoordinator, describe_api_error, is_auth_error
 
 PLATFORMS: list[Platform] = [Platform.NUMBER, Platform.SELECT, Platform.SENSOR]
 
@@ -188,7 +188,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: SungrowConfigEntry) -> b
         if is_auth_error(err):
             raise ConfigEntryAuthFailed(f"Authentication with iSolarCloud failed: {err}") from err
         # A timeout arrives here as TimeoutError and is treated as transient.
-        raise ConfigEntryNotReady(f"Unable to fetch plants from iSolarCloud: {err}") from err
+        raise ConfigEntryNotReady(describe_api_error(err) or f"Unable to fetch plants from iSolarCloud: {err}") from err
 
     coordinators: list[SungrowPlantCoordinator] = []
     devices_by_plant: dict[str, list[dict[str, Any]]] = {}

--- a/custom_components/sungrow/auth.py
+++ b/custom_components/sungrow/auth.py
@@ -27,11 +27,16 @@ _LOGGER = logging.getLogger(__name__)
 # (a PySolarCloudException), raised when a refresh returns no access token.
 #
 # The "E*" codes are the documented iSolarCloud OpenAPI result codes for dead or
-# unauthorized credentials (E00003 token invalid/expired, E900 unauthorized, E919
-# de-whitelisted, E912/E914 bad or mismatched app key). pysolarcloud >=0.8.0 raises
+# unauthorized credentials (E00003 token invalid/expired, E900 unauthorized,
+# E912/E914 bad or mismatched app key). pysolarcloud >=0.8.0 raises
 # PySolarCloudException carrying the API result_code on ``.error``, so these now
-# reliably drive reauth; the quota/throttle codes E998/E999 are deliberately excluded
-# because they are transient and must keep retrying (UpdateFailed), not reauth.
+# reliably drive reauth.
+#
+# Deliberately NOT here (kept transient/retry, not reauth): the quota/throttle codes
+# E998/E999, and the whitelist rejections E918 (IP not whitelisted) / E919 (user not
+# whitelisted). A whitelist rejection is a Developer-Portal configuration issue that
+# re-authorizing cannot fix, so it must keep retrying until the whitelist is corrected;
+# ``describe_api_error`` (coordinator.py) turns those codes into an actionable log hint.
 AUTH_ERRORS = frozenset(
     {
         "auth_not_initialised",
@@ -40,7 +45,6 @@ AUTH_ERRORS = frozenset(
         "token_refresh_failed",
         "E00003",
         "E900",
-        "E919",
         "E912",
         "E914",
     }

--- a/custom_components/sungrow/coordinator.py
+++ b/custom_components/sungrow/coordinator.py
@@ -44,6 +44,30 @@ def is_auth_error(err: Exception) -> bool:
     return False
 
 
+# Actionable hints for otherwise-opaque iSolarCloud result codes. Both are Developer-
+# Portal whitelist rejections (Appendix 2) that keep retrying (see AUTH_ERRORS), so the
+# raw code would just repeat in the log with no explanation of how to fix it.
+API_ERROR_HINTS = {
+    "E918": (
+        "iSolarCloud rejected the request: this client's IP address is not in your API "
+        "application's IP whitelist (E918). In the iSolarCloud Developer Portal, add this "
+        "machine's public IP to the whitelist or disable it, then it recovers automatically."
+    ),
+    "E919": (
+        "iSolarCloud rejected the request: your account is not in your API application's user "
+        "whitelist (E919). In the iSolarCloud Developer Portal, add your account to the whitelist "
+        "or disable it, then it recovers automatically."
+    ),
+}
+
+
+def describe_api_error(err: Exception) -> str | None:
+    """Return an actionable message for a known iSolarCloud error code, else None."""
+    if isinstance(err, PySolarCloudException) and err.error is not None:
+        return API_ERROR_HINTS.get(err.error)
+    return None
+
+
 class SungrowPlantCoordinator(DataUpdateCoordinator[dict[str, Any]]):
     """Coordinator to manage fetching data from a single plant."""
 
@@ -95,7 +119,7 @@ class SungrowPlantCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             if is_auth_error(err):
                 raise ConfigEntryAuthFailed(f"Authentication with iSolarCloud failed: {err}") from err
             # A timeout arrives here as TimeoutError and is treated as transient.
-            raise UpdateFailed(f"Error communicating with iSolarCloud API: {err}") from err
+            raise UpdateFailed(describe_api_error(err) or f"Error communicating with iSolarCloud API: {err}") from err
 
         # Refresh the device list so devices added to the plant after setup are
         # picked up at runtime (dynamic-devices) and removed ones can be pruned

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -16,7 +16,7 @@ from custom_components.sungrow.const import (
     CONF_SCAN_INTERVAL,
     DEVICE_REFRESH_INTERVAL,
 )
-from custom_components.sungrow.coordinator import SungrowPlantCoordinator, is_auth_error
+from custom_components.sungrow.coordinator import SungrowPlantCoordinator, describe_api_error, is_auth_error
 
 from .conftest import MOCK_REALTIME_DATA
 
@@ -60,7 +60,7 @@ def test_is_auth_error_transient():
     assert is_auth_error(PySolarCloudException({"error": "server_busy"})) is False
 
 
-@pytest.mark.parametrize("code", ["E00003", "E900", "E919", "E912", "E914"])
+@pytest.mark.parametrize("code", ["E00003", "E900", "E912", "E914"])
 def test_is_auth_error_documented_reauth_codes(code):
     """The documented API auth/permission error codes trigger reauth (issue #109)."""
     assert is_auth_error(PySolarCloudException({"error": code})) is True
@@ -70,6 +70,21 @@ def test_is_auth_error_documented_reauth_codes(code):
 def test_is_auth_error_quota_codes_are_transient(code):
     """API quota/throttle codes are transient and must NOT trigger reauth (issue #109)."""
     assert is_auth_error(PySolarCloudException({"error": code})) is False
+
+
+@pytest.mark.parametrize("code", ["E918", "E919"])
+def test_is_auth_error_whitelist_codes_are_transient(code):
+    """Whitelist rejections (IP/user) are Developer-Portal config issues re-auth can't fix,
+    so they must keep retrying rather than trigger reauth."""
+    assert is_auth_error(PySolarCloudException({"error": code})) is False
+
+
+def test_describe_api_error_whitelist_hints():
+    """Whitelist codes get an actionable hint; other errors get none."""
+    assert "IP whitelist" in (describe_api_error(PySolarCloudException({"error": "E918"})) or "")
+    assert "user whitelist" in (describe_api_error(PySolarCloudException({"error": "E919"})) or "")
+    assert describe_api_error(PySolarCloudException({"error": "E900"})) is None
+    assert describe_api_error(ConnectionError("boom")) is None
 
 
 def test_is_auth_error_unrelated_code_is_transient():
@@ -119,6 +134,16 @@ async def test_update_data_auth_error_raises_config_entry_auth_failed(hass: Home
 
     coordinator = SungrowPlantCoordinator(hass, _make_entry(), plants, "12345", "Test Plant")
     with pytest.raises(ConfigEntryAuthFailed):
+        await coordinator._async_update_data()
+
+
+async def test_update_data_whitelist_error_surfaces_hint(hass: HomeAssistant):
+    """An IP-whitelist rejection retries (UpdateFailed) with an actionable message, not reauth."""
+    plants = MagicMock()
+    plants.async_get_realtime_data = AsyncMock(side_effect=PySolarCloudException({"error": "E918"}))
+
+    coordinator = SungrowPlantCoordinator(hass, _make_entry(), plants, "12345", "Test Plant")
+    with pytest.raises(UpdateFailed, match="IP whitelist"):
         await coordinator._async_update_data()
 
 


### PR DESCRIPTION
## Summary

After enabling an API-application whitelist in the iSolarCloud Developer Portal, a rejected request surfaced only as an opaque `result_code: E918` in the HA log — no indication of the cause or how to fix it. This maps the two whitelist codes to actionable messages.

## Change

- Add `describe_api_error()` + `API_ERROR_HINTS` in `coordinator.py`:
  - **E918** — "this client's IP address is not in your API application's IP whitelist … add this machine's public IP or disable it."
  - **E919** — "your account is not in your API application's user whitelist … add your account or disable it."
- Surface the hint on both the **setup** path (`ConfigEntryNotReady`) and the **poll** path (`UpdateFailed`); it falls back to the generic message for every other error.
- **Reclassify E919 out of `AUTH_ERRORS`.** A whitelist rejection is a Developer-Portal configuration issue that re-authorizing cannot fix — so, like E918, it must keep **retrying** (and auto-recovers once the whitelist is corrected) rather than launching a futile reauth flow. E918 was already transient; this makes E919 consistent.

## Tests

- `test_is_auth_error_whitelist_codes_are_transient` — E918 **and** E919 are transient (not reauth).
- `test_describe_api_error_whitelist_hints` — hints returned for E918/E919, `None` otherwise.
- `test_update_data_whitelist_error_surfaces_hint` — a poll hitting E918 raises `UpdateFailed` matching "IP whitelist".
- Updated `test_is_auth_error_documented_reauth_codes` to drop E919.

Full suite green (276 passed), ruff + format + mypy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)