### PR TITLE
feat: device connectivity, commissioning date & WLAN signal strength

### DIFF
--- a/custom_components/sungrow/binary_sensor.py
+++ b/custom_components/sungrow/binary_sensor.py
@@ -48,9 +48,31 @@ def fault_is_on(status: Any) -> bool | None:
     return None
 
 
+def connectivity_is_on(status: Any) -> bool | None:
+    """Map a device's ``dev_status`` to online (True) / offline (False), or None if unknown.
+
+    The device list reports ``dev_status`` as "1" (online) / "0" (offline); the int forms
+    are tolerated too.
+    """
+    if status is None:
+        return None
+    text = str(status)
+    if text == "1":
+        return True
+    if text == "0":
+        return False
+    return None
+
+
 def _build_binary_sensors(coordinator: SungrowPlantCoordinator) -> list[BinarySensorEntity]:
-    """Build a fault binary sensor for every device the coordinator currently reports."""
-    return [SungrowDeviceFaultBinarySensor(coordinator, device) for device in coordinator.devices if device.get("uuid")]
+    """Build the fault + connectivity binary sensors for every device the plant reports."""
+    sensors: list[BinarySensorEntity] = []
+    for device in coordinator.devices:
+        if not device.get("uuid"):
+            continue
+        sensors.append(SungrowDeviceFaultBinarySensor(coordinator, device))
+        sensors.append(SungrowDeviceConnectivityBinarySensor(coordinator, device))
+    return sensors
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry, async_add_entities: AddEntitiesCallback) -> None:
@@ -115,3 +137,42 @@ class SungrowDeviceFaultBinarySensor(CoordinatorEntity[SungrowPlantCoordinator],
         device = self._device() or {}
         status = device.get("dev_fault_status")
         return {"fault_status": str(getattr(status, "name", status)) if status is not None else None}
+
+
+class SungrowDeviceConnectivityBinarySensor(CoordinatorEntity[SungrowPlantCoordinator], BinarySensorEntity):
+    """A ``connectivity`` binary sensor reflecting whether a device is online."""
+
+    _attr_has_entity_name = True
+    _attr_device_class = BinarySensorDeviceClass.CONNECTIVITY
+    _attr_entity_category = EntityCategory.DIAGNOSTIC
+    _attr_translation_key = "device_connectivity"
+
+    def __init__(self, coordinator: SungrowPlantCoordinator, device: dict[str, Any]) -> None:
+        """Initialize the connectivity binary sensor for a device."""
+        super().__init__(coordinator)
+        self.device_uuid = str(device["uuid"])
+        self._attr_unique_id = f"{coordinator.plant_id}_{self.device_uuid}_online"
+        self._attr_device_info = build_device_info(device, coordinator.plant_id, fallback_name=coordinator.plant_name)
+
+    def _device(self) -> dict[str, Any] | None:
+        """Return this sensor's device from the coordinator's live list, if still present."""
+        return next((d for d in self.coordinator.devices if str(d.get("uuid")) == self.device_uuid), None)
+
+    @property
+    def available(self) -> bool:
+        """Unavailable only if the poll failed or the device dropped out of the plant."""
+        return super().available and self._device() is not None
+
+    @property
+    def is_on(self) -> bool | None:
+        """True when the device reports itself online (``dev_status``)."""
+        device = self._device()
+        if device is None:
+            return None
+        return connectivity_is_on(device.get("dev_status"))
+
+    @property
+    def extra_state_attributes(self) -> dict[str, Any]:
+        """Expose static device details (commissioning date) for the device page."""
+        device = self._device() or {}
+        return {"commissioning_date": device.get("grid_connection_date")}

--- a/custom_components/sungrow/const.py
+++ b/custom_components/sungrow/const.py
@@ -82,3 +82,11 @@ BATTERY_DEVICE_POINTS: dict[str, str] = {
 # The technical/health subset of the battery points shown as diagnostics; the rest
 # (SOC, charge/discharge energy) stay primary sensors for the dashboards.
 BATTERY_DIAGNOSTIC_CODES = frozenset({"battery_voltage", "battery_current", "battery_temperature", "battery_soh"})
+
+# Communication-module (WiNet-S) device-level measuring points surfaced as diagnostic
+# sensors (#149), requested per-device when device sensors are enabled. Both IDs are in
+# the measure-point catalog.
+COMM_MODULE_POINTS: dict[str, str] = {
+    "23014": "wlan_signal_strength",
+    "23001": "wireless_signal_strength",
+}

--- a/custom_components/sungrow/coordinator.py
+++ b/custom_components/sungrow/coordinator.py
@@ -18,6 +18,7 @@ from pysolarcloud.plants import DeviceType, Plants
 from .auth import AUTH_ERRORS
 from .const import (
     BATTERY_DEVICE_POINTS,
+    COMM_MODULE_POINTS,
     CONF_ENABLE_DEVICE_SENSORS,
     CONF_EXTRA_MEASURE_POINTS,
     CONF_SCAN_INTERVAL,
@@ -290,6 +291,9 @@ class SungrowPlantCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                 extra.update(INVERTER_DIAGNOSTIC_POINTS)
             if type_id in (DeviceType.BATTERY.value, DeviceType.ENERGY_STORAGE_SYSTEM.value):
                 extra.update(BATTERY_DEVICE_POINTS)
+            # Communication modules report WLAN/wireless signal strength (#149).
+            if type_id == DeviceType.COMMUNICATION_MODULE.value:
+                extra.update(COMM_MODULE_POINTS)
             try:
                 async with asyncio.timeout(self._poll_timeout):
                     result = await self.plants_service.async_get_device_realtime(

--- a/custom_components/sungrow/sensor.py
+++ b/custom_components/sungrow/sensor.py
@@ -14,6 +14,7 @@ from homeassistant.helpers.update_coordinator import CoordinatorEntity
 from . import build_device_info
 from .const import (
     BATTERY_DIAGNOSTIC_CODES,
+    COMM_MODULE_POINTS,
     CONF_GATEWAY,
     DEFAULT_CONSOLE_URL,
     DOMAIN,
@@ -37,7 +38,9 @@ _LOGGER = logging.getLogger(__name__)
 
 # Inverter + battery-health point codes get the DIAGNOSTIC entity category so they land
 # in the device page's Diagnostic section instead of cluttering the main sensors (#149/#154).
-_DIAGNOSTIC_CODES = frozenset(INVERTER_DIAGNOSTIC_POINTS.values()) | BATTERY_DIAGNOSTIC_CODES
+_DIAGNOSTIC_CODES = (
+    frozenset(INVERTER_DIAGNOSTIC_POINTS.values()) | BATTERY_DIAGNOSTIC_CODES | frozenset(COMM_MODULE_POINTS.values())
+)
 
 
 def infer_device_class(

--- a/custom_components/sungrow/strings.json
+++ b/custom_components/sungrow/strings.json
@@ -82,6 +82,9 @@
   },
   "entity": {
     "binary_sensor": {
+      "device_connectivity": {
+        "name": "Connectivity"
+      },
       "device_fault": {
         "name": "Fault"
       }

--- a/custom_components/sungrow/translations/en.json
+++ b/custom_components/sungrow/translations/en.json
@@ -82,6 +82,9 @@
   },
   "entity": {
     "binary_sensor": {
+      "device_connectivity": {
+        "name": "Connectivity"
+      },
       "device_fault": {
         "name": "Fault"
       }

--- a/tests/test_binary_sensor.py
+++ b/tests/test_binary_sensor.py
@@ -10,8 +10,10 @@ from pytest_homeassistant_custom_component.common import MockConfigEntry
 
 from custom_components.sungrow import SungrowData
 from custom_components.sungrow.binary_sensor import (
+    SungrowDeviceConnectivityBinarySensor,
     SungrowDeviceFaultBinarySensor,
     async_setup_entry,
+    connectivity_is_on,
     fault_is_on,
 )
 from custom_components.sungrow.const import DOMAIN
@@ -64,14 +66,14 @@ async def test_fault_binary_sensor_created_per_device(hass: HomeAssistant):
     added: list = []
     await async_setup_entry(hass, entry, lambda entities: added.extend(entities))
 
-    assert len(added) == 2
-    by_uuid = {e.device_uuid: e for e in added}
-    assert by_uuid["inv-1"]._attr_device_class == BinarySensorDeviceClass.PROBLEM
-    assert by_uuid["inv-1"]._attr_entity_category == EntityCategory.DIAGNOSTIC
-    assert by_uuid["inv-1"]._attr_unique_id == "12345_inv-1_fault"
-    assert by_uuid["inv-1"].is_on is False
-    assert by_uuid["meter-1"].is_on is True
-    assert by_uuid["meter-1"].extra_state_attributes["fault_status"] == "FAULT"
+    fault = {e.device_uuid: e for e in added if isinstance(e, SungrowDeviceFaultBinarySensor)}
+    assert set(fault) == {"inv-1", "meter-1"}  # the no-uuid device is skipped
+    assert fault["inv-1"]._attr_device_class == BinarySensorDeviceClass.PROBLEM
+    assert fault["inv-1"]._attr_entity_category == EntityCategory.DIAGNOSTIC
+    assert fault["inv-1"]._attr_unique_id == "12345_inv-1_fault"
+    assert fault["inv-1"].is_on is False
+    assert fault["meter-1"].is_on is True
+    assert fault["meter-1"].extra_state_attributes["fault_status"] == "FAULT"
 
 
 async def test_fault_binary_sensor_unavailable_when_device_gone(hass: HomeAssistant):
@@ -89,6 +91,35 @@ async def test_fault_binary_sensor_unavailable_when_device_gone(hass: HomeAssist
     data.coordinators[0].devices = []
     assert sensor.available is False
     assert sensor.is_on is None
+
+
+def test_connectivity_is_on_maps_dev_status():
+    """connectivity_is_on maps dev_status 1/0 to online/offline, else unknown."""
+    assert connectivity_is_on("1") is True
+    assert connectivity_is_on(1) is True
+    assert connectivity_is_on("0") is False
+    assert connectivity_is_on(0) is False
+    assert connectivity_is_on(None) is None
+    assert connectivity_is_on("x") is None
+
+
+async def test_connectivity_binary_sensor(hass: HomeAssistant):
+    """A CONNECTIVITY sensor per device reflects dev_status + exposes the commissioning date."""
+    entry = MockConfigEntry(domain=DOMAIN, data=MOCK_CONFIG_DATA.copy())
+    entry.add_to_hass(hass)
+    devices = [
+        {"uuid": "meter-1", "device_name": "Meter1", "dev_status": "0", "grid_connection_date": "2025-10-26 23:41:51"}
+    ]
+    _setup_entry_data(entry, devices)
+
+    added: list = []
+    await async_setup_entry(hass, entry, lambda entities: added.extend(entities))
+
+    conn = next(e for e in added if isinstance(e, SungrowDeviceConnectivityBinarySensor))
+    assert conn._attr_device_class == BinarySensorDeviceClass.CONNECTIVITY
+    assert conn._attr_unique_id == "12345_meter-1_online"
+    assert conn.is_on is False  # dev_status "0" -> offline
+    assert conn.extra_state_attributes["commissioning_date"] == "2025-10-26 23:41:51"
 
 
 def test_fault_binary_sensor_device_info_enriched():

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -531,6 +531,23 @@ async def test_device_data_ess_gets_both_inverter_and_battery_points(hass: HomeA
     assert "58604" in extra  # battery level
 
 
+async def test_device_data_requests_comm_module_points(hass: HomeAssistant):
+    """A communication module is asked for the WLAN/signal points (#149)."""
+    plants = MagicMock()
+    plants.async_get_realtime_data = AsyncMock(return_value=MOCK_REALTIME_DATA)
+    plants.async_get_device_realtime = AsyncMock(return_value={})
+    devices = [{"uuid": "comm-1", "device_type": DeviceType.COMMUNICATION_MODULE, "ps_key": "12345_22_247_1"}]
+    coordinator = SungrowPlantCoordinator(
+        hass, _make_entry({CONF_ENABLE_DEVICE_SENSORS: True}), plants, "12345", "Test Plant", devices
+    )
+
+    await coordinator._async_update_data()
+
+    extra = plants.async_get_device_realtime.await_args.kwargs["extra_measure_points"]
+    assert extra["23014"] == "wlan_signal_strength"
+    assert "29" not in extra  # not the inverter points
+
+
 async def test_device_data_dedupes_device_types(hass: HomeAssistant):
     """Two devices of the same type trigger a single per-type fetch."""
     plants = MagicMock()


### PR DESCRIPTION
## What & why

Rounds out the HA device pages to match what the iSolarCloud device page shows (online/offline, commissioning date, WLAN signal). Model / serial / manufacturer are already on the device card (from #162).

## Added
- **Connectivity binary sensor** per device (`device_class=connectivity`, diagnostic) reflecting `dev_status` (online/offline) — e.g. a `Meter1` that's offline now shows as such. It exposes the **commissioning date** (`grid_connection_date`) as a state attribute.
- **WLAN / Wireless signal-strength sensors** for the **communication module** (WiNet-S): points `23014` / `23001`, fetched from the comm-module device realtime just like the inverter (#149) and battery (#154) points, tagged diagnostic.

## How
- `connectivity_is_on()` maps `dev_status` `"1"`/`"0"` → online/offline (unknown otherwise), mirroring the fault binary sensor (#151).
- `COMM_MODULE_POINTS` requested for `COMMUNICATION_MODULE` devices in the coordinator; both IDs are already in the measure-point catalog, so they classify automatically.

## Notes
- Signal-strength points carry no unit in the API, so they surface as plain diagnostic measurements (no dBm device class).
- Gated behind the existing "device sensors" option (per-device fetch).

## Tests
- `connectivity_is_on` mapping; connectivity sensor created per device with the commissioning-date attribute + offline state.
- Comm-module device → WLAN points requested (not the inverter points).
- Updated the #151 fault test for the extra per-device sensor.

Rebased onto current `main` (with #153). `ruff`, `ruff format`, `mypy`, full suite (**314 passed**) green locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)