### PR TITLE
fix: hide battery-only dispatch controls on PV-only plants (#148)

### DIFF
--- a/custom_components/sungrow/__init__.py
+++ b/custom_components/sungrow/__init__.py
@@ -103,6 +103,41 @@ async def _async_dispatch_supported(control: Control, devices: list[dict[str, An
         return True
 
 
+def _has_battery_device(devices: list[dict[str, Any]]) -> bool:
+    """Return True if the plant reports an energy-storage or battery device."""
+    return any(
+        _matches_device_type(d, DeviceType.ENERGY_STORAGE_SYSTEM) or _matches_device_type(d, DeviceType.BATTERY)
+        for d in devices
+    )
+
+
+async def _async_has_battery(plants_service: Plants, plant_id: str, devices: list[dict[str, Any]]) -> bool:
+    """Return whether a plant has a battery, to gate battery-only dispatch controls (#148).
+
+    The plant's configured battery capacity (``design_capacity_battery`` from the
+    plant-detail endpoint) is authoritative: a value of 0 means a PV-only system, so
+    the battery-only controls are hidden even if a hybrid inverter also reports an
+    ESS device with no pack attached. Only when plant details can't be fetched (or
+    omit the field) does this fall back to ESS/battery device presence, so a
+    transient failure never hides a real battery user's controls.
+    """
+    try:
+        async with asyncio.timeout(SETUP_TIMEOUT):
+            details = await plants_service.async_get_plant_details(plant_id)
+    except Exception as err:  # pylint: disable=broad-except
+        _LOGGER.debug("Could not fetch plant details for %s; using device list for battery check: %s", plant_id, err)
+        return _has_battery_device(devices)
+    for entry in details or []:
+        capacity = entry.get("design_capacity_battery")
+        if capacity is not None:
+            try:
+                return float(capacity) > 0
+            except (TypeError, ValueError):
+                break
+    # No usable capacity figure — fall back to device presence.
+    return _has_battery_device(devices)
+
+
 class IterableSchema(vol.Schema):
     """A Schema that can be iterated over (yielding nothing) to satisfy HA's checks."""
 
@@ -223,6 +258,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: SungrowConfigEntry) -> b
             continue
 
         coordinator.dispatch_update_supported = await _async_dispatch_supported(control_service, devices)
+        coordinator.has_battery = await _async_has_battery(plants_service, plant_id, devices)
         devices_by_plant[plant_id] = devices
         coordinators.append(coordinator)
 

--- a/custom_components/sungrow/coordinator.py
+++ b/custom_components/sungrow/coordinator.py
@@ -129,6 +129,13 @@ class SungrowPlantCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         # setup; defaults True (fail-open) so an unavailable/unknown check never
         # hides working controls.
         self.dispatch_update_supported: bool = True
+        # Whether the plant has a battery. Battery-only dispatch controls
+        # (charge/discharge, SOC limits, forced-charge, battery-first) are hidden
+        # when False: on a PV-only inverter they can't act and instead put it into
+        # External-EMS mode, silently curtailing generation to ~0 (#148). Checked
+        # once at setup; defaults True (fail-open) so a failed check never hides a
+        # real battery user's controls.
+        self.has_battery: bool = True
 
     async def _async_update_data(self) -> dict[str, Any]:
         """Fetch data from the API for this plant."""

--- a/custom_components/sungrow/number.py
+++ b/custom_components/sungrow/number.py
@@ -70,6 +70,8 @@ DISPATCH_NUMBERS: dict[str, dict[str, Any]] = {
         "native_max_value": DEFAULT_MAX_DISPATCH_POWER,
         "native_step": 100,
         "mode": NumberMode.SLIDER,
+        # Battery actuation: meaningless (and harmful — see #148) without a battery.
+        "battery_only": True,
     },
     "soc_upper_limit": {
         "device_class": NumberDeviceClass.BATTERY,
@@ -80,6 +82,7 @@ DISPATCH_NUMBERS: dict[str, dict[str, Any]] = {
         "mode": NumberMode.SLIDER,
         # SOC limits set battery policy rather than actuate — configuration entities.
         "entity_category": EntityCategory.CONFIG,
+        "battery_only": True,
     },
     "soc_lower_limit": {
         "device_class": NumberDeviceClass.BATTERY,
@@ -89,6 +92,7 @@ DISPATCH_NUMBERS: dict[str, dict[str, Any]] = {
         "native_step": 1,
         "mode": NumberMode.SLIDER,
         "entity_category": EntityCategory.CONFIG,
+        "battery_only": True,
     },
     "forced_charging_target_soc_1": {
         "device_class": NumberDeviceClass.BATTERY,
@@ -98,6 +102,7 @@ DISPATCH_NUMBERS: dict[str, dict[str, Any]] = {
         "native_step": 1,
         "mode": NumberMode.SLIDER,
         "entity_category": EntityCategory.CONFIG,
+        "battery_only": True,
     },
     # Target SOC for the second forced-charging window (mirrors ..._soc_1).
     "forced_charging_target_soc_2": {
@@ -108,6 +113,7 @@ DISPATCH_NUMBERS: dict[str, dict[str, Any]] = {
         "native_step": 1,
         "mode": NumberMode.SLIDER,
         "entity_category": EntityCategory.CONFIG,
+        "battery_only": True,
     },
     # Export (feed-in) limit as an absolute power in watts. Only takes effect when
     # the feed_in_limitation select is enabled. Sized to the device's rating.
@@ -171,6 +177,9 @@ def _build_numbers(coordinator: SungrowPlantCoordinator, control: Control) -> li
     max_power = rated_power_w(target) or DEFAULT_MAX_DISPATCH_POWER
     entities: list[NumberEntity] = []
     for param, meta in DISPATCH_NUMBERS.items():
+        # Hide battery-only controls on PV-only plants — see #148.
+        if meta.get("battery_only") and not coordinator.has_battery:
+            continue
         if param in _RATED_POWER_PARAMS and max_power != meta["native_max_value"]:
             meta = {**meta, "native_max_value": max_power}
         entities.append(SungrowDispatchNumber(coordinator, control, device_uuid, device_name, param, meta))

--- a/custom_components/sungrow/select.py
+++ b/custom_components/sungrow/select.py
@@ -34,6 +34,8 @@ DISPATCH_SELECTS: dict[str, dict[str, Any]] = {
             "Charge": Control.CHARGE_DISCHARGE_COMMANDS["charge"],
             "Discharge": Control.CHARGE_DISCHARGE_COMMANDS["discharge"],
         },
+        # Battery actuation: meaningless (and harmful — see #148) without a battery.
+        "battery_only": True,
     },
     "forced_charging": {
         "options_map": {
@@ -42,6 +44,7 @@ DISPATCH_SELECTS: dict[str, dict[str, Any]] = {
         },
         # Enabling/disabling forced charging is a policy setting, not actuation.
         "entity_category": EntityCategory.CONFIG,
+        "battery_only": True,
     },
     # Sungrow enable/disable enum (device-verified): Enable=170, Disable=85.
     "feed_in_limitation": {
@@ -57,6 +60,7 @@ DISPATCH_SELECTS: dict[str, dict[str, Any]] = {
     "battery_first": {
         "options_map": {"Disable": "85", "Enable": "170"},
         "entity_category": EntityCategory.CONFIG,
+        "battery_only": True,
     },
 }
 
@@ -83,9 +87,11 @@ def _build_selects(coordinator: SungrowPlantCoordinator, control: Control) -> li
     # is pruned on the first refresh after setup — the "pops in then disappears" bug.
     device_uuid = str(device_uuid)
     device_name = target.get("device_name") or coordinator.plant_name
+    # Hide battery-only controls on PV-only plants — see #148.
     return [
         SungrowDispatchSelect(coordinator, control, device_uuid, device_name, param, meta)
         for param, meta in DISPATCH_SELECTS.items()
+        if coordinator.has_battery or not meta.get("battery_only")
     ]
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -195,6 +195,8 @@ def mock_plants_service():
         plants_instance.async_get_plants = AsyncMock(return_value=MOCK_PLANT_LIST)
         plants_instance.async_get_realtime_data = AsyncMock(return_value=MOCK_REALTIME_DATA)
         plants_instance.async_get_plant_devices = AsyncMock(return_value=[])
+        # Battery-presence detection (#148) fetches plant details during setup.
+        plants_instance.async_get_plant_details = AsyncMock(return_value=[{"design_capacity_battery": 10.0}])
         mock_plants_cls.return_value = plants_instance
 
         control_instance = MagicMock()

--- a/tests/test_dispatch.py
+++ b/tests/test_dispatch.py
@@ -11,7 +11,7 @@ from pysolarcloud import PySolarCloudException
 from pysolarcloud.plants import DeviceType
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 
-from custom_components.sungrow import SungrowData, select_dispatch_device
+from custom_components.sungrow import SungrowData, _async_has_battery, _has_battery_device, select_dispatch_device
 from custom_components.sungrow.const import DOMAIN
 from custom_components.sungrow.number import DISPATCH_NUMBERS
 from custom_components.sungrow.number import async_setup_entry as number_setup_entry
@@ -27,6 +27,9 @@ def _coordinator_with(plant_id, plant_name):
     coordinator.plant_name = plant_name
     coordinator.config_entry = MagicMock()
     coordinator.last_update_success = True
+    # Default to a battery plant so the full dispatch set is built; the no-battery
+    # gating tests (#148) override this to False.
+    coordinator.has_battery = True
     return coordinator
 
 
@@ -168,6 +171,121 @@ async def test_dispatch_device_survives_prune_with_int_uuid(hass: HomeAssistant)
 
     assert registry.async_get(plant.id) is not None
     assert registry.async_get(inverter.id) is not None  # removed before the fix
+
+
+# --- Battery-presence gating (#148) ---------------------------------------
+
+# Dispatch params that only make sense with a battery and must be hidden on
+# PV-only plants (setting them puts the inverter into External-EMS "Dispatched
+# running" mode and silently curtails PV to ~0).
+BATTERY_ONLY_NUMBERS = {
+    "charge_discharge_power",
+    "soc_upper_limit",
+    "soc_lower_limit",
+    "forced_charging_target_soc_1",
+    "forced_charging_target_soc_2",
+}
+GRID_SIDE_NUMBERS = {
+    "feed_in_limitation_value",
+    "feed_in_limitation_ratio",
+    "active_power_limit_ratio",
+}
+BATTERY_ONLY_SELECTS = {"charge_discharge_command", "forced_charging", "battery_first"}
+GRID_SIDE_SELECTS = {"feed_in_limitation", "limited_power_switch"}
+
+
+def test_battery_only_sets_partition_dispatch_dicts():
+    """The battery-only / grid-side split covers exactly the dispatch params.
+
+    Guards against a new dispatch param being added without deciding whether it is
+    battery-only (and therefore must be gated for #148).
+    """
+    assert set(DISPATCH_NUMBERS) == BATTERY_ONLY_NUMBERS | GRID_SIDE_NUMBERS
+    assert BATTERY_ONLY_NUMBERS.isdisjoint(GRID_SIDE_NUMBERS)
+    assert set(DISPATCH_SELECTS) == BATTERY_ONLY_SELECTS | GRID_SIDE_SELECTS
+    assert BATTERY_ONLY_SELECTS.isdisjoint(GRID_SIDE_SELECTS)
+
+
+async def test_number_hides_battery_controls_without_battery(hass: HomeAssistant):
+    """On a battery-less plant, only grid-side numbers are created (#148)."""
+    entry = MockConfigEntry(domain=DOMAIN, data=MOCK_CONFIG_DATA.copy())
+    entry.add_to_hass(hass)
+    devices = [{"uuid": "inv-1", "device_type": "INVERTER"}]
+    data = _setup_entry_data(entry, devices)
+    data.coordinators[0].has_battery = False
+
+    added = []
+    await number_setup_entry(hass, entry, lambda entities: added.extend(entities))
+
+    assert {e.param for e in added} == GRID_SIDE_NUMBERS
+
+
+async def test_select_hides_battery_controls_without_battery(hass: HomeAssistant):
+    """On a battery-less plant, only grid-side selects are created (#148)."""
+    entry = MockConfigEntry(domain=DOMAIN, data=MOCK_CONFIG_DATA.copy())
+    entry.add_to_hass(hass)
+    devices = [{"uuid": "inv-1", "device_type": "INVERTER"}]
+    data = _setup_entry_data(entry, devices)
+    data.coordinators[0].has_battery = False
+
+    added = []
+    await select_setup_entry(hass, entry, lambda entities: added.extend(entities))
+
+    assert {e.param for e in added} == GRID_SIDE_SELECTS
+
+
+async def test_dispatch_full_set_with_battery(hass: HomeAssistant):
+    """A battery plant still gets the full set of dispatch controls (#148)."""
+    entry = MockConfigEntry(domain=DOMAIN, data=MOCK_CONFIG_DATA.copy())
+    entry.add_to_hass(hass)
+    devices = [{"uuid": "ess-1", "device_type": "ENERGY_STORAGE_SYSTEM"}]
+    data = _setup_entry_data(entry, devices)
+    data.coordinators[0].has_battery = True
+
+    numbers, selects = [], []
+    await number_setup_entry(hass, entry, lambda e: numbers.extend(e))
+    await select_setup_entry(hass, entry, lambda e: selects.extend(e))
+
+    assert {e.param for e in numbers} == set(DISPATCH_NUMBERS)
+    assert {e.param for e in selects} == set(DISPATCH_SELECTS)
+
+
+def test_has_battery_device_detects_ess_and_battery():
+    """_has_battery_device matches ESS/battery devices across enum/int/string forms."""
+    assert _has_battery_device([{"uuid": "e", "device_type": "ENERGY_STORAGE_SYSTEM"}])
+    assert _has_battery_device([{"uuid": "b", "device_type": DeviceType.BATTERY}])
+    assert _has_battery_device([{"uuid": "b", "device_type": 43}])
+    assert not _has_battery_device([{"uuid": "i", "device_type": "INVERTER"}])
+    assert not _has_battery_device([])
+
+
+async def test_async_has_battery_uses_design_capacity():
+    """design_capacity_battery is authoritative: 0 -> no battery, >0 -> battery."""
+    svc = MagicMock()
+    svc.async_get_plant_details = AsyncMock(return_value=[{"design_capacity_battery": 0.0}])
+    assert await _async_has_battery(svc, "1", [{"uuid": "i", "device_type": "INVERTER"}]) is False
+
+    svc.async_get_plant_details = AsyncMock(return_value=[{"design_capacity_battery": 9.6}])
+    assert await _async_has_battery(svc, "1", []) is True
+
+
+async def test_async_has_battery_capacity_zero_overrides_ess_device():
+    """A configured capacity of 0 hides controls even if an ESS device is present.
+
+    Hybrid inverters can report an ESS device with no battery pack attached, so the
+    plant's configured capacity is trusted over device-type presence.
+    """
+    svc = MagicMock()
+    svc.async_get_plant_details = AsyncMock(return_value=[{"design_capacity_battery": 0}])
+    assert await _async_has_battery(svc, "1", [{"uuid": "e", "device_type": "ENERGY_STORAGE_SYSTEM"}]) is False
+
+
+async def test_async_has_battery_falls_back_to_devices_on_error():
+    """If plant details can't be fetched, fall back to ESS/battery device presence."""
+    svc = MagicMock()
+    svc.async_get_plant_details = AsyncMock(side_effect=PySolarCloudException("boom"))
+    assert await _async_has_battery(svc, "1", [{"uuid": "e", "device_type": "ENERGY_STORAGE_SYSTEM"}]) is True
+    assert await _async_has_battery(svc, "1", [{"uuid": "i", "device_type": "INVERTER"}]) is False
 
 
 async def test_number_setup_no_devices(hass: HomeAssistant):


### PR DESCRIPTION
## What & why

Closes #148.

On a **battery-less inverter**, the charge/discharge, SOC, forced-charge and battery-first controls are battery *actuation* — they can't do anything useful, and setting one puts the inverter into External-EMS **"Dispatched running"** mode, silently curtailing PV output to ~0. This was observed live: a single `Charge` selection zeroed generation for a full day (0 kWh vs a normal ~8 kWh) with no fault — the inverter was simply parked in dispatch mode, panels at open-circuit voltage.

This PR stops creating the battery-only controls when the plant has no battery.

## Battery-only controls now gated (8 entities)

| Platform | Params hidden when no battery |
|---|---|
| select | `charge_discharge_command`, `forced_charging`, `battery_first` |
| number | `charge_discharge_power`, `soc_upper_limit`, `soc_lower_limit`, `forced_charging_target_soc_1`, `forced_charging_target_soc_2` |

**Kept on PV-only plants** (legitimate grid-side controls): `feed_in_limitation` / `limited_power_switch` selects and `feed_in_limitation_value` / `feed_in_limitation_ratio` / `active_power_limit_ratio` numbers.

## How battery presence is detected

At setup, `_async_has_battery()` reads the plant's configured **`design_capacity_battery`** from `async_get_plant_details` — authoritative: `0` ⇒ PV-only. A hybrid inverter can report an ESS device with **no pack attached**, so device-type presence alone is unreliable; device presence is only used as a fallback when plant details can't be fetched (so a transient failure never hides a real battery user's controls). Result is cached on the coordinator as `has_battery` (defaults `True`, fail-open), mirroring the existing `dispatch_update_supported` pattern. Costs one extra cloud call per plant, once, at setup.

## Implementation notes

- Each battery-only param is tagged `"battery_only": True` in `DISPATCH_SELECTS` / `DISPATCH_NUMBERS`; `_build_selects` / `_build_numbers` skip tagged params when `not coordinator.has_battery`.
- Because `charge_discharge_command` (the sole owner of the EMS heartbeat) is hidden, all heartbeat-arming paths are removed on PV-only plants — no other changes needed.

## Tests

- `test_number_hides_battery_controls_without_battery` / `test_select_hides_...` — only grid-side controls on a no-battery plant.
- `test_dispatch_full_set_with_battery` — battery plants keep the full set.
- `test_battery_only_sets_partition_dispatch_dicts` — **guards completeness**: every dispatch param must be classified battery-only or grid-side, so a newly added control can't silently skip the gate.
- `test_has_battery_device_detects_ess_and_battery`, `test_async_has_battery_uses_design_capacity`, `test_async_has_battery_capacity_zero_overrides_ess_device`, `test_async_has_battery_falls_back_to_devices_on_error` — detection logic incl. the hybrid-with-no-pack case.

`ruff`, `ruff format`, `mypy`, and the full suite (285 passed) are green locally.

## Migration note

Existing PV-only installs that already have these entities will see them go **unavailable** (HA doesn't auto-delete entities an integration stops creating); users can remove them manually. Auto-cleanup could be a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)