### PR TITLE
ci: annotate lint/mypy inline + prune superseded dev RC pre-releases

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,11 +54,15 @@ jobs:
           cache: pip
           cache-dependency-path: .github/workflows/ci.yml
 
-      - name: Install dependencies
-        run: pip install ruff==0.15.16
+      - name: Install ruff
+        # Pin to the same ruff as the test env (requirements_test.txt) so lint and
+        # format can't drift between the two jobs.
+        run: pip install "$(grep -E '^ruff==' requirements_test.txt)"
 
       - name: Lint with ruff
-        run: ruff check custom_components/ tests/
+        # --output-format=github emits ::error annotations inline on the offending
+        # lines in the PR "Files changed" view.
+        run: ruff check --output-format=github custom_components/ tests/
 
       - name: Check formatting
         run: ruff format --check custom_components/ tests/
@@ -84,7 +88,14 @@ jobs:
         run: pip install -r requirements_test.txt
 
       - name: Type check with mypy
-        run: mypy
+        # Convert mypy output into GitHub annotations (inline on the PR diff) while
+        # preserving its exit status via pipefail, so type errors are surfaced on the
+        # offending line instead of only in the raw log.
+        run: |
+          set -o pipefail
+          mypy | sed -E \
+            -e 's/^([^:]+):([0-9]+): error: (.*)$/::error file=\1,line=\2::\3/' \
+            -e 's/^([^:]+):([0-9]+): note: (.*)$/::notice file=\1,line=\2::\3/'
 
       - name: Run tests with coverage
         run: >-

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -284,7 +284,29 @@ jobs:
           export VERSION RUN_ID HEAD_BRANCH WORKFLOW_EVENT
           TAG=$(bash scripts/compute-dev-tag.sh)
           echo "tag=${TAG}" >> "$GITHUB_OUTPUT"
+          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
           echo "skip=false" >> "$GITHUB_OUTPUT"
+
+      - name: Prune superseded main RC pre-releases
+        if: ${{ steps.tag.outputs.skip != 'true' }}
+        env:
+          GH_TOKEN: ${{ github.token }}
+          VERSION: ${{ steps.tag.outputs.version }}
+        run: |
+          # On main there should only be RC builds for the *current* next-version. When a
+          # new feat/fix bumps the computed version (e.g. 3.2.1 -> 3.3.0), the earlier
+          # dev-v<old>-rc* builds are superseded and will never ship — delete them now
+          # rather than waiting for a real release or the 30-day sweep.
+          gh release list --limit 1000 --json tagName,isPrerelease \
+            --jq ".[] | select(.isPrerelease and (.tagName | test(\"^dev-v[0-9]+\\\\.[0-9]+\\\\.[0-9]+-rc[0-9]+$\"))) | .tagName" \
+          | while read -r tag; do
+              tag_version="${tag#dev-v}"
+              tag_version="${tag_version%-rc*}"
+              if [ "$tag_version" != "$VERSION" ]; then
+                echo "Deleting superseded RC pre-release: ${tag} (version ${tag_version} != ${VERSION})"
+                gh release delete "$tag" --yes --cleanup-tag
+              fi
+            done
 
       - name: Create pre-release
         if: ${{ steps.tag.outputs.skip != 'true' }}


### PR DESCRIPTION
Two CI fixes prompted by the #163 mypy failure and stale `dev-v3.2.1-rc*` pre-releases.

## 1. Inline lint/type annotations
When #163's mypy failed, the error was only visible in the raw job log. Now:
- **ruff** → `ruff check --output-format=github` emits `::error` annotations inline on the PR "Files changed" view.
- **mypy** → output piped through `sed` to emit `::error` / `::notice` annotations, with `set -o pipefail` preserving mypy's exit status.
- **ruff version** → the lint job installs ruff from `requirements_test.txt`'s pin instead of a separate hardcoded `ruff==0.15.16`; they had drifted (0.15.16 vs 0.15.20). `requirements_test.txt` is now the single source of truth.

pytest failures were already annotated (`github-actions-annotate-failures`), so this brings ruff + mypy to parity.

## 2. Prune superseded main RC pre-releases
`dev-release-main` only deleted RC pre-releases once a version was *fully released*, so when a feat/fix bumped the computed next version (e.g. 3.2.1 → 3.3.0) the earlier `dev-v<old>-rc*` builds lingered until a real release or the 30-day sweep. Added a **prune step** that deletes any main RC pre-release whose version differs from the current next-version (matches only `^dev-v<semver>-rc<n>$`, so branch dev builds and full releases are untouched).

(The already-stale `dev-v3.2.1-rc*` / `dev-v3.2.0-rc*` pre-releases have been deleted manually; this prevents recurrence.)

## Validation
- `ci.yml` parses as valid YAML.
- mypy sed transform verified against a real error line.
- Prune logic verified: `dev-v3.2.1-rc…` → version 3.2.1 → delete; `dev-v3.3.0-rc…` → keep; branch tags / `v3.2.0` ignored by the regex.

🤖 Generated with [Claude Code](https://claude.com/claude-code)