### PR TITLE
feat: expose battery/ESS device-level sensors for hybrid users (#154)

### DIFF
--- a/custom_components/sungrow/const.py
+++ b/custom_components/sungrow/const.py
@@ -64,3 +64,21 @@ INVERTER_DIAGNOSTIC_POINTS: dict[str, str] = {
     "9": "mppt3_voltage",
     "10": "mppt3_current",
 }
+
+# Battery/ESS device-level measuring points surfaced as sensors for hybrid users (#154),
+# requested per-device when device sensors are enabled. Every ID is already in the
+# measure-point catalog, so it classifies automatically (level -> battery, charge/discharge
+# energy -> total_increasing, voltage/current/temperature accordingly).
+BATTERY_DEVICE_POINTS: dict[str, str] = {
+    "58604": "battery_level",
+    "58606": "battery_total_charge_energy",
+    "58607": "battery_total_discharge_energy",
+    "58601": "battery_voltage",
+    "58602": "battery_current",
+    "58603": "battery_temperature",
+    "58605": "battery_soh",
+}
+
+# The technical/health subset of the battery points shown as diagnostics; the rest
+# (SOC, charge/discharge energy) stay primary sensors for the dashboards.
+BATTERY_DIAGNOSTIC_CODES = frozenset({"battery_voltage", "battery_current", "battery_temperature", "battery_soh"})

--- a/custom_components/sungrow/coordinator.py
+++ b/custom_components/sungrow/coordinator.py
@@ -16,6 +16,7 @@ from pysolarcloud.plants import DeviceType, Plants
 
 from .auth import AUTH_ERRORS
 from .const import (
+    BATTERY_DEVICE_POINTS,
     CONF_ENABLE_DEVICE_SENSORS,
     CONF_EXTRA_MEASURE_POINTS,
     CONF_SCAN_INTERVAL,
@@ -245,9 +246,12 @@ class SungrowPlantCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             ]
             # Inverter/ESS devices also report the diagnostic points (operating status,
             # MPPT, DC power, ...); request them on top of any user-configured extras (#149).
+            # Battery/ESS devices likewise report battery points (SOC, temp, SOH, ...) (#154).
             extra = dict(self.extra_measure_points)
             if type_id in (DeviceType.INVERTER.value, DeviceType.ENERGY_STORAGE_SYSTEM.value):
                 extra.update(INVERTER_DIAGNOSTIC_POINTS)
+            if type_id in (DeviceType.BATTERY.value, DeviceType.ENERGY_STORAGE_SYSTEM.value):
+                extra.update(BATTERY_DEVICE_POINTS)
             try:
                 async with asyncio.timeout(self._poll_timeout):
                     result = await self.plants_service.async_get_device_realtime(

--- a/custom_components/sungrow/sensor.py
+++ b/custom_components/sungrow/sensor.py
@@ -12,7 +12,14 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from . import build_device_info
-from .const import CONF_GATEWAY, DEFAULT_CONSOLE_URL, DOMAIN, GATEWAY_CONSOLE_URLS, INVERTER_DIAGNOSTIC_POINTS
+from .const import (
+    BATTERY_DIAGNOSTIC_CODES,
+    CONF_GATEWAY,
+    DEFAULT_CONSOLE_URL,
+    DOMAIN,
+    GATEWAY_CONSOLE_URLS,
+    INVERTER_DIAGNOSTIC_POINTS,
+)
 from .coordinator import SungrowPlantCoordinator
 from .measure_points import (
     PERCENT_FRACTION_POINT_IDS,
@@ -28,9 +35,9 @@ PARALLEL_UPDATES = 0
 
 _LOGGER = logging.getLogger(__name__)
 
-# Inverter diagnostic point codes get the DIAGNOSTIC entity category so they land in
-# the device page's Diagnostic section instead of cluttering the main sensors (#149).
-_DIAGNOSTIC_CODES = frozenset(INVERTER_DIAGNOSTIC_POINTS.values())
+# Inverter + battery-health point codes get the DIAGNOSTIC entity category so they land
+# in the device page's Diagnostic section instead of cluttering the main sensors (#149/#154).
+_DIAGNOSTIC_CODES = frozenset(INVERTER_DIAGNOSTIC_POINTS.values()) | BATTERY_DIAGNOSTIC_CODES
 
 
 def infer_device_class(

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -465,6 +465,41 @@ async def test_device_data_diagnostic_points_only_for_inverter(hass: HomeAssista
     assert extra is None or "29" not in extra
 
 
+async def test_device_data_requests_battery_points_for_battery_device(hass: HomeAssistant):
+    """A battery device is asked for the battery points, not the inverter-only ones (#154)."""
+    plants = MagicMock()
+    plants.async_get_realtime_data = AsyncMock(return_value=MOCK_REALTIME_DATA)
+    plants.async_get_device_realtime = AsyncMock(return_value={})
+    devices = [{"uuid": "bat-1", "device_type": DeviceType.BATTERY, "ps_key": "12345_43_1_1"}]
+    coordinator = SungrowPlantCoordinator(
+        hass, _make_entry({CONF_ENABLE_DEVICE_SENSORS: True}), plants, "12345", "Test Plant", devices
+    )
+
+    await coordinator._async_update_data()
+
+    extra = plants.async_get_device_realtime.await_args.kwargs["extra_measure_points"]
+    assert extra["58604"] == "battery_level"
+    assert extra["58606"] == "battery_total_charge_energy"
+    assert "29" not in extra  # not the inverter operating-status point
+
+
+async def test_device_data_ess_gets_both_inverter_and_battery_points(hass: HomeAssistant):
+    """An ESS device reports both the inverter and the battery points (#149/#154)."""
+    plants = MagicMock()
+    plants.async_get_realtime_data = AsyncMock(return_value=MOCK_REALTIME_DATA)
+    plants.async_get_device_realtime = AsyncMock(return_value={})
+    devices = [{"uuid": "ess-1", "device_type": DeviceType.ENERGY_STORAGE_SYSTEM, "ps_key": "12345_14_1_1"}]
+    coordinator = SungrowPlantCoordinator(
+        hass, _make_entry({CONF_ENABLE_DEVICE_SENSORS: True}), plants, "12345", "Test Plant", devices
+    )
+
+    await coordinator._async_update_data()
+
+    extra = plants.async_get_device_realtime.await_args.kwargs["extra_measure_points"]
+    assert "29" in extra  # inverter operating status
+    assert "58604" in extra  # battery level
+
+
 async def test_device_data_dedupes_device_types(hass: HomeAssistant):
     """Two devices of the same type trigger a single per-type fetch."""
     plants = MagicMock()

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -545,6 +545,34 @@ async def test_inverter_diagnostic_sensor_is_diagnostic_and_enum(hass: HomeAssis
     assert sensor.native_value not in (None, "64")
 
 
+async def test_battery_device_sensor_categories(hass: HomeAssistant):
+    """Battery health points are diagnostic; SOC stays a primary sensor (#154)."""
+    entry = MockConfigEntry(domain=DOMAIN, data=MOCK_CONFIG_DATA.copy())
+    entry.add_to_hass(hass)
+
+    coordinator = _coordinator_with("12345", "Plant A", {"total_active_power": {"value": "5.0", "unit": "kW"}})
+    coordinator.enable_device_sensors = True
+    coordinator.devices = [{"uuid": "bat-1", "device_name": "Battery1", "device_type": DeviceType.BATTERY}]
+    coordinator.device_data = {
+        "bat-1": {
+            "battery_temperature": {"id": "58603", "code": "battery_temperature", "value": "25.0", "unit": "°C"},
+            "battery_level": {"id": "58604", "code": "battery_level", "value": "80", "unit": "%"},
+        }
+    }
+    entry.runtime_data = SungrowData(
+        coordinators=[coordinator], control=MagicMock(), devices={"12345": coordinator.devices}
+    )
+
+    added = []
+    await async_setup_entry(hass, entry, lambda entities: added.extend(entities))
+
+    by_code = {e.point_code: e for e in added if isinstance(e, SungrowDeviceSensor)}
+    assert by_code["battery_temperature"].entity_category == EntityCategory.DIAGNOSTIC
+    assert by_code["battery_temperature"].device_class == SensorDeviceClass.TEMPERATURE
+    assert by_code["battery_level"].entity_category is None  # SOC is a primary sensor
+    assert by_code["battery_level"].device_class == SensorDeviceClass.BATTERY
+
+
 async def test_device_sensors_not_created_when_disabled(hass: HomeAssistant):
     """No device sensors are created when the option is off, even with device data present."""
     entry = MockConfigEntry(domain=DOMAIN, data=MOCK_CONFIG_DATA.copy())


### PR DESCRIPTION
## What & why

Closes #154. Rounds out battery support for hybrid users by surfacing the **battery device's own measuring points**, mirroring the inverter diagnostics from #149.

**First I audited the plant-level battery/meter aggregates** — they already classify correctly for the Energy Dashboard (grid import/export & battery charge/discharge → `energy` / `total_increasing`, SOC → `battery`, power → `power`). So this PR focuses on the genuine gap: **per-battery-device** detail.

## Sensors added (when device sensors are enabled)

| Sensor | Point | Class | Category |
|---|---|---|---|
| Battery level (SOC) | 58604 | battery | primary |
| Total charge / discharge energy | 58606 / 58607 | energy / total_increasing | primary (Energy Dashboard) |
| Battery voltage / current | 58601 / 58602 | voltage / current | diagnostic |
| Battery temperature | 58603 | temperature | diagnostic |
| Battery health (SOH) | 58605 | — | diagnostic |

## How
- `BATTERY_DEVICE_POINTS` (const) maps each battery point ID → a stable code; all IDs are **already in the measure-point catalog**, so classification is automatic (verified).
- The coordinator requests them for **`BATTERY` and `ESS`** device types (an ESS device gets both inverter *and* battery points), merged on top of user extras.
- `battery_voltage/current/temperature/soh` are tagged `EntityCategory.DIAGNOSTIC`; SOC + energy totals stay primary.

## Notes
- Best-effort per-device fetch (degrades gracefully if an account/model doesn't return these). I don't have a battery to validate against live, so this is validated by catalog classification + the same working pattern as #149 — flagging that explicitly.
- Per-cell/per-module voltages (58610–58633) are intentionally left out to avoid entity bloat; easy follow-up if wanted.

## Tests
- Battery device → battery points requested (not inverter-only); ESS device → both sets.
- `battery_temperature` sensor is `DIAGNOSTIC` + `temperature`; `battery_level` is primary + `battery`.

`ruff`, `ruff format`, `mypy`, full suite (**309 passed**) green locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)