### PR TITLE
fix: ride out transient poll failures instead of flapping unavailable (#152)

### DIFF
--- a/custom_components/sungrow/coordinator.py
+++ b/custom_components/sungrow/coordinator.py
@@ -28,6 +28,13 @@ from .const import (
 # the coordinator indefinitely nor let successive polls pile up.
 MAX_POLL_TIMEOUT = 60
 
+# How long (seconds) to keep serving the last-good data — staying "available" — when
+# polls fail transiently, before marking entities unavailable. Rides out the
+# intermittent cloud/device hiccups that would otherwise flap every entity several
+# times a minute (#152). iSolarCloud only updates every ~5 min, so a few minutes of
+# staleness is harmless.
+AVAILABILITY_GRACE_SECONDS = 900
+
 _LOGGER = logging.getLogger(__name__)
 
 
@@ -121,6 +128,9 @@ class SungrowPlantCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         self._poll_timeout: float = min(scan_seconds, MAX_POLL_TIMEOUT)
         # Monotonic timestamp of the last device-list refresh; None until first poll.
         self._last_device_refresh: float | None = None
+        # Monotonic timestamp of the last successful realtime poll; drives the
+        # availability grace window (#152). None until the first success.
+        self._last_successful_update: float | None = None
         self.devices: list[dict[str, Any]] = list(devices or [])
         self.extra_measure_points: dict[str, str] = dict(config_entry.options.get(CONF_EXTRA_MEASURE_POINTS, {}))
         self.enable_device_sensors: bool = bool(config_entry.options.get(CONF_ENABLE_DEVICE_SENSORS, False))
@@ -150,8 +160,17 @@ class SungrowPlantCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         except Exception as err:
             if is_auth_error(err):
                 raise ConfigEntryAuthFailed(f"Authentication with iSolarCloud failed: {err}") from err
+            # Transient failure (a timeout arrives here as TimeoutError). Rather than flap
+            # every entity to "unavailable" on a brief cloud hiccup, keep serving the
+            # last-good data while a recent success is still within the grace window (#152);
+            # only give up once the data would be genuinely stale.
+            if self.data is not None and self._within_availability_grace():
+                _LOGGER.debug("Transient poll failure for %s; keeping last-good data: %s", self.plant_name, err)
+                return self.data
             # A timeout arrives here as TimeoutError and is treated as transient.
             raise UpdateFailed(describe_api_error(err) or f"Error communicating with iSolarCloud API: {err}") from err
+
+        self._last_successful_update = self.hass.loop.time()
 
         # Refresh the device list so devices added to the plant after setup are
         # picked up at runtime (dynamic-devices) and removed ones can be pruned
@@ -163,6 +182,12 @@ class SungrowPlantCoordinator(DataUpdateCoordinator[dict[str, Any]]):
 
         # pysolarcloud is untyped, so the realtime payload is Any.
         return cast("dict[str, Any]", all_plants_data.get(self.plant_id, {}))
+
+    def _within_availability_grace(self) -> bool:
+        """True while the last successful poll is recent enough to keep serving stale data."""
+        if self._last_successful_update is None:
+            return False
+        return (self.hass.loop.time() - self._last_successful_update) < AVAILABILITY_GRACE_SECONDS
 
     async def _async_maybe_refresh_devices(self) -> None:
         """Refresh the device list periodically rather than on every poll (saves quota).

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -143,6 +143,51 @@ async def test_update_data_transient_error_raises_update_failed(hass: HomeAssist
         await coordinator._async_update_data()
 
 
+async def test_transient_failure_keeps_last_good_within_grace(hass: HomeAssistant):
+    """A brief poll failure keeps the last-good data instead of flapping unavailable (#152)."""
+    plants = MagicMock()
+    plants.async_get_realtime_data = AsyncMock(return_value=MOCK_REALTIME_DATA)
+    coordinator = SungrowPlantCoordinator(hass, _make_entry(), plants, "12345", "Test Plant")
+    await coordinator.async_refresh()
+    assert coordinator.last_update_success is True
+    good = coordinator.data
+
+    # The next poll fails transiently, within the grace window.
+    plants.async_get_realtime_data = AsyncMock(side_effect=ConnectionError("blip"))
+    await coordinator.async_refresh()
+
+    assert coordinator.last_update_success is True  # stayed available
+    assert coordinator.data == good  # served the last-good data
+
+
+async def test_transient_failure_raises_after_grace(hass: HomeAssistant):
+    """Once the last success is older than the grace window, entities go unavailable (#152)."""
+    plants = MagicMock()
+    plants.async_get_realtime_data = AsyncMock(return_value=MOCK_REALTIME_DATA)
+    coordinator = SungrowPlantCoordinator(hass, _make_entry(), plants, "12345", "Test Plant")
+    await coordinator.async_refresh()
+    assert coordinator.last_update_success is True
+
+    # Pretend the last success was long ago, then fail.
+    coordinator._last_successful_update = hass.loop.time() - 100000
+    plants.async_get_realtime_data = AsyncMock(side_effect=ConnectionError("down"))
+    await coordinator.async_refresh()
+
+    assert coordinator.last_update_success is False
+
+
+async def test_auth_error_not_debounced_within_grace(hass: HomeAssistant):
+    """An auth error still triggers reauth immediately, even inside the grace window (#152)."""
+    plants = MagicMock()
+    plants.async_get_realtime_data = AsyncMock(return_value=MOCK_REALTIME_DATA)
+    coordinator = SungrowPlantCoordinator(hass, _make_entry(), plants, "12345", "Test Plant")
+    await coordinator.async_refresh()  # success -> within grace, has last-good data
+
+    plants.async_get_realtime_data = AsyncMock(side_effect=PySolarCloudException({"error": "invalid_token"}))
+    with pytest.raises(ConfigEntryAuthFailed):
+        await coordinator._async_update_data()
+
+
 async def test_update_data_auth_error_raises_config_entry_auth_failed(hass: HomeAssistant):
     """A failed token refresh raises ConfigEntryAuthFailed (triggers reauth)."""
     plants = MagicMock()


### PR DESCRIPTION
## What & why

Closes #152. On a live install the entities repeatedly dropped to `unavailable` and recovered — several times a minute — because the coordinator marked **every entity unavailable on a single failed poll**, and the cloud/device realtime calls fail intermittently.

## Fix
On a **transient** failure, keep serving the **last-good data** (so entities stay available with recent values) as long as a successful poll happened within a **15-minute grace window**. Only once the data would be genuinely stale does it mark entities unavailable. iSolarCloud only updates every ~5 min, so a few minutes of staleness is harmless — and it also cuts the "coordinator failed" log spam.

- **Auth errors are not debounced** — they still raise `ConfigEntryAuthFailed` immediately so reauth triggers.
- **First poll** (no prior data) still fails hard → `ConfigEntryNotReady` on setup, as before.

## Tests
- `test_transient_failure_keeps_last_good_within_grace` — a blip keeps the last-good data, stays available.
- `test_transient_failure_raises_after_grace` — once the last success is older than the window, it goes unavailable.
- `test_auth_error_not_debounced_within_grace` — auth errors still reauth immediately.
- Existing first-poll transient/whitelist tests unchanged (no prior data → still raise).

`ruff`, `ruff format`, `mypy`, full suite (**306 passed**) green locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)