### PR TITLE
fix: pass ps_key_list to device realtime; bump pysolarcloud to 0.9.1 (#155)

### DIFF
--- a/custom_components/sungrow/coordinator.py
+++ b/custom_components/sungrow/coordinator.py
@@ -207,11 +207,22 @@ class SungrowPlantCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             if type_id in seen_types:
                 continue
             seen_types.add(type_id)
+            # Forward the ps_key of every device of this type. getDeviceRealTimeData is
+            # keyed per-device and rejects the call with result_code 009 when neither
+            # ps_key_list nor sn_list is supplied (pysolarcloud >=0.9.1). Passing None
+            # lets the library discover the keys itself (an extra list call) for older
+            # payloads that omit ps_key.
+            ps_keys = [
+                str(d["ps_key"])
+                for d in self.devices
+                if getattr(d.get("device_type"), "value", d.get("device_type")) == type_id and d.get("ps_key")
+            ]
             try:
                 async with asyncio.timeout(self._poll_timeout):
                     result = await self.plants_service.async_get_device_realtime(
                         self.plant_id,
                         device_type,
+                        ps_key_list=ps_keys or None,
                         extra_measure_points=self.extra_measure_points or None,
                     )
             except Exception as err:  # pylint: disable=broad-except

--- a/custom_components/sungrow/manifest.json
+++ b/custom_components/sungrow/manifest.json
@@ -17,7 +17,7 @@
   ],
   "quality_scale": "platinum",
   "requirements": [
-    "sungrow-isolarcloud==0.9.0"
+    "sungrow-isolarcloud==0.9.1"
   ],
   "version": "3.2.0"
 }

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -10,4 +10,4 @@ ruff==0.15.20
 mypy==2.1.0
 
 # Component dependencies
-sungrow-isolarcloud==0.9.0
+sungrow-isolarcloud==0.9.1

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -367,6 +367,25 @@ async def test_device_data_best_effort_on_error(hass: HomeAssistant):
     assert "chg-1" not in coordinator.device_data
 
 
+async def test_device_data_forwards_ps_key_list(hass: HomeAssistant):
+    """Each device's ps_key is forwarded so getDeviceRealTimeData isn't rejected (009)."""
+    plants = MagicMock()
+    plants.async_get_realtime_data = AsyncMock(return_value=MOCK_REALTIME_DATA)
+    plants.async_get_device_realtime = AsyncMock(return_value={})
+    devices = [
+        {"uuid": "inv-1", "device_type": DeviceType.INVERTER, "ps_key": "12345_1_1_1"},
+        {"uuid": "inv-2", "device_type": DeviceType.INVERTER, "ps_key": "12345_1_1_2"},
+    ]
+    coordinator = SungrowPlantCoordinator(
+        hass, _make_entry({CONF_ENABLE_DEVICE_SENSORS: True}), plants, "12345", "Test Plant", devices
+    )
+
+    await coordinator._async_update_data()
+
+    plants.async_get_device_realtime.assert_awaited_once()
+    assert plants.async_get_device_realtime.await_args.kwargs["ps_key_list"] == ["12345_1_1_1", "12345_1_1_2"]
+
+
 async def test_device_data_dedupes_device_types(hass: HomeAssistant):
     """Two devices of the same type trigger a single per-type fetch."""
     plants = MagicMock()


### PR DESCRIPTION
## What & why

Closes #155.

With device sensors enabled, the coordinator's per-device realtime fetch called `getDeviceRealTimeData` without `ps_key_list`/`sn_list`, so the API rejected **every poll** with:

```
result_code 009 — "Parameters ps_key_list,sn_list cannot be empty at the same time!"
```

— spamming the log and returning no device data.

## Changes

- **Bump `pysolarcloud` pin → `0.9.1`** (KRoperUK/pysolarcloud#26), which adds the `ps_key_list` parameter to `async_get_device_realtime` and discovers the keys itself when omitted.
- **Coordinator** now forwards each device's `ps_key` (grouped by device type) as `ps_key_list`, so the call succeeds without the extra device-list lookup the library would otherwise do. Falls back to `None` (library self-discovery) for older payloads that omit `ps_key`.

## Impact
- Kills the per-poll `009` log spam.
- Makes per-device realtime actually return data — the prerequisite for the device-level diagnostic sensors (the remaining half of #149).

## Tests
- `test_device_data_forwards_ps_key_list` — asserts each device's `ps_key` is forwarded as `ps_key_list`.
- Existing per-device tests unchanged (they tolerate the new kwarg).

`ruff`, `ruff format`, `mypy`, full suite (**296 passed**) green locally against pysolarcloud 0.9.1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)