### PR TITLE
feat: raise HA Repair issues for whitelist & rate-limit errors (#153)

### DIFF
--- a/custom_components/sungrow/coordinator.py
+++ b/custom_components/sungrow/coordinator.py
@@ -10,6 +10,7 @@ from typing import Any, cast
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryAuthFailed
+from homeassistant.helpers import issue_registry as ir
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 from pysolarcloud import AuthError, PySolarCloudException
 from pysolarcloud.plants import DeviceType, Plants
@@ -22,6 +23,7 @@ from .const import (
     CONF_SCAN_INTERVAL,
     DEFAULT_SCAN_INTERVAL,
     DEVICE_REFRESH_INTERVAL,
+    DOMAIN,
     INVERTER_DIAGNOSTIC_POINTS,
 )
 
@@ -101,6 +103,16 @@ def describe_api_error(err: Exception) -> str | None:
     return None
 
 
+# iSolarCloud error codes that warrant a user-facing Repair (#153). Each maps to a
+# translation key under ``issues.<key>``. Reauth is intentionally absent: HA already opens
+# a reauth flow when the coordinator raises ConfigEntryAuthFailed.
+_REPAIR_CODES: dict[str, frozenset[str]] = {
+    "whitelist_rejection": WHITELIST_ERRORS,
+    "rate_limited": frozenset({"E998", "E999"}),
+}
+_REPAIR_LEARN_MORE = "https://github.com/KRoperUK/sungrow-hass/blob/main/docs/TROUBLESHOOTING.md"
+
+
 class SungrowPlantCoordinator(DataUpdateCoordinator[dict[str, Any]]):
     """Coordinator to manage fetching data from a single plant."""
 
@@ -161,6 +173,8 @@ class SungrowPlantCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         except Exception as err:
             if is_auth_error(err):
                 raise ConfigEntryAuthFailed(f"Authentication with iSolarCloud failed: {err}") from err
+            # Surface actionable errors (whitelist, rate limit) as HA Repairs (#153).
+            self._async_manage_repairs(err)
             # Transient failure (a timeout arrives here as TimeoutError). Rather than flap
             # every entity to "unavailable" on a brief cloud hiccup, keep serving the
             # last-good data while a recent success is still within the grace window (#152);
@@ -171,6 +185,7 @@ class SungrowPlantCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             # A timeout arrives here as TimeoutError and is treated as transient.
             raise UpdateFailed(describe_api_error(err) or f"Error communicating with iSolarCloud API: {err}") from err
 
+        self._async_manage_repairs(None)
         self._last_successful_update = self.hass.loop.time()
 
         # Refresh the device list so devices added to the plant after setup are
@@ -189,6 +204,29 @@ class SungrowPlantCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         if self._last_successful_update is None:
             return False
         return (self.hass.loop.time() - self._last_successful_update) < AVAILABILITY_GRACE_SECONDS
+
+    def _async_manage_repairs(self, err: Exception | None) -> None:
+        """Raise or clear Repair issues for actionable iSolarCloud errors (#153).
+
+        Called on every poll: creates the matching Repair when a known actionable code
+        occurs and clears the rest, so a recovered plant automatically dismisses its issue.
+        """
+        code = err.error if isinstance(err, PySolarCloudException) else None
+        for key, codes in _REPAIR_CODES.items():
+            issue_id = f"{key}_{self.plant_id}"
+            if code in codes:
+                ir.async_create_issue(
+                    self.hass,
+                    DOMAIN,
+                    issue_id,
+                    is_fixable=False,
+                    severity=ir.IssueSeverity.WARNING,
+                    translation_key=key,
+                    translation_placeholders={"plant": self.plant_name},
+                    learn_more_url=_REPAIR_LEARN_MORE,
+                )
+            else:
+                ir.async_delete_issue(self.hass, DOMAIN, issue_id)
 
     async def _async_maybe_refresh_devices(self) -> None:
         """Refresh the device list periodically rather than on every poll (saves quota).

--- a/custom_components/sungrow/strings.json
+++ b/custom_components/sungrow/strings.json
@@ -70,6 +70,16 @@
       }
     }
   },
+  "issues": {
+    "whitelist_rejection": {
+      "title": "iSolarCloud rejected the request (whitelist)",
+      "description": "iSolarCloud is rejecting API requests for **{plant}** because this client's IP address or your account is not in your API application's whitelist (E918/E919). Add them in the iSolarCloud Developer Portal (or disable the whitelist); the integration recovers automatically once accepted."
+    },
+    "rate_limited": {
+      "title": "iSolarCloud API rate limit reached",
+      "description": "iSolarCloud is rejecting requests for **{plant}** because the API call limit was reached (E998/E999). Increase the polling interval in the integration options to make fewer calls; it recovers when the quota resets."
+    }
+  },
   "entity": {
     "binary_sensor": {
       "device_fault": {

--- a/custom_components/sungrow/translations/en.json
+++ b/custom_components/sungrow/translations/en.json
@@ -70,6 +70,16 @@
       }
     }
   },
+  "issues": {
+    "whitelist_rejection": {
+      "title": "iSolarCloud rejected the request (whitelist)",
+      "description": "iSolarCloud is rejecting API requests for **{plant}** because this client's IP address or your account is not in your API application's whitelist (E918/E919). Add them in the iSolarCloud Developer Portal (or disable the whitelist); the integration recovers automatically once accepted."
+    },
+    "rate_limited": {
+      "title": "iSolarCloud API rate limit reached",
+      "description": "iSolarCloud is rejecting requests for **{plant}** because the API call limit was reached (E998/E999). Increase the polling interval in the integration options to make fewer calls; it recovers when the quota resets."
+    }
+  },
   "entity": {
     "binary_sensor": {
       "device_fault": {

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -6,6 +6,7 @@ from unittest.mock import AsyncMock, MagicMock
 import pytest
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryAuthFailed
+from homeassistant.helpers import issue_registry as ir
 from homeassistant.helpers.update_coordinator import UpdateFailed
 from pysolarcloud import AuthError, PySolarCloudException
 from pysolarcloud.plants import DeviceType
@@ -15,6 +16,7 @@ from custom_components.sungrow.const import (
     CONF_EXTRA_MEASURE_POINTS,
     CONF_SCAN_INTERVAL,
     DEVICE_REFRESH_INTERVAL,
+    DOMAIN,
 )
 from custom_components.sungrow.coordinator import SungrowPlantCoordinator, describe_api_error, is_auth_error
 
@@ -141,6 +143,35 @@ async def test_update_data_transient_error_raises_update_failed(hass: HomeAssist
     coordinator = SungrowPlantCoordinator(hass, _make_entry(), plants, "12345", "Test Plant")
     with pytest.raises(UpdateFailed):
         await coordinator._async_update_data()
+
+
+async def test_whitelist_error_raises_repair_and_recovery_clears_it(hass: HomeAssistant):
+    """A whitelist rejection raises a Repair; a later success clears it (#153)."""
+    plants = MagicMock()
+    plants.async_get_realtime_data = AsyncMock(side_effect=PySolarCloudException({"error": "E918"}))
+    coordinator = SungrowPlantCoordinator(hass, _make_entry(), plants, "12345", "Test Plant")
+    with pytest.raises(UpdateFailed):
+        await coordinator._async_update_data()
+
+    registry = ir.async_get(hass)
+    assert registry.async_get_issue(DOMAIN, "whitelist_rejection_12345") is not None
+
+    plants.async_get_realtime_data = AsyncMock(return_value=MOCK_REALTIME_DATA)
+    await coordinator._async_update_data()
+    assert registry.async_get_issue(DOMAIN, "whitelist_rejection_12345") is None
+
+
+async def test_rate_limit_error_raises_its_repair_only(hass: HomeAssistant):
+    """A rate-limit rejection raises the rate_limited Repair, not the whitelist one (#153)."""
+    plants = MagicMock()
+    plants.async_get_realtime_data = AsyncMock(side_effect=PySolarCloudException({"error": "E999"}))
+    coordinator = SungrowPlantCoordinator(hass, _make_entry(), plants, "12345", "Test Plant")
+    with pytest.raises(UpdateFailed):
+        await coordinator._async_update_data()
+
+    registry = ir.async_get(hass)
+    assert registry.async_get_issue(DOMAIN, "rate_limited_12345") is not None
+    assert registry.async_get_issue(DOMAIN, "whitelist_rejection_12345") is None
 
 
 async def test_transient_failure_keeps_last_good_within_grace(hass: HomeAssistant):


### PR DESCRIPTION
## What & why

Closes #153. Two real, actionable failures — **whitelist rejection (E918/E919)** and **API rate-limiting (E998/E999)** — were only surfaced as a log hint while the integration retried silently. Now they raise a **HA Repair card** so the user actually sees them and knows the fix.

## Behaviour
- On a poll failure with `E918`/`E919` → **"iSolarCloud rejected the request (whitelist)"** Repair (add IP/account in the Developer Portal).
- On `E998`/`E999` → **"iSolarCloud API rate limit reached"** Repair (increase the polling interval).
- **Cleared automatically** on the next successful poll (and each error type clears the other's card, so switching failure modes doesn't leave a stale card).
- Per-plant issue IDs, `WARNING` severity, `is_fixable=False`, with a learn-more link to the troubleshooting doc.
- **Reauth is intentionally not duplicated** — HA already opens a reauth flow when the coordinator raises `ConfigEntryAuthFailed`. (The #148 dispatch-without-battery footgun is also moot now that #150 hides those controls.)

## Tests
- Whitelist error → Repair created; recovery → cleared.
- Rate-limit error → only the `rate_limited` card (not whitelist).

Translations added under `issues.*` in `strings.json` + `en.json`. `ruff`, `ruff format`, `mypy`, full suite (**311 passed**) green locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)