### PR TITLE
feat: back off the poll interval when rate-limited (#156)

### DIFF
--- a/custom_components/sungrow/coordinator.py
+++ b/custom_components/sungrow/coordinator.py
@@ -39,6 +39,10 @@ MAX_POLL_TIMEOUT = 60
 # staleness is harmless.
 AVAILABILITY_GRACE_SECONDS = 900
 
+# Ceiling for the backed-off poll interval: each rate-limited poll doubles the interval up
+# to this cap, and a successful poll restores the configured interval (#156).
+BACKOFF_MAX_INTERVAL = timedelta(hours=1)
+
 _LOGGER = logging.getLogger(__name__)
 
 
@@ -47,6 +51,10 @@ _LOGGER = logging.getLogger(__name__)
 # though pysolarcloud >=0.9.0 types E919 as an ``AuthError``. Guarded ahead of the
 # ``isinstance`` check in ``is_auth_error`` so that typing never overrides this.
 WHITELIST_ERRORS = frozenset({"E918", "E919"})
+
+# iSolarCloud quota/throttle codes (E998 monthly, E999 hourly). On these the coordinator
+# backs off its poll interval rather than hammering the API (#156).
+RATE_LIMIT_ERRORS = frozenset({"E998", "E999"})
 
 
 def is_auth_error(err: Exception) -> bool:
@@ -104,12 +112,17 @@ def describe_api_error(err: Exception) -> str | None:
     return None
 
 
+def is_rate_limit_error(err: Exception) -> bool:
+    """Return True if the error is an iSolarCloud quota/throttle rejection (E998/E999)."""
+    return isinstance(err, PySolarCloudException) and err.error in RATE_LIMIT_ERRORS
+
+
 # iSolarCloud error codes that warrant a user-facing Repair (#153). Each maps to a
 # translation key under ``issues.<key>``. Reauth is intentionally absent: HA already opens
 # a reauth flow when the coordinator raises ConfigEntryAuthFailed.
 _REPAIR_CODES: dict[str, frozenset[str]] = {
     "whitelist_rejection": WHITELIST_ERRORS,
-    "rate_limited": frozenset({"E998", "E999"}),
+    "rate_limited": RATE_LIMIT_ERRORS,
 }
 _REPAIR_LEARN_MORE = "https://github.com/KRoperUK/sungrow-hass/blob/main/docs/TROUBLESHOOTING.md"
 
@@ -138,6 +151,8 @@ class SungrowPlantCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         self.plants_service = plants_service
         self.plant_id = plant_id
         self.plant_name = plant_name
+        # The user-configured poll interval, restored after a rate-limit back-off (#156).
+        self._base_update_interval = timedelta(seconds=scan_seconds)
         # Cap each poll's requests at the scan interval, never longer than 60 s.
         self._poll_timeout: float = min(scan_seconds, MAX_POLL_TIMEOUT)
         # Monotonic timestamp of the last device-list refresh; None until first poll.
@@ -176,6 +191,8 @@ class SungrowPlantCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                 raise ConfigEntryAuthFailed(f"Authentication with iSolarCloud failed: {err}") from err
             # Surface actionable errors (whitelist, rate limit) as HA Repairs (#153).
             self._async_manage_repairs(err)
+            # Back off the poll interval while rate-limited so we stop hammering the API (#156).
+            self._adjust_poll_backoff(rate_limited=is_rate_limit_error(err))
             # Transient failure (a timeout arrives here as TimeoutError). Rather than flap
             # every entity to "unavailable" on a brief cloud hiccup, keep serving the
             # last-good data while a recent success is still within the grace window (#152);
@@ -187,6 +204,7 @@ class SungrowPlantCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             raise UpdateFailed(describe_api_error(err) or f"Error communicating with iSolarCloud API: {err}") from err
 
         self._async_manage_repairs(None)
+        self._adjust_poll_backoff(rate_limited=False)
         self._last_successful_update = self.hass.loop.time()
 
         # Refresh the device list so devices added to the plant after setup are
@@ -205,6 +223,27 @@ class SungrowPlantCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         if self._last_successful_update is None:
             return False
         return (self.hass.loop.time() - self._last_successful_update) < AVAILABILITY_GRACE_SECONDS
+
+    def _adjust_poll_backoff(self, *, rate_limited: bool) -> None:
+        """Back off the poll interval on rate-limit errors, restoring it on recovery (#156).
+
+        Each rate-limited poll doubles the interval up to ``BACKOFF_MAX_INTERVAL``, so the
+        integration stops hammering iSolarCloud once it hits the hourly/monthly quota; the
+        next successful poll restores the user's configured interval.
+        """
+        if rate_limited:
+            current = self.update_interval or self._base_update_interval
+            new = min(current * 2, BACKOFF_MAX_INTERVAL)
+            if new != self.update_interval:
+                self.update_interval = new
+                _LOGGER.warning("iSolarCloud rate-limited %s; backing off poll interval to %s", self.plant_name, new)
+        elif self.update_interval != self._base_update_interval:
+            self.update_interval = self._base_update_interval
+            _LOGGER.info(
+                "iSolarCloud recovered for %s; poll interval restored to %s",
+                self.plant_name,
+                self._base_update_interval,
+            )
 
     def _async_manage_repairs(self, err: Exception | None) -> None:
         """Raise or clear Repair issues for actionable iSolarCloud errors (#153).

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -18,7 +18,12 @@ from custom_components.sungrow.const import (
     DEVICE_REFRESH_INTERVAL,
     DOMAIN,
 )
-from custom_components.sungrow.coordinator import SungrowPlantCoordinator, describe_api_error, is_auth_error
+from custom_components.sungrow.coordinator import (
+    BACKOFF_MAX_INTERVAL,
+    SungrowPlantCoordinator,
+    describe_api_error,
+    is_auth_error,
+)
 
 from .conftest import MOCK_REALTIME_DATA
 
@@ -172,6 +177,50 @@ async def test_rate_limit_error_raises_its_repair_only(hass: HomeAssistant):
     registry = ir.async_get(hass)
     assert registry.async_get_issue(DOMAIN, "rate_limited_12345") is not None
     assert registry.async_get_issue(DOMAIN, "whitelist_rejection_12345") is None
+
+
+async def test_rate_limit_backs_off_and_recovers(hass: HomeAssistant):
+    """Rate-limit errors widen the poll interval; a success restores it (#156)."""
+    plants = MagicMock()
+    plants.async_get_realtime_data = AsyncMock(side_effect=PySolarCloudException.from_response({"result_code": "E999"}))
+    coordinator = SungrowPlantCoordinator(hass, _make_entry({CONF_SCAN_INTERVAL: 300}), plants, "12345", "Test Plant")
+    base = coordinator.update_interval
+
+    with pytest.raises(UpdateFailed):
+        await coordinator._async_update_data()
+    assert coordinator.update_interval == base * 2
+    with pytest.raises(UpdateFailed):
+        await coordinator._async_update_data()
+    assert coordinator.update_interval == base * 4
+
+    # Recover.
+    plants.async_get_realtime_data = AsyncMock(return_value=MOCK_REALTIME_DATA)
+    await coordinator._async_update_data()
+    assert coordinator.update_interval == base
+
+
+async def test_rate_limit_backoff_is_capped(hass: HomeAssistant):
+    """The backed-off interval never exceeds BACKOFF_MAX_INTERVAL (#156)."""
+    plants = MagicMock()
+    plants.async_get_realtime_data = AsyncMock(side_effect=PySolarCloudException.from_response({"result_code": "E998"}))
+    coordinator = SungrowPlantCoordinator(hass, _make_entry({CONF_SCAN_INTERVAL: 300}), plants, "12345", "Test Plant")
+    for _ in range(20):
+        with pytest.raises(UpdateFailed):
+            await coordinator._async_update_data()
+    assert coordinator.update_interval == BACKOFF_MAX_INTERVAL
+
+
+async def test_non_rate_limit_error_does_not_back_off(hass: HomeAssistant):
+    """A plain connection error leaves the poll interval untouched (#156)."""
+    plants = MagicMock()
+    plants.async_get_realtime_data = AsyncMock(side_effect=ConnectionError("blip"))
+    coordinator = SungrowPlantCoordinator(hass, _make_entry({CONF_SCAN_INTERVAL: 300}), plants, "12345", "Test Plant")
+    base = coordinator.update_interval
+
+    with pytest.raises(UpdateFailed):
+        await coordinator._async_update_data()
+
+    assert coordinator.update_interval == base
 
 
 async def test_transient_failure_keeps_last_good_within_grace(hass: HomeAssistant):


### PR DESCRIPTION
## What & why

Closes #156 (last 3.3.0 item). When iSolarCloud returns a quota rejection — **E998** (monthly) / **E999** (hourly) — the integration kept polling at the configured cadence, wasting calls against a quota that's already exhausted.

## Now
On a rate-limit error the coordinator **doubles its poll interval**, up to a **1-hour ceiling**, so it stops hammering the API; the next successful poll **restores the user's configured interval**. This complements the rate-limit **Repair card** from #153 (which tells the user *why*).

## Details
- `is_rate_limit_error()` detects E998/E999; `_adjust_poll_backoff()` widens/restores `update_interval`.
- Only rate-limit errors back off — ordinary transient failures (timeouts, connection errors) leave the interval untouched.
- `RATE_LIMIT_ERRORS` is now the single source shared by the back-off and the #153 Repair map.

## Tests
- Rate-limit → interval doubles each poll; recovery → restored.
- Back-off capped at `BACKOFF_MAX_INTERVAL` (1 h).
- Non-rate-limit error → interval unchanged.

`ruff`, `ruff format`, `mypy`, full suite (**317 passed**) green locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)