### PR TITLE
feat: adopt pysolarcloud 0.9.0 typed exceptions for auth classification

### DIFF
--- a/custom_components/sungrow/auth.py
+++ b/custom_components/sungrow/auth.py
@@ -23,30 +23,25 @@ _LOGGER = logging.getLogger(__name__)
 
 # Errors raised by pysolarcloud that indicate the stored credentials/tokens are no
 # longer usable and the user must re-authorize (as opposed to a transient outage).
-# "token_refresh_failed" is the code on pysolarcloud>=0.6.0's TokenRefreshError
-# (a PySolarCloudException), raised when a refresh returns no access token.
+# These are the errors pysolarcloud does NOT surface as a typed ``AuthError``:
+# "token_refresh_failed" (its ``TokenRefreshError``, raised when a refresh returns no
+# access token) and the OAuth token-exchange failures ("invalid_grant"/"invalid_token")
+# and "auth_not_initialised". ``is_auth_error`` matches these by string.
 #
-# The "E*" codes are the documented iSolarCloud OpenAPI result codes for dead or
-# unauthorized credentials (E00003 token invalid/expired, E900 unauthorized,
-# E912/E914 bad or mismatched app key). pysolarcloud >=0.8.0 raises
-# PySolarCloudException carrying the API result_code on ``.error``, so these now
-# reliably drive reauth.
+# The documented dead-credential *result codes* (E00003, E900, E912, E914) are NOT listed
+# here: pysolarcloud >=0.9.0 raises them as a typed ``AuthError`` (KRoperUK/pysolarcloud#23),
+# which ``is_auth_error`` catches via ``isinstance`` — so the integration no longer
+# duplicates the library's code list and picks up any new auth codes automatically.
 #
-# Deliberately NOT here (kept transient/retry, not reauth): the quota/throttle codes
-# E998/E999, and the whitelist rejections E918 (IP not whitelisted) / E919 (user not
-# whitelisted). A whitelist rejection is a Developer-Portal configuration issue that
-# re-authorizing cannot fix, so it must keep retrying until the whitelist is corrected;
-# ``describe_api_error`` (coordinator.py) turns those codes into an actionable log hint.
+# The whitelist rejections E918 / E919 are handled separately (``WHITELIST_ERRORS`` in
+# coordinator.py): a whitelist rejection is a Developer-Portal config issue that reauth
+# cannot fix, so it must keep retrying — even though 0.9.0 types E919 as ``AuthError``.
 AUTH_ERRORS = frozenset(
     {
         "auth_not_initialised",
         "invalid_grant",
         "invalid_token",
         "token_refresh_failed",
-        "E00003",
-        "E900",
-        "E912",
-        "E914",
     }
 )
 

--- a/custom_components/sungrow/coordinator.py
+++ b/custom_components/sungrow/coordinator.py
@@ -11,7 +11,7 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryAuthFailed
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
-from pysolarcloud import PySolarCloudException
+from pysolarcloud import AuthError, PySolarCloudException
 from pysolarcloud.plants import Plants
 
 from .auth import AUTH_ERRORS
@@ -30,23 +30,38 @@ MAX_POLL_TIMEOUT = 60
 _LOGGER = logging.getLogger(__name__)
 
 
+# Developer-Portal whitelist rejections (Appendix 2). These must keep RETRYING rather
+# than trigger reauth — re-authorizing can't add an IP/user to the app's whitelist — even
+# though pysolarcloud >=0.9.0 types E919 as an ``AuthError``. Guarded ahead of the
+# ``isinstance`` check in ``is_auth_error`` so that typing never overrides this.
+WHITELIST_ERRORS = frozenset({"E918", "E919"})
+
+
 def is_auth_error(err: Exception) -> bool:
     """Return True if the error means the stored credentials are no longer valid.
 
-    A failed token refresh raises ``PySolarCloudException`` (``TokenRefreshError``,
-    error ``token_refresh_failed``), and explicit auth problems raise
-    ``PySolarCloudException`` with a known error code — both matched via
-    ``AUTH_ERRORS``. All require the user to re-authorize rather than waiting for a
-    transient outage to clear.
+    pysolarcloud >=0.9.0 raises a typed ``AuthError`` for the documented dead-credential
+    result codes (E00003/E900/E912/E914 — E919 too, but that is a whitelist code handled
+    below), so those are matched via ``isinstance`` and need no per-code list here. The
+    non-typed failures — a failed token refresh (``TokenRefreshError``), the OAuth
+    ``invalid_grant``/``invalid_token`` errors, and ``auth_not_initialised`` — are matched
+    by string via ``AUTH_ERRORS``. All require the user to re-authorize.
+
+    Whitelist rejections (E918/E919) are explicitly excluded: they are Developer-Portal
+    config issues that reauth cannot fix, so they stay transient (retry) despite E919's
+    ``AuthError`` typing.
     """
-    if isinstance(err, PySolarCloudException):
-        return err.error in AUTH_ERRORS
-    return False
+    if not isinstance(err, PySolarCloudException):
+        return False
+    if err.error in WHITELIST_ERRORS:
+        return False
+    return isinstance(err, AuthError) or err.error in AUTH_ERRORS
 
 
-# Actionable hints for otherwise-opaque iSolarCloud result codes. Both are Developer-
-# Portal whitelist rejections (Appendix 2) that keep retrying (see AUTH_ERRORS), so the
-# raw code would just repeat in the log with no explanation of how to fix it.
+# Actionable hints for otherwise-opaque iSolarCloud result codes (Appendix 2). These all
+# keep retrying rather than reauth, so without a hint the raw code would just repeat in the
+# log with no explanation of the cause or fix. Covers the whitelist rejections (E918/E919)
+# and the API quota limits (E998/E999, pysolarcloud's ``RateLimitError``).
 API_ERROR_HINTS = {
     "E918": (
         "iSolarCloud rejected the request: this client's IP address is not in your API "
@@ -57,6 +72,15 @@ API_ERROR_HINTS = {
         "iSolarCloud rejected the request: your account is not in your API application's user "
         "whitelist (E919). In the iSolarCloud Developer Portal, add your account to the whitelist "
         "or disable it, then it recovers automatically."
+    ),
+    "E998": (
+        "iSolarCloud rejected the request: the monthly API call limit has been reached (E998). "
+        "The integration will keep retrying; it recovers when the quota resets."
+    ),
+    "E999": (
+        "iSolarCloud rejected the request: the hourly API call limit has been reached (E999). "
+        "The integration will keep retrying; increase the polling interval in the integration "
+        "options to make fewer calls."
     ),
 }
 

--- a/custom_components/sungrow/manifest.json
+++ b/custom_components/sungrow/manifest.json
@@ -17,7 +17,7 @@
   ],
   "quality_scale": "platinum",
   "requirements": [
-    "sungrow-isolarcloud==0.8.0"
+    "sungrow-isolarcloud==0.9.0"
   ],
   "version": "3.0.0"
 }

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -10,4 +10,4 @@ ruff==0.15.16
 mypy==2.1.0
 
 # Component dependencies
-sungrow-isolarcloud==0.8.0
+sungrow-isolarcloud==0.9.0

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -7,7 +7,7 @@ import pytest
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryAuthFailed
 from homeassistant.helpers.update_coordinator import UpdateFailed
-from pysolarcloud import PySolarCloudException
+from pysolarcloud import AuthError, PySolarCloudException
 from pysolarcloud.plants import DeviceType
 
 from custom_components.sungrow.const import (
@@ -62,14 +62,20 @@ def test_is_auth_error_transient():
 
 @pytest.mark.parametrize("code", ["E00003", "E900", "E912", "E914"])
 def test_is_auth_error_documented_reauth_codes(code):
-    """The documented API auth/permission error codes trigger reauth (issue #109)."""
-    assert is_auth_error(PySolarCloudException({"error": code})) is True
+    """Documented dead-credential codes are typed AuthError (0.9.0) and trigger reauth (#109/#131).
+
+    Built via ``from_response`` — the real raise path — so the exception is an actual
+    ``AuthError`` caught by ``isinstance``, not just a code-list match.
+    """
+    err = PySolarCloudException.from_response({"result_code": code})
+    assert isinstance(err, AuthError)
+    assert is_auth_error(err) is True
 
 
 @pytest.mark.parametrize("code", ["E998", "E999"])
 def test_is_auth_error_quota_codes_are_transient(code):
-    """API quota/throttle codes are transient and must NOT trigger reauth (issue #109)."""
-    assert is_auth_error(PySolarCloudException({"error": code})) is False
+    """API quota/throttle codes (RateLimitError in 0.9.0) are transient, never reauth (#109)."""
+    assert is_auth_error(PySolarCloudException.from_response({"result_code": code})) is False
 
 
 @pytest.mark.parametrize("code", ["E918", "E919"])
@@ -79,10 +85,20 @@ def test_is_auth_error_whitelist_codes_are_transient(code):
     assert is_auth_error(PySolarCloudException({"error": code})) is False
 
 
-def test_describe_api_error_whitelist_hints():
-    """Whitelist codes get an actionable hint; other errors get none."""
+def test_is_auth_error_e919_stays_transient_despite_autherror_typing():
+    """pysolarcloud 0.9.0 types E919 as AuthError, but it's a whitelist rejection — reauth
+    can't add a user to the whitelist, so it must stay transient (#131 must not regress #133)."""
+    err = PySolarCloudException.from_response({"result_code": "E919"})
+    assert isinstance(err, AuthError)  # the typing that would otherwise force reauth
+    assert is_auth_error(err) is False  # ...guarded so it keeps retrying
+
+
+def test_describe_api_error_hints():
+    """Whitelist and quota codes get an actionable hint; other errors get none."""
     assert "IP whitelist" in (describe_api_error(PySolarCloudException({"error": "E918"})) or "")
     assert "user whitelist" in (describe_api_error(PySolarCloudException({"error": "E919"})) or "")
+    assert "monthly" in (describe_api_error(PySolarCloudException({"error": "E998"})) or "")
+    assert "hourly" in (describe_api_error(PySolarCloudException({"error": "E999"})) or "")
     assert describe_api_error(PySolarCloudException({"error": "E900"})) is None
     assert describe_api_error(ConnectionError("boom")) is None
 


### PR DESCRIPTION
## Summary

pysolarcloud 0.9.0 raises typed `AuthError` / `RateLimitError` subclasses (KRoperUK/pysolarcloud#23). This bumps the pin and switches reauth-vs-retry classification from a hand-maintained code list to the exception type.

## Change

- **Pin → 0.9.0** (`manifest.json`, `requirements_test.txt`).
- **`is_auth_error` uses `isinstance(err, AuthError)`** for the documented dead-credential result codes, so the integration no longer duplicates the library's `{E00003, E900, E912, E914}` list and automatically handles any new auth codes the library types. `AUTH_ERRORS` is trimmed to the **non-typed** string errors the library does *not* wrap in `AuthError` (`token_refresh_failed`, OAuth `invalid_grant`/`invalid_token`, `auth_not_initialised`).
- **Whitelist guard preserved.** 0.9.0 types **E919 as `AuthError`**, but a whitelist rejection is a Developer-Portal config issue reauth can't fix — so `WHITELIST_ERRORS` (E918/E919) is checked *before* the `isinstance`, keeping them transient (retry). This deliberately avoids regressing the previous whitelist-handling change.
- **Rate-limit hints.** Added actionable log messages for the quota codes **E998** (monthly) / **E999** (hourly, 0.9.0's `RateLimitError`), including the tip to raise the polling interval on E999.

## Tests

- `test_is_auth_error_documented_reauth_codes` now builds errors via `from_response` (the real raise path → actual `AuthError`) and asserts `isinstance` + reauth.
- `test_is_auth_error_e919_stays_transient_despite_autherror_typing` — **regression guard**: E919 *is* an `AuthError`, yet `is_auth_error` returns `False`.
- Quota codes built via `from_response` (real `RateLimitError`) assert transient.
- `test_describe_api_error_hints` extended to cover E998/E999.

Full suite green against 0.9.0 (277 passed), ruff + format + mypy clean.

Closes #131

🤖 Generated with [Claude Code](https://claude.com/claude-code)