### PR TITLE
ci: number main RC pre-releases rc1, rc2, rc3… instead of the run id

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -258,7 +258,6 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           SKIPPED: ${{ steps.nextver.outputs.skipped }}
           NEXT_VERSION: ${{ steps.nextver.outputs.version }}
-          RUN_ID: ${{ github.run_id }}
         run: |
           if [ "$SKIPPED" = "true" ] || [ -z "$NEXT_VERSION" ]; then
             VERSION=$(jq -r .version custom_components/sungrow/manifest.json)
@@ -279,9 +278,17 @@ jobs:
             echo "skip=true" >> "$GITHUB_OUTPUT"
             exit 0
           fi
+          # Incrementing RC number for this version: highest existing dev-v<ver>-rc<n> + 1,
+          # so builds are rc1, rc2, rc3, ... It resets to rc1 when the next version bumps,
+          # since no dev-v<new>-rc* exist yet.
+          version_regex=$(printf '%s' "$VERSION" | sed 's/\./\\./g')
+          highest_rc=$(gh release list --limit 1000 --json tagName,isPrerelease \
+            --jq ".[] | select(.isPrerelease and (.tagName | test(\"^dev-v${version_regex}-rc[0-9]+$\"))) | .tagName" \
+            | sed -E 's/.*-rc([0-9]+)$/\1/' | sort -n | tail -1)
+          RC_NUMBER=$(( ${highest_rc:-0} + 1 ))
           HEAD_BRANCH=main
           WORKFLOW_EVENT=push
-          export VERSION RUN_ID HEAD_BRANCH WORKFLOW_EVENT
+          export VERSION RC_NUMBER HEAD_BRANCH WORKFLOW_EVENT
           TAG=$(bash scripts/compute-dev-tag.sh)
           echo "tag=${TAG}" >> "$GITHUB_OUTPUT"
           echo "version=${VERSION}" >> "$GITHUB_OUTPUT"

--- a/scripts/compute-dev-tag.sh
+++ b/scripts/compute-dev-tag.sh
@@ -4,14 +4,15 @@
 #   VERSION        predicted next version, no leading v (e.g. 3.1.0)
 #   HEAD_BRANCH    branch CI ran on (main, or a PR source branch)
 #   WORKFLOW_EVENT CI run's triggering event (push / pull_request)
-#   RUN_ID         globally-unique run id
-# Prints the tag to stdout: dev-v<ver>-rc<id> (main push) or dev-v<ver>-<branch>-<id>.
+#   RC_NUMBER      incrementing RC counter for the current version (main push)
+#   RUN_ID         globally-unique run id (PR branch builds)
+# Prints the tag to stdout: dev-v<ver>-rc<n> (main push) or dev-v<ver>-<branch>-<id>.
 set -euo pipefail
 
 sanitize() { printf '%s' "$1" | sed 's/[^a-zA-Z0-9._-]/-/g' | sed 's/-\{2,\}/-/g'; }
 
 if [ "${HEAD_BRANCH}" = "main" ] && [ "${WORKFLOW_EVENT}" = "push" ]; then
-    printf 'dev-v%s-rc%s\n' "${VERSION}" "${RUN_ID}"
+    printf 'dev-v%s-rc%s\n' "${VERSION}" "${RC_NUMBER}"
 else
     printf 'dev-v%s-%s-%s\n' "${VERSION}" "$(sanitize "${HEAD_BRANCH}")" "${RUN_ID}"
 fi


### PR DESCRIPTION
## Why
The main release-candidate tags used the GitHub **run id** as the suffix — e.g. `dev-v3.3.0-rc28758455396` — which is long and meaningless.

## Now
They're numbered with a simple incrementing counter **per version**: `dev-v3.3.0-rc1`, `-rc2`, `-rc3`, …

- The `dev-release-main` "Compute dev tag" step computes the next RC number as `(highest existing dev-v<ver>-rc<n>) + 1`.
- It **resets to `rc1` when the next version bumps** (e.g. 3.2.1 → 3.3.0), since no `dev-v3.3.0-rc*` exist yet.
- `scripts/compute-dev-tag.sh` now takes `RC_NUMBER` for the main path; branch/PR dev builds are unchanged (still `-<branch>-<run_id>`).

## Validation
- `dev-v3.3.0-rc5` produced for the main path with `RC_NUMBER=5`; branch path unaffected (and `set -u`-safe with `RC_NUMBER` unset).
- RC-number extraction verified (`rc1`/`rc2`/`rc3` → next `4`; other-version tags ignored).
- YAML valid; composes cleanly with the RC warning-banner/changelog from #168.

🤖 Generated with [Claude Code](https://claude.com/claude-code)