### PR TITLE
ci(fix): RC number now actually increments (rc1 → rc2 → rc3…)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -267,10 +267,9 @@ jobs:
           # If this version is already fully released, remove any leftover RC
           # pre-releases for it and skip creating a new RC build.
           if gh release view "v${VERSION}" >/dev/null 2>&1; then
-            VERSION_REGEX=$(printf '%s' "$VERSION" | sed 's/\./\\./g')
             echo "Full release v${VERSION} exists; deleting matching RC pre-releases."
-            gh release list --limit 1000 --json tagName,isPrerelease \
-              --jq ".[] | select(.isPrerelease and (.tagName | test(\"^dev-v${VERSION_REGEX}-rc[0-9]+$\"))) | .tagName" \
+            gh release list --limit 1000 --json tagName --jq '.[].tagName' \
+            | { grep -E "^dev-v${VERSION}-rc[0-9]+$" || true; } \
             | while read -r tag; do
                 echo "Deleting stale RC pre-release: ${tag}"
                 gh release delete "$tag" --yes --cleanup-tag
@@ -278,13 +277,13 @@ jobs:
             echo "skip=true" >> "$GITHUB_OUTPUT"
             exit 0
           fi
-          # Incrementing RC number for this version: highest existing dev-v<ver>-rc<n> + 1,
-          # so builds are rc1, rc2, rc3, ... It resets to rc1 when the next version bumps,
-          # since no dev-v<new>-rc* exist yet.
-          version_regex=$(printf '%s' "$VERSION" | sed 's/\./\\./g')
-          highest_rc=$(gh release list --limit 1000 --json tagName,isPrerelease \
-            --jq ".[] | select(.isPrerelease and (.tagName | test(\"^dev-v${version_regex}-rc[0-9]+$\"))) | .tagName" \
-            | sed -E 's/.*-rc([0-9]+)$/\1/' | sort -n | tail -1)
+          # Incrementing RC number for this version: highest existing dev-v<ver>-rcN + 1, so
+          # builds are rc1, rc2, rc3, ... (resets to rc1 when the next version bumps, since no
+          # dev-v<new>-rc* exist yet). A plain grep over the release tag names avoids jq's
+          # string-escaping pitfalls — an unescaped "\." inside a jq string is an invalid
+          # escape and made the previous jq `test()` fail, so it always computed rc1.
+          highest_rc=$(gh release list --limit 1000 --json tagName --jq '.[].tagName' \
+            | grep -E "^dev-v${VERSION}-rc[0-9]+$" | sed -E 's/^.*-rc//' | sort -n | tail -1 || true)
           RC_NUMBER=$(( ${highest_rc:-0} + 1 ))
           HEAD_BRANCH=main
           WORKFLOW_EVENT=push


### PR DESCRIPTION
## The bug
Every main build kept minting `dev-v3.3.0-**rc1**` (then "Release already exists, skipping").

**Root cause:** the RC counter used
```
--jq ".[] | select(.isPrerelease and (.tagName | test(\"^dev-v${version_regex}-rc[0-9]+$\")))"
```
where `version_regex` is `3\.3\.0`. Inside a **jq string**, `\.` is an **invalid escape** (jq wants `\\.`), so jq errored, the query returned nothing, `highest_rc` was empty, and `RC_NUMBER` fell back to `1` — forever. (The `-rc<run_id>` you saw in the checkout are orphan *tags* from the old scheme, not releases.)

## The fix
As you suggested — just find the `rc<D>` releases and add 1 — via a plain `grep` over the release tag names, which needs no jq regex escaping:
```
highest_rc=$(gh release list --limit 1000 --json tagName --jq '.[].tagName' \
  | grep -E "^dev-v${VERSION}-rc[0-9]+$" | sed -E 's/^.*-rc//' | sort -n | tail -1 || true)
RC_NUMBER=$(( ${highest_rc:-0} + 1 ))
```
The identical `\.` bug in the "full release exists → delete RCs" cleanup is fixed the same way.

## Validated locally (bash `-eo pipefail`, like CI)
- `dev-v3.3.0-rc1` exists → **RC_NUMBER=2** ✅
- no matching releases → **RC_NUMBER=1**, no error (the `|| true` keeps it pipefail-safe) ✅

## Note
There are leftover orphan `dev-v3.3.0-rc<run_id>` **tags** (no releases) from the old scheme — harmless to this logic (it only looks at releases), but I can add a one-off cleanup for those tags if you want them gone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)