### PR TITLE
ci: give RC pre-releases a warning banner + release-please changelog

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -313,10 +313,35 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
           TAG: ${{ steps.tag.outputs.tag }}
+          VERSION: ${{ steps.tag.outputs.version }}
           COMMIT_SHA: ${{ github.sha }}
+          # Release-please-style changelog for the changes since the last stable release.
+          CHANGELOG: ${{ steps.nextver.outputs.clean_changelog }}
         run: |
+          # Latest published stable (non-prerelease, non-draft) release, to steer users away
+          # from RC builds. Empty if none has shipped yet.
+          latest_stable=$(gh api "repos/${GITHUB_REPOSITORY}/releases/latest" --jq '.tag_name' 2>/dev/null || true)
+          if [ -n "$latest_stable" ]; then
+            stable_line="For everyday use, install the latest **stable** release instead: [\`${latest_stable}\`](https://github.com/${GITHUB_REPOSITORY}/releases/tag/${latest_stable})."
+          else
+            stable_line="No stable release has been published yet."
+          fi
+          {
+            echo "> [!WARNING]"
+            echo "> **This is an automated release-candidate build, not an official release.**"
+            echo "> It previews the upcoming **v${VERSION}** release from \`main\` (commit \`${COMMIT_SHA}\`) and may be unstable."
+            echo "> ${stable_line}"
+            echo ""
+            echo "## What's changed for v${VERSION}"
+            echo ""
+            if [ -n "${CHANGELOG}" ]; then
+              printf '%s\n' "${CHANGELOG}"
+            else
+              echo "_No user-facing changes detected since the last release._"
+            fi
+          } > rc-notes.md
           gh release create "$TAG" \
             --prerelease \
             --title "$TAG" \
-            --notes "Release-candidate build from \`main\` at commit \`${COMMIT_SHA}\`." \
+            --notes-file rc-notes.md \
             || echo "Release already exists for this tag, skipping."


### PR DESCRIPTION
## Why
The main RC pre-releases (`dev-v<next>-rc<n>`) had a one-line body ("Release-candidate build from `main`…"). Someone landing on one from the releases page had no warning it's unstable, no pointer to the stable release, and no idea what's in it.

## Now
The RC body renders as:

> [!WARNING]
> **This is an automated release-candidate build, not an official release.**
> It previews the upcoming **v3.3.0** release from `main` (commit `abc1234`) and may be unstable.
> For everyday use, install the latest **stable** release instead: [`v3.2.0`](https://github.com/KRoperUK/sungrow-hass/releases/tag/v3.2.0).
>
> ## What's changed for v3.3.0
> ### Features
> * …
> ### Bug Fixes
> * …

- **Warning banner** naming the upcoming version and linking the latest **stable** release (from `gh api …/releases/latest`, which already excludes pre-releases/drafts; falls back gracefully if none exists).
- **Release-please-style changelog** from the existing `conventional-changelog-action` (`clean_changelog`) — the changes since the last release. Falls back to a placeholder when empty.

## Notes
- Only the **main RC** (`dev-release-main`) build is changed; branch/PR dev builds keep their existing note. Happy to give those the same warning if you want.
- The changelog is passed via env and printed with `printf '%s'` (values aren't re-evaluated, so commit-message backticks/`$()` are inert).
- YAML validated; note rendering verified locally with sample inputs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)