### PR TITLE
feat: enrich device registry with model/serial/manufacturer (part of #149)

### DIFF
--- a/custom_components/sungrow/__init__.py
+++ b/custom_components/sungrow/__init__.py
@@ -16,6 +16,7 @@ from homeassistant.core import HomeAssistant, callback
 from homeassistant.exceptions import ConfigEntryAuthFailed, ConfigEntryNotReady
 from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
+from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.http import HomeAssistantView
 from pysolarcloud.control import Control
 from pysolarcloud.plants import DeviceType, Plants
@@ -136,6 +137,25 @@ async def _async_has_battery(plants_service: Plants, plant_id: str, devices: lis
                 break
     # No usable capacity figure — fall back to device presence.
     return _has_battery_device(devices)
+
+
+def build_device_info(device: dict[str, Any], plant_id: str, *, fallback_name: str | None = None) -> DeviceInfo:
+    """Build a device-registry entry for a physical device, nested under its plant.
+
+    Enriches the HA device card with the model, serial number and manufacturer the
+    cloud reports (``device_model_code`` / ``device_sn`` / ``factory_name`` from
+    ``getDeviceListByPsId``) instead of a bare name, and links it to the plant device
+    via ``via_device``. The uuid is stringified so the identifier matches
+    ``_known_device_ids`` (which keys on ``str(uuid)``) and the device isn't pruned.
+    """
+    return DeviceInfo(
+        identifiers={(DOMAIN, str(device["uuid"]))},
+        name=device.get("device_name") or device.get("device_model_name") or fallback_name,
+        manufacturer=device.get("factory_name") or "Sungrow",
+        model=device.get("device_model_code") or device.get("device_model_name"),
+        serial_number=device.get("device_sn"),
+        via_device=(DOMAIN, plant_id),
+    )
 
 
 class IterableSchema(vol.Schema):

--- a/custom_components/sungrow/number.py
+++ b/custom_components/sungrow/number.py
@@ -11,13 +11,12 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import EntityCategory
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.exceptions import HomeAssistantError
-from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 from pysolarcloud import PySolarCloudException
 from pysolarcloud.control import Control
 
-from . import select_dispatch_device
+from . import build_device_info, select_dispatch_device
 from .const import DOMAIN
 from .coordinator import SungrowPlantCoordinator
 
@@ -164,14 +163,8 @@ def _build_numbers(coordinator: SungrowPlantCoordinator, control: Control) -> li
     target = select_dispatch_device(coordinator.devices)
     if target is None:
         return []
-    device_uuid = target.get("uuid")
-    if not device_uuid:
+    if not target.get("uuid"):
         return []
-    # The API returns the uuid as an int; device-registry identifiers must be strings
-    # to match `_known_device_ids` (which keys on `str(uuid)`). Without this the device
-    # is pruned on the first refresh after setup — the "pops in then disappears" bug.
-    device_uuid = str(device_uuid)
-    device_name = target.get("device_name") or coordinator.plant_name
     # Size the power sliders to the device's rated power when it can be derived
     # from the model code; otherwise use the conservative default.
     max_power = rated_power_w(target) or DEFAULT_MAX_DISPATCH_POWER
@@ -182,7 +175,7 @@ def _build_numbers(coordinator: SungrowPlantCoordinator, control: Control) -> li
             continue
         if param in _RATED_POWER_PARAMS and max_power != meta["native_max_value"]:
             meta = {**meta, "native_max_value": max_power}
-        entities.append(SungrowDispatchNumber(coordinator, control, device_uuid, device_name, param, meta))
+        entities.append(SungrowDispatchNumber(coordinator, control, target, param, meta))
     return entities
 
 
@@ -221,26 +214,21 @@ class SungrowDispatchNumber(CoordinatorEntity[SungrowPlantCoordinator], RestoreN
         self,
         coordinator: SungrowPlantCoordinator,
         control: Control,
-        device_uuid: str,
-        device_name: str,
+        device: dict[str, Any],
         param: str,
         meta: dict[str, Any],
     ) -> None:
         """Initialize the dispatch number."""
         super().__init__(coordinator)
         self.control = control
-        self.device_uuid = device_uuid
+        self.device_uuid = str(device["uuid"])
         self.param = param
         # Entity name comes from translations (entity.number.<param>.name).
         self._attr_translation_key = param
-        self._attr_unique_id = f"{coordinator.plant_id}_{device_uuid}_{param}"
-        self._attr_device_info = DeviceInfo(
-            identifiers={(DOMAIN, device_uuid)},
-            name=device_name,
-            manufacturer="Sungrow",
-            # Nest the dispatch device under the plant device the sensors created.
-            via_device=(DOMAIN, coordinator.plant_id),
-        )
+        self._attr_unique_id = f"{coordinator.plant_id}_{self.device_uuid}_{param}"
+        # Nest the dispatch device under the plant device the sensors created,
+        # enriched with the model/serial the cloud reports.
+        self._attr_device_info = build_device_info(device, coordinator.plant_id, fallback_name=coordinator.plant_name)
         self._attr_device_class = meta.get("device_class")
         self._attr_native_unit_of_measurement = meta.get("native_unit_of_measurement")
         self._attr_native_min_value = meta["native_min_value"]

--- a/custom_components/sungrow/select.py
+++ b/custom_components/sungrow/select.py
@@ -10,14 +10,13 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import EntityCategory
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.exceptions import HomeAssistantError
-from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.restore_state import RestoreEntity
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 from pysolarcloud import PySolarCloudException
 from pysolarcloud.control import Control
 
-from . import async_start_heartbeat, async_stop_heartbeat, select_dispatch_device
+from . import async_start_heartbeat, async_stop_heartbeat, build_device_info, select_dispatch_device
 from .const import DOMAIN
 from .coordinator import SungrowPlantCoordinator
 
@@ -79,17 +78,11 @@ def _build_selects(coordinator: SungrowPlantCoordinator, control: Control) -> li
     target = select_dispatch_device(coordinator.devices)
     if target is None:
         return []
-    device_uuid = target.get("uuid")
-    if not device_uuid:
+    if not target.get("uuid"):
         return []
-    # The API returns the uuid as an int; device-registry identifiers must be strings
-    # to match `_known_device_ids` (which keys on `str(uuid)`). Without this the device
-    # is pruned on the first refresh after setup — the "pops in then disappears" bug.
-    device_uuid = str(device_uuid)
-    device_name = target.get("device_name") or coordinator.plant_name
     # Hide battery-only controls on PV-only plants — see #148.
     return [
-        SungrowDispatchSelect(coordinator, control, device_uuid, device_name, param, meta)
+        SungrowDispatchSelect(coordinator, control, target, param, meta)
         for param, meta in DISPATCH_SELECTS.items()
         if coordinator.has_battery or not meta.get("battery_only")
     ]
@@ -130,29 +123,24 @@ class SungrowDispatchSelect(CoordinatorEntity[SungrowPlantCoordinator], RestoreE
         self,
         coordinator: SungrowPlantCoordinator,
         control: Control,
-        device_uuid: str,
-        device_name: str,
+        device: dict[str, Any],
         param: str,
         meta: dict[str, Any],
     ) -> None:
         """Initialize the dispatch select."""
         super().__init__(coordinator)
         self.control = control
-        self.device_uuid = device_uuid
+        self.device_uuid = str(device["uuid"])
         self.param = param
         self.options_map = dict(meta["options_map"])
         reverse_map = {v: k for k, v in self.options_map.items()}
         self._reverse_map = reverse_map
         # Entity name comes from translations (entity.select.<param>.name).
         self._attr_translation_key = param
-        self._attr_unique_id = f"{coordinator.plant_id}_{device_uuid}_{param}"
-        self._attr_device_info = DeviceInfo(
-            identifiers={(DOMAIN, device_uuid)},
-            name=device_name,
-            manufacturer="Sungrow",
-            # Nest the dispatch device under the plant device the sensors created.
-            via_device=(DOMAIN, coordinator.plant_id),
-        )
+        self._attr_unique_id = f"{coordinator.plant_id}_{self.device_uuid}_{param}"
+        # Nest the dispatch device under the plant device the sensors created,
+        # enriched with the model/serial the cloud reports.
+        self._attr_device_info = build_device_info(device, coordinator.plant_id, fallback_name=coordinator.plant_name)
         self._attr_options = list(self.options_map.keys())
         self._attr_entity_category = meta.get("entity_category")
 

--- a/custom_components/sungrow/sensor.py
+++ b/custom_components/sungrow/sensor.py
@@ -11,6 +11,7 @@ from homeassistant.helpers.device_registry import DeviceEntryType, DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
+from . import build_device_info
 from .const import CONF_GATEWAY, DEFAULT_CONSOLE_URL, DOMAIN, GATEWAY_CONSOLE_URLS
 from .coordinator import SungrowPlantCoordinator
 from .measure_points import (
@@ -72,19 +73,13 @@ def _build_sensors(coordinator: SungrowPlantCoordinator, console_url: str) -> li
     # under the inverter.
     if coordinator.enable_device_sensors and coordinator.device_data:
         plant_codes = set(coordinator.data or {})
-        device_names = {
-            str(d.get("uuid")): (d.get("device_name") or d.get("device_model_name") or coordinator.plant_name)
-            for d in coordinator.devices
-            if d.get("uuid")
-        }
+        devices_by_uuid = {str(d["uuid"]): d for d in coordinator.devices if d.get("uuid")}
         for uuid, points in coordinator.device_data.items():
-            device_name = device_names.get(uuid, f"Device {uuid}")
+            device = devices_by_uuid.get(uuid, {"uuid": uuid})
             for point_code, point_data in points.items():
                 if point_code in plant_codes:
                     continue
-                sensor = SungrowDeviceSensor(
-                    coordinator, point_code, coordinator.plant_id, uuid, device_name, point_data
-                )
+                sensor = SungrowDeviceSensor(coordinator, point_code, device, point_data)
                 if sensor.native_value is None:
                     continue
                 sensors.append(sensor)
@@ -250,9 +245,7 @@ class SungrowDeviceSensor(SungrowSensor):
         self,
         coordinator: SungrowPlantCoordinator,
         point_code: str,
-        plant_id: str,
-        device_uuid: str,
-        device_name: str,
+        device: dict[str, Any],
         init_data: dict[str, Any],
     ) -> None:
         """Initialize a device-scoped sensor."""
@@ -260,15 +253,12 @@ class SungrowDeviceSensor(SungrowSensor):
         # metadata helper but with a device-scoped identity and data source.
         CoordinatorEntity.__init__(self, coordinator)
         self.point_code = point_code
-        self.plant_id = plant_id
-        self.device_uuid = device_uuid
-        self._attr_unique_id = f"{plant_id}_{device_uuid}_{point_code}"
-        self._attr_device_info = DeviceInfo(
-            identifiers={(DOMAIN, device_uuid)},
-            name=device_name,
-            manufacturer="Sungrow",
-            via_device=(DOMAIN, plant_id),
-        )
+        self.plant_id = coordinator.plant_id
+        self.device_uuid = str(device["uuid"])
+        device_name = device.get("device_name") or device.get("device_model_name") or coordinator.plant_name
+        self._attr_unique_id = f"{self.plant_id}_{self.device_uuid}_{point_code}"
+        # Enrich the device card with the model/serial the cloud reports.
+        self._attr_device_info = build_device_info(device, self.plant_id, fallback_name=coordinator.plant_name)
         self._apply_point_metadata(point_code, init_data, device_name)
 
     def _current_point(self) -> dict[str, Any] | None:

--- a/tests/test_dispatch.py
+++ b/tests/test_dispatch.py
@@ -11,7 +11,13 @@ from pysolarcloud import PySolarCloudException
 from pysolarcloud.plants import DeviceType
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 
-from custom_components.sungrow import SungrowData, _async_has_battery, _has_battery_device, select_dispatch_device
+from custom_components.sungrow import (
+    SungrowData,
+    _async_has_battery,
+    _has_battery_device,
+    build_device_info,
+    select_dispatch_device,
+)
 from custom_components.sungrow.const import DOMAIN
 from custom_components.sungrow.number import DISPATCH_NUMBERS
 from custom_components.sungrow.number import async_setup_entry as number_setup_entry
@@ -286,6 +292,65 @@ async def test_async_has_battery_falls_back_to_devices_on_error():
     svc.async_get_plant_details = AsyncMock(side_effect=PySolarCloudException("boom"))
     assert await _async_has_battery(svc, "1", [{"uuid": "e", "device_type": "ENERGY_STORAGE_SYSTEM"}]) is True
     assert await _async_has_battery(svc, "1", [{"uuid": "i", "device_type": "INVERTER"}]) is False
+
+
+# --- Device-registry metadata (#149) --------------------------------------
+
+
+def test_build_device_info_enriches_model_and_serial():
+    """build_device_info surfaces the cloud's model/serial/manufacturer and str-ifies the uuid."""
+    info = build_device_info(
+        {
+            "uuid": 4841885,
+            "device_name": "7-Tadmore-Close-Inverter",
+            "device_model_code": "SG3.6RS",
+            "device_sn": "A2281821940",
+            "factory_name": "SUNGROW",
+        },
+        "5718745",
+        fallback_name="Plant",
+    )
+    assert info["identifiers"] == {(DOMAIN, "4841885")}
+    assert info["name"] == "7-Tadmore-Close-Inverter"
+    assert info["model"] == "SG3.6RS"
+    assert info["serial_number"] == "A2281821940"
+    assert info["manufacturer"] == "SUNGROW"
+    assert info["via_device"] == (DOMAIN, "5718745")
+
+
+def test_build_device_info_falls_back_when_fields_absent():
+    """Missing name falls back to the plant name; manufacturer defaults to Sungrow."""
+    info = build_device_info({"uuid": "x"}, "p", fallback_name="Plant Name")
+    assert info["name"] == "Plant Name"
+    assert info["manufacturer"] == "Sungrow"
+    assert info.get("model") is None
+    assert info.get("serial_number") is None
+
+
+async def test_dispatch_device_info_carries_model_and_serial(hass: HomeAssistant):
+    """Dispatch entities expose the device's model/serial on the device card (#149)."""
+    entry = MockConfigEntry(domain=DOMAIN, data=MOCK_CONFIG_DATA.copy())
+    entry.add_to_hass(hass)
+    devices = [
+        {
+            "uuid": "inv-1",
+            "device_type": "ENERGY_STORAGE_SYSTEM",
+            "device_name": "Inverter1",
+            "device_model_code": "SH10RT",
+            "device_sn": "SN123",
+            "factory_name": "SUNGROW",
+        }
+    ]
+    _setup_entry_data(entry, devices)
+
+    added: list = []
+    await number_setup_entry(hass, entry, lambda e: added.extend(e))
+
+    assert added
+    info = added[0]._attr_device_info
+    assert info["model"] == "SH10RT"
+    assert info["serial_number"] == "SN123"
+    assert info["manufacturer"] == "SUNGROW"
 
 
 async def test_number_setup_no_devices(hass: HomeAssistant):

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -421,7 +421,16 @@ async def test_device_sensors_created_when_enabled(hass: HomeAssistant):
     coordinator = _coordinator_with("12345", "Plant A", {"total_active_power": {"value": "5.0", "unit": "kW"}})
     coordinator.enable_device_sensors = True
     # The platform reads the live device list from the coordinator for naming.
-    coordinator.devices = [{"uuid": "chg-1", "device_name": "AC011E", "device_type": 999}]
+    coordinator.devices = [
+        {
+            "uuid": "chg-1",
+            "device_name": "AC011E",
+            "device_type": 999,
+            "device_model_code": "AC011E-01",
+            "device_sn": "S1234567",
+            "factory_name": "SUNGROW",
+        }
+    ]
     coordinator.device_data = {
         "chg-1": {
             "ev_charger_power": {"code": "ev_charger_power", "value": "7.2", "unit": "kW"},
@@ -448,6 +457,10 @@ async def test_device_sensors_created_when_enabled(hass: HomeAssistant):
     assert sensor._attr_device_info["name"] == "AC011E"
     assert (DOMAIN, "chg-1") in sensor._attr_device_info["identifiers"]
     assert sensor._attr_device_info["via_device"] == (DOMAIN, "12345")
+    # Device card is enriched with the cloud's model/serial/manufacturer (#149).
+    assert sensor._attr_device_info["model"] == "AC011E-01"
+    assert sensor._attr_device_info["serial_number"] == "S1234567"
+    assert sensor._attr_device_info["manufacturer"] == "SUNGROW"
     # Reads its value from the coordinator's per-device data.
     assert sensor.native_value == 7.2
 


### PR DESCRIPTION
## What & why

Part of #149. The inverter / dispatch / per-device HA device cards only showed a name and "Sungrow". This enriches them with the **model**, **serial number** and reported **manufacturer** the cloud already returns in the device list — so e.g. the inverter card shows `SG3.6RS` / `A2281821940` / `SUNGROW`.

## How

- New shared helper `build_device_info(device, plant_id, *, fallback_name)` in `__init__.py` that builds a `DeviceInfo` with `model` (`device_model_code`), `serial_number` (`device_sn`), `manufacturer` (`factory_name` → fallback `Sungrow`), a str-ified uuid identifier, and `via_device` nesting under the plant.
- Dispatch `select`/`number` and per-device `sensor` entities now take the full device dict and route through the helper.
- **Net simplification**: three duplicated `DeviceInfo` blocks (and the int-uuid→str guard from #150) collapse into one place — source is −65 lines.

## Not included
- **Firmware / `sw_version`** isn't exposed by `getDeviceListByPsId`, so it's omitted (would need a different endpoint — noted in #149).
- **Device-level diagnostic sensors** (operating status, MPPT, DC power) — the other half of #149 — follow in a separate PR (they depend on the coordinator fetching inverter point codes; groundwork is the pysolarcloud 0.9.1 fix in #155).

## Tests
- `test_build_device_info_enriches_model_and_serial` / `…falls_back_when_fields_absent` — helper unit tests.
- `test_dispatch_device_info_carries_model_and_serial` — dispatch entity card carries model/serial.
- `test_device_sensors_created_when_enabled` — extended to assert model/serial/manufacturer on the per-device sensor.

`ruff`, `ruff format`, `mypy`, full suite (**295 passed**) green locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)