### PR TITLE
feat: add a per-device fault/alarm binary sensor (#151)

### DIFF
--- a/custom_components/sungrow/__init__.py
+++ b/custom_components/sungrow/__init__.py
@@ -34,7 +34,7 @@ from .const import (
 )
 from .coordinator import SungrowPlantCoordinator, describe_api_error, is_auth_error
 
-PLATFORMS: list[Platform] = [Platform.NUMBER, Platform.SELECT, Platform.SENSOR]
+PLATFORMS: list[Platform] = [Platform.BINARY_SENSOR, Platform.NUMBER, Platform.SELECT, Platform.SENSOR]
 
 # How long to wait for a heartbeat loop to observe its stop event and exit
 # before force-cancelling it.

--- a/custom_components/sungrow/binary_sensor.py
+++ b/custom_components/sungrow/binary_sensor.py
@@ -1,0 +1,117 @@
+"""Binary sensors for the Sungrow iSolarCloud integration.
+
+A per-device ``problem`` binary sensor derived from each device's fault status
+(``dev_fault_status`` from the device list): the "is something wrong?" signal that
+was missing when a plant silently produced nothing (#151).
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from homeassistant.components.binary_sensor import BinarySensorDeviceClass, BinarySensorEntity
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import EntityCategory
+from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
+
+from . import build_device_info
+from .coordinator import SungrowPlantCoordinator
+
+# Read-only, updated in bulk by the coordinator.
+PARALLEL_UPDATES = 0
+
+_LOGGER = logging.getLogger(__name__)
+
+# Fault-status forms that mean "problem" / "no problem". pysolarcloud converts the
+# raw code to a ``DeviceFaultStaus`` enum (FAULT=1, ALARM=2, NORMAL=4), but the raw
+# API and test mocks may present an int or a string, so match every representation.
+_OK_STATES = {"4", "NORMAL"}
+_PROBLEM_STATES = {"1", "2", "FAULT", "ALARM"}
+
+
+def fault_is_on(status: Any) -> bool | None:
+    """Map a device's ``dev_fault_status`` to a PROBLEM on/off, or None if unknown.
+
+    NORMAL -> off, FAULT/ALARM -> on, anything unrecognised -> None (unknown) rather
+    than a misleading "no problem".
+    """
+    if status is None:
+        return None
+    text = str(getattr(status, "name", status))
+    if text in _OK_STATES:
+        return False
+    if text in _PROBLEM_STATES:
+        return True
+    return None
+
+
+def _build_binary_sensors(coordinator: SungrowPlantCoordinator) -> list[BinarySensorEntity]:
+    """Build a fault binary sensor for every device the coordinator currently reports."""
+    return [SungrowDeviceFaultBinarySensor(coordinator, device) for device in coordinator.devices if device.get("uuid")]
+
+
+async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry, async_add_entities: AddEntitiesCallback) -> None:
+    """Set up Sungrow binary sensors from the coordinators created during entry setup."""
+    coordinators = entry.runtime_data.coordinators
+
+    known_unique_ids: set[str] = set()
+
+    @callback
+    def _add_new_entities() -> None:
+        new_entities: list[BinarySensorEntity] = []
+        for coordinator in coordinators:
+            for entity in _build_binary_sensors(coordinator):
+                uid = entity.unique_id
+                if uid is None or uid in known_unique_ids:
+                    continue
+                known_unique_ids.add(uid)
+                new_entities.append(entity)
+        if new_entities:
+            async_add_entities(new_entities)
+
+    _add_new_entities()
+    for coordinator in coordinators:
+        entry.async_on_unload(coordinator.async_add_listener(_add_new_entities))
+
+
+class SungrowDeviceFaultBinarySensor(CoordinatorEntity[SungrowPlantCoordinator], BinarySensorEntity):
+    """A ``problem`` binary sensor reflecting a device's fault/alarm status."""
+
+    _attr_has_entity_name = True
+    _attr_device_class = BinarySensorDeviceClass.PROBLEM
+    _attr_entity_category = EntityCategory.DIAGNOSTIC
+    _attr_translation_key = "device_fault"
+
+    def __init__(self, coordinator: SungrowPlantCoordinator, device: dict[str, Any]) -> None:
+        """Initialize the fault binary sensor for a device."""
+        super().__init__(coordinator)
+        self.device_uuid = str(device["uuid"])
+        self._attr_unique_id = f"{coordinator.plant_id}_{self.device_uuid}_fault"
+        self._attr_device_info = build_device_info(device, coordinator.plant_id, fallback_name=coordinator.plant_name)
+
+    def _device(self) -> dict[str, Any] | None:
+        """Return this sensor's device from the coordinator's live list, if still present."""
+        return next((d for d in self.coordinator.devices if str(d.get("uuid")) == self.device_uuid), None)
+
+    @property
+    def available(self) -> bool:
+        """Unavailable if the poll failed or the device dropped out of the plant."""
+        return super().available and self._device() is not None
+
+    @property
+    def is_on(self) -> bool | None:
+        """True when the device reports a fault or alarm."""
+        device = self._device()
+        if device is None:
+            return None
+        return fault_is_on(device.get("dev_fault_status"))
+
+    @property
+    def extra_state_attributes(self) -> dict[str, Any]:
+        """Expose the raw fault status for troubleshooting."""
+        device = self._device() or {}
+        status = device.get("dev_fault_status")
+        return {"fault_status": str(getattr(status, "name", status)) if status is not None else None}

--- a/custom_components/sungrow/strings.json
+++ b/custom_components/sungrow/strings.json
@@ -71,6 +71,11 @@
     }
   },
   "entity": {
+    "binary_sensor": {
+      "device_fault": {
+        "name": "Fault"
+      }
+    },
     "number": {
       "charge_discharge_power": {
         "name": "Charge/Discharge Power"

--- a/custom_components/sungrow/translations/en.json
+++ b/custom_components/sungrow/translations/en.json
@@ -71,6 +71,11 @@
     }
   },
   "entity": {
+    "binary_sensor": {
+      "device_fault": {
+        "name": "Fault"
+      }
+    },
     "number": {
       "charge_discharge_power": {
         "name": "Charge/Discharge Power"

--- a/tests/test_binary_sensor.py
+++ b/tests/test_binary_sensor.py
@@ -1,0 +1,111 @@
+"""Tests for the Sungrow binary_sensor platform (device fault, #151)."""
+
+from unittest.mock import MagicMock
+
+from homeassistant.components.binary_sensor import BinarySensorDeviceClass
+from homeassistant.const import EntityCategory
+from homeassistant.core import HomeAssistant
+from pysolarcloud.plants import DeviceFaultStaus
+from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+from custom_components.sungrow import SungrowData
+from custom_components.sungrow.binary_sensor import (
+    SungrowDeviceFaultBinarySensor,
+    async_setup_entry,
+    fault_is_on,
+)
+from custom_components.sungrow.const import DOMAIN
+
+from .conftest import MOCK_CONFIG_DATA
+
+
+def _coordinator_with(devices):
+    coordinator = MagicMock()
+    coordinator.plant_id = "12345"
+    coordinator.plant_name = "Test Plant"
+    coordinator.config_entry = MagicMock()
+    coordinator.last_update_success = True
+    coordinator.devices = devices
+    return coordinator
+
+
+def _setup_entry_data(entry, devices) -> SungrowData:
+    coordinator = _coordinator_with(devices)
+    data = SungrowData(coordinators=[coordinator], control=MagicMock(), devices={"12345": devices})
+    entry.runtime_data = data
+    return data
+
+
+def test_fault_is_on_maps_all_status_forms():
+    """fault_is_on handles the enum, int and string representations of the status."""
+    assert fault_is_on(DeviceFaultStaus.NORMAL) is False
+    assert fault_is_on(DeviceFaultStaus.FAULT) is True
+    assert fault_is_on(DeviceFaultStaus.ALARM) is True
+    assert fault_is_on("NORMAL") is False
+    assert fault_is_on("FAULT") is True
+    assert fault_is_on(4) is False
+    assert fault_is_on(1) is True
+    # Unknown / missing -> None (unknown), never a misleading "no problem".
+    assert fault_is_on(None) is None
+    assert fault_is_on("mystery") is None
+
+
+async def test_fault_binary_sensor_created_per_device(hass: HomeAssistant):
+    """A PROBLEM binary sensor is created for every device with a uuid."""
+    entry = MockConfigEntry(domain=DOMAIN, data=MOCK_CONFIG_DATA.copy())
+    entry.add_to_hass(hass)
+    devices = [
+        {"uuid": "inv-1", "device_name": "Inverter1", "dev_fault_status": DeviceFaultStaus.NORMAL},
+        {"uuid": "meter-1", "device_name": "Meter1", "dev_fault_status": DeviceFaultStaus.FAULT},
+        {"device_name": "no-uuid"},  # skipped
+    ]
+    _setup_entry_data(entry, devices)
+
+    added: list = []
+    await async_setup_entry(hass, entry, lambda entities: added.extend(entities))
+
+    assert len(added) == 2
+    by_uuid = {e.device_uuid: e for e in added}
+    assert by_uuid["inv-1"]._attr_device_class == BinarySensorDeviceClass.PROBLEM
+    assert by_uuid["inv-1"]._attr_entity_category == EntityCategory.DIAGNOSTIC
+    assert by_uuid["inv-1"]._attr_unique_id == "12345_inv-1_fault"
+    assert by_uuid["inv-1"].is_on is False
+    assert by_uuid["meter-1"].is_on is True
+    assert by_uuid["meter-1"].extra_state_attributes["fault_status"] == "FAULT"
+
+
+async def test_fault_binary_sensor_unavailable_when_device_gone(hass: HomeAssistant):
+    """The sensor goes unavailable if its device drops out of the plant on a later refresh."""
+    entry = MockConfigEntry(domain=DOMAIN, data=MOCK_CONFIG_DATA.copy())
+    entry.add_to_hass(hass)
+    devices = [{"uuid": "inv-1", "device_name": "Inverter1", "dev_fault_status": DeviceFaultStaus.NORMAL}]
+    data = _setup_entry_data(entry, devices)
+
+    added: list = []
+    await async_setup_entry(hass, entry, lambda entities: added.extend(entities))
+    sensor = added[0]
+    assert sensor.available is True
+
+    data.coordinators[0].devices = []
+    assert sensor.available is False
+    assert sensor.is_on is None
+
+
+def test_fault_binary_sensor_device_info_enriched():
+    """The binary sensor's device card carries model/serial (via build_device_info)."""
+    coordinator = _coordinator_with(
+        [
+            {
+                "uuid": "inv-1",
+                "device_name": "Inv",
+                "device_model_code": "SG3.6RS",
+                "device_sn": "A1",
+                "factory_name": "SUNGROW",
+            }
+        ]
+    )
+    sensor = SungrowDeviceFaultBinarySensor(coordinator, coordinator.devices[0])
+    info = sensor._attr_device_info
+    assert info["model"] == "SG3.6RS"
+    assert info["serial_number"] == "A1"
+    assert (DOMAIN, "inv-1") in info["identifiers"]


### PR DESCRIPTION
## What & why

Closes #151. The integration had **no "is something wrong?" signal** — an inverter fault only manifested as mysteriously low generation (exactly the #148 incident). This adds a `binary_sensor` platform with a **PROBLEM binary sensor per device**, driven by the device list's `dev_fault_status`.

## Behaviour
- `NORMAL` → off, `FAULT`/`ALARM` → on, anything unrecognised/missing → unknown (never a misleading "no problem").
- Handles every representation of the status (pysolarcloud `DeviceFaultStaus` enum, or a raw int/string).
- One sensor per device (inverter, meter, comm module…), nested under the device via `build_device_info`, `EntityCategory.DIAGNOSTIC`.
- Goes **unavailable** if its device drops out of the plant.
- Raw status exposed as a `fault_status` state attribute for troubleshooting.

## Notes
- Fault status comes from the device list, which refreshes every ~15 min (`DEVICE_REFRESH_INTERVAL`), so detection latency is up to that interval — fine for persistent faults. A faster/plant-level `ps_fault_status` surface could be a follow-up.
- New `Platform.BINARY_SENSOR`; entity name added to `strings.json` + `translations/en.json`.

## Tests (`tests/test_binary_sensor.py`)
- `fault_is_on` across enum/int/string/unknown forms.
- One sensor created per device-with-uuid; PROBLEM class + diagnostic category + correct on/off.
- Unavailable when the device disappears.
- Device card enriched with model/serial.

`ruff`, `ruff format`, `mypy`, full suite (**300 passed**) green locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)