### PR TITLE
feat: expose inverter device-level diagnostic sensors (#149)

### DIFF
--- a/custom_components/sungrow/const.py
+++ b/custom_components/sungrow/const.py
@@ -45,3 +45,22 @@ MAX_SCAN_INTERVAL = 86400
 # calls against the ~2000/hour free-plan cap. Refresh at most this often (plus
 # always on the first poll) so newly added/removed devices are still picked up.
 DEVICE_REFRESH_INTERVAL = 900
+
+# Inverter/ESS device-level measuring points surfaced as diagnostic sensors (#149),
+# requested per-device when device sensors are enabled. Maps the documented inverter
+# point ID -> a stable code. Every ID is already in the measure-point catalog, so it
+# classifies automatically (29 -> operating-status enum, 14 -> DC power, 5-10 -> MPPT
+# voltage/current, 4 -> temperature, 27 -> frequency, 94 -> insulation resistance).
+INVERTER_DIAGNOSTIC_POINTS: dict[str, str] = {
+    "29": "operating_status",
+    "14": "total_dc_power",
+    "4": "internal_temperature",
+    "27": "grid_frequency",
+    "94": "array_insulation_resistance",
+    "5": "mppt1_voltage",
+    "6": "mppt1_current",
+    "7": "mppt2_voltage",
+    "8": "mppt2_current",
+    "9": "mppt3_voltage",
+    "10": "mppt3_current",
+}

--- a/custom_components/sungrow/coordinator.py
+++ b/custom_components/sungrow/coordinator.py
@@ -12,7 +12,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryAuthFailed
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 from pysolarcloud import AuthError, PySolarCloudException
-from pysolarcloud.plants import Plants
+from pysolarcloud.plants import DeviceType, Plants
 
 from .auth import AUTH_ERRORS
 from .const import (
@@ -21,6 +21,7 @@ from .const import (
     CONF_SCAN_INTERVAL,
     DEFAULT_SCAN_INTERVAL,
     DEVICE_REFRESH_INTERVAL,
+    INVERTER_DIAGNOSTIC_POINTS,
 )
 
 # Upper bound on a single poll's cloud calls, so a hung request can neither stall
@@ -217,13 +218,18 @@ class SungrowPlantCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                 for d in self.devices
                 if getattr(d.get("device_type"), "value", d.get("device_type")) == type_id and d.get("ps_key")
             ]
+            # Inverter/ESS devices also report the diagnostic points (operating status,
+            # MPPT, DC power, ...); request them on top of any user-configured extras (#149).
+            extra = dict(self.extra_measure_points)
+            if type_id in (DeviceType.INVERTER.value, DeviceType.ENERGY_STORAGE_SYSTEM.value):
+                extra.update(INVERTER_DIAGNOSTIC_POINTS)
             try:
                 async with asyncio.timeout(self._poll_timeout):
                     result = await self.plants_service.async_get_device_realtime(
                         self.plant_id,
                         device_type,
                         ps_key_list=ps_keys or None,
-                        extra_measure_points=self.extra_measure_points or None,
+                        extra_measure_points=extra or None,
                     )
             except Exception as err:  # pylint: disable=broad-except
                 _LOGGER.debug("Per-device realtime failed for plant %s type %s: %s", self.plant_id, type_id, err)

--- a/custom_components/sungrow/sensor.py
+++ b/custom_components/sungrow/sensor.py
@@ -5,14 +5,14 @@ from typing import Any
 
 from homeassistant.components.sensor import SensorDeviceClass, SensorEntity, SensorStateClass
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import PERCENTAGE
+from homeassistant.const import PERCENTAGE, EntityCategory
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.device_registry import DeviceEntryType, DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from . import build_device_info
-from .const import CONF_GATEWAY, DEFAULT_CONSOLE_URL, DOMAIN, GATEWAY_CONSOLE_URLS
+from .const import CONF_GATEWAY, DEFAULT_CONSOLE_URL, DOMAIN, GATEWAY_CONSOLE_URLS, INVERTER_DIAGNOSTIC_POINTS
 from .coordinator import SungrowPlantCoordinator
 from .measure_points import (
     PERCENT_FRACTION_POINT_IDS,
@@ -27,6 +27,10 @@ from .measure_points import (
 PARALLEL_UPDATES = 0
 
 _LOGGER = logging.getLogger(__name__)
+
+# Inverter diagnostic point codes get the DIAGNOSTIC entity category so they land in
+# the device page's Diagnostic section instead of cluttering the main sensors (#149).
+_DIAGNOSTIC_CODES = frozenset(INVERTER_DIAGNOSTIC_POINTS.values())
 
 
 def infer_device_class(
@@ -260,6 +264,9 @@ class SungrowDeviceSensor(SungrowSensor):
         # Enrich the device card with the model/serial the cloud reports.
         self._attr_device_info = build_device_info(device, self.plant_id, fallback_name=coordinator.plant_name)
         self._apply_point_metadata(point_code, init_data, device_name)
+        # Inverter internals (operating status, MPPT, DC power, ...) are diagnostics.
+        if point_code in _DIAGNOSTIC_CODES:
+            self._attr_entity_category = EntityCategory.DIAGNOSTIC
 
     def _current_point(self) -> dict[str, Any] | None:
         """Return the current point payload from the coordinator's per-device data."""

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -386,6 +386,40 @@ async def test_device_data_forwards_ps_key_list(hass: HomeAssistant):
     assert plants.async_get_device_realtime.await_args.kwargs["ps_key_list"] == ["12345_1_1_1", "12345_1_1_2"]
 
 
+async def test_device_data_requests_inverter_diagnostic_points(hass: HomeAssistant):
+    """Inverter/ESS device realtime is asked for the diagnostic points (#149)."""
+    plants = MagicMock()
+    plants.async_get_realtime_data = AsyncMock(return_value=MOCK_REALTIME_DATA)
+    plants.async_get_device_realtime = AsyncMock(return_value={})
+    devices = [{"uuid": "inv-1", "device_type": DeviceType.INVERTER, "ps_key": "12345_1_1_1"}]
+    coordinator = SungrowPlantCoordinator(
+        hass, _make_entry({CONF_ENABLE_DEVICE_SENSORS: True}), plants, "12345", "Test Plant", devices
+    )
+
+    await coordinator._async_update_data()
+
+    extra = plants.async_get_device_realtime.await_args.kwargs["extra_measure_points"]
+    assert extra["29"] == "operating_status"
+    assert extra["14"] == "total_dc_power"
+    assert "5" in extra  # MPPT1 voltage
+
+
+async def test_device_data_diagnostic_points_only_for_inverter(hass: HomeAssistant):
+    """A non-inverter device is not asked for inverter diagnostic points (#149)."""
+    plants = MagicMock()
+    plants.async_get_realtime_data = AsyncMock(return_value=MOCK_REALTIME_DATA)
+    plants.async_get_device_realtime = AsyncMock(return_value={})
+    devices = [{"uuid": "chg-1", "device_type": 999, "ps_key": "12345_999_1_1"}]
+    coordinator = SungrowPlantCoordinator(
+        hass, _make_entry({CONF_ENABLE_DEVICE_SENSORS: True}), plants, "12345", "Test Plant", devices
+    )
+
+    await coordinator._async_update_data()
+
+    extra = plants.async_get_device_realtime.await_args.kwargs["extra_measure_points"]
+    assert extra is None or "29" not in extra
+
+
 async def test_device_data_dedupes_device_types(hass: HomeAssistant):
     """Two devices of the same type trigger a single per-type fetch."""
     plants = MagicMock()

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -4,7 +4,9 @@ from unittest.mock import MagicMock
 
 import pytest
 from homeassistant.components.sensor import SensorDeviceClass, SensorStateClass
+from homeassistant.const import EntityCategory
 from homeassistant.core import HomeAssistant
+from pysolarcloud.plants import DeviceType
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 
 from custom_components.sungrow import SungrowData
@@ -518,6 +520,29 @@ async def test_sensor_dynamic_add_when_placeholder_becomes_real(hass: HomeAssist
     for cb in listeners:
         cb()
     assert {e.point_code for e in added} == {"total_active_power", "battery_power"}
+
+
+async def test_inverter_diagnostic_sensor_is_diagnostic_and_enum(hass: HomeAssistant):
+    """Operating-status device sensor is DIAGNOSTIC and maps its code to a label (#149)."""
+    entry = MockConfigEntry(domain=DOMAIN, data=MOCK_CONFIG_DATA.copy())
+    entry.add_to_hass(hass)
+
+    coordinator = _coordinator_with("12345", "Plant A", {"total_active_power": {"value": "5.0", "unit": "kW"}})
+    coordinator.enable_device_sensors = True
+    coordinator.devices = [{"uuid": "inv-1", "device_name": "Inverter1", "device_type": DeviceType.INVERTER}]
+    coordinator.device_data = {"inv-1": {"operating_status": {"id": "29", "code": "operating_status", "value": "64"}}}
+    entry.runtime_data = SungrowData(
+        coordinators=[coordinator], control=MagicMock(), devices={"12345": coordinator.devices}
+    )
+
+    added = []
+    await async_setup_entry(hass, entry, lambda entities: added.extend(entities))
+
+    sensor = next(e for e in added if isinstance(e, SungrowDeviceSensor) and e.point_code == "operating_status")
+    assert sensor._attr_entity_category == EntityCategory.DIAGNOSTIC
+    assert sensor._attr_device_class == SensorDeviceClass.ENUM
+    # Raw code "64" maps to a human label from the operating-status enum.
+    assert sensor.native_value not in (None, "64")
 
 
 async def test_device_sensors_not_created_when_disabled(hass: HomeAssistant):


### PR DESCRIPTION
## What & why

Closes #149 (the diagnostic-sensors half; device metadata shipped in #162).

Surfaces the inverter's own measuring points as **diagnostic sensors**, so the device page shows what the iSolarCloud web UI shows. The **operating-status** sensor is the headline: it decodes to `Grid-connected operation` / `Dispatched running` / `Operation fault` / `Standby` / … — exactly the signal that would have made the recent "0 kWh all day" incident (#148) obvious at a glance.

## Sensors added (when device sensors are enabled)

| Sensor | Point | Class |
|---|---|---|
| **Operating status** | 29 | enum |
| Total DC power | 14 | power |
| Internal temperature | 4 | temperature |
| Grid frequency | 27 | frequency |
| Array insulation resistance | 94 | — |
| MPPT1–3 voltage / current | 5–10 | voltage / current |

## How

- `INVERTER_DIAGNOSTIC_POINTS` (const) maps each inverter point ID → a stable code. Every ID is **already in the measure-point catalog**, so classification (and the operating-status enum decode) is automatic — no catalog changes.
- The coordinator requests these points **only for inverter/ESS device types**, merged on top of any user-configured extra points (leveraging the `ps_key_list` device-realtime fix from #163).
- `SungrowDeviceSensor` tags these codes as `EntityCategory.DIAGNOSTIC` so they land in the device's Diagnostic section rather than cluttering the main sensors.

## Notes
- Gated behind the existing **"device sensors" option** (per-device fetch). Making operating-status available always-on (independent of that option) could be a follow-up.
- Non-inverter devices (meters, chargers) are unaffected — verified by test.

## Tests
- `test_device_data_requests_inverter_diagnostic_points` / `…only_for_inverter` — the diagnostic points are requested for inverters and *not* for other device types.
- `test_inverter_diagnostic_sensor_is_diagnostic_and_enum` — the operating-status sensor is `DIAGNOSTIC`, classifies as `ENUM`, and decodes its raw code to a label.

`ruff`, `ruff format`, `mypy`, full suite (**299 passed**) green locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)