### PR TITLE
ci: semver-compliant RC identifier (rc.N) so pre-releases order correctly

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -269,7 +269,7 @@ jobs:
           if gh release view "v${VERSION}" >/dev/null 2>&1; then
             echo "Full release v${VERSION} exists; deleting matching RC pre-releases."
             gh release list --limit 1000 --json tagName --jq '.[].tagName' \
-            | { grep -E "^dev-v${VERSION}-rc[0-9]+$" || true; } \
+            | { grep -E "^dev-v${VERSION}-rc\.?[0-9]+$" || true; } \
             | while read -r tag; do
                 echo "Deleting stale RC pre-release: ${tag}"
                 gh release delete "$tag" --yes --cleanup-tag
@@ -283,7 +283,7 @@ jobs:
           # string-escaping pitfalls — an unescaped "\." inside a jq string is an invalid
           # escape and made the previous jq `test()` fail, so it always computed rc1.
           highest_rc=$(gh release list --limit 1000 --json tagName --jq '.[].tagName' \
-            | grep -E "^dev-v${VERSION}-rc[0-9]+$" | sed -E 's/^.*-rc//' | sort -n | tail -1 || true)
+            | grep -E "^dev-v${VERSION}-rc\.[0-9]+$" | sed -E 's/^.*-rc\.//' | sort -n | tail -1 || true)
           RC_NUMBER=$(( ${highest_rc:-0} + 1 ))
           HEAD_BRANCH=main
           WORKFLOW_EVENT=push
@@ -303,8 +303,8 @@ jobs:
           # new feat/fix bumps the computed version (e.g. 3.2.1 -> 3.3.0), the earlier
           # dev-v<old>-rc* builds are superseded and will never ship — delete them now
           # rather than waiting for a real release or the 30-day sweep.
-          gh release list --limit 1000 --json tagName,isPrerelease \
-            --jq ".[] | select(.isPrerelease and (.tagName | test(\"^dev-v[0-9]+\\\\.[0-9]+\\\\.[0-9]+-rc[0-9]+$\"))) | .tagName" \
+          gh release list --limit 1000 --json tagName --jq '.[].tagName' \
+          | { grep -E '^dev-v[0-9]+\.[0-9]+\.[0-9]+-rc\.?[0-9]+$' || true; } \
           | while read -r tag; do
               tag_version="${tag#dev-v}"
               tag_version="${tag_version%-rc*}"

--- a/scripts/compute-dev-tag.sh
+++ b/scripts/compute-dev-tag.sh
@@ -6,13 +6,15 @@
 #   WORKFLOW_EVENT CI run's triggering event (push / pull_request)
 #   RC_NUMBER      incrementing RC counter for the current version (main push)
 #   RUN_ID         globally-unique run id (PR branch builds)
-# Prints the tag to stdout: dev-v<ver>-rc<n> (main push) or dev-v<ver>-<branch>-<id>.
+# Prints the tag to stdout: dev-v<ver>-rc.<n> (main push) or dev-v<ver>-<branch>-<id>.
+# The RC uses a *dotted* numeric identifier (rc.N) so the embedded version stays a valid
+# semver pre-release that orders numerically (3.3.0-rc.10 > 3.3.0-rc.9), per semver.org §11.
 set -euo pipefail
 
 sanitize() { printf '%s' "$1" | sed 's/[^a-zA-Z0-9._-]/-/g' | sed 's/-\{2,\}/-/g'; }
 
 if [ "${HEAD_BRANCH}" = "main" ] && [ "${WORKFLOW_EVENT}" = "push" ]; then
-    printf 'dev-v%s-rc%s\n' "${VERSION}" "${RC_NUMBER}"
+    printf 'dev-v%s-rc.%s\n' "${VERSION}" "${RC_NUMBER}"
 else
     printf 'dev-v%s-%s-%s\n' "${VERSION}" "$(sanitize "${HEAD_BRANCH}")" "${RUN_ID}"
 fi


### PR DESCRIPTION
## Semver audit result

**Your published versioning already abides by [semver.org](https://semver.org/)** — releases `0.2.3 → 3.2.0` are all valid `MAJOR.MINOR.PATCH`, enforced by release-please + conventional commits, and kept in sync across `manifest.json` / `pyproject.toml` / `version.txt` / the release-please manifest. Nothing to change there.

The one genuine issue was in the **RC dev-build pre-release identifier**.

## The problem
The RC tag was `dev-v3.3.0-rc**1**` (undotted). Per [semver §11](https://semver.org/#spec-item-11), a pre-release identifier containing letters (`rc1`) is compared **lexically** — so `3.3.0-rc10` sorts **before** `3.3.0-rc9`. Wrong once RC counts hit double digits.

## The fix
Use a **dotted numeric** identifier: `dev-v3.3.0-rc.N`. The embedded `3.3.0-rc.N` is a valid semver pre-release whose numeric part is compared numerically (`rc.10 > rc.9`).

- `compute-dev-tag.sh` now emits `dev-v<ver>-rc.<n>`.
- The RC count/cleanup/prune patterns are updated to `-rc\.` and, for cleanup, tolerate the **old undotted** tags (`-rc\.?`) so legacy builds still get swept.

## Validated locally
- `dev-v3.3.0-rc.5` produced; count grep orders numerically (`rc.1, rc.2, rc.10` → next **rc.11**).
- Official **semver.org regex**: `3.2.0`, `3.3.0-rc.1`, `3.3.0-rc.10` all valid.
- Ordering proof: dotted `rc.9 < rc.10` ✅; undotted `rc9 < rc10` ❌ (lexical).
- Cleanup grep matches both `rc.1` and legacy `rc1`, ignores real `v3.3.0`.
- YAML valid.

(Also deleted the last stale undotted `dev-v3.3.0-rc1` release/tag.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)