### PR TITLE
ci: redeploy docs on release so the header version refreshes

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -7,6 +7,13 @@ on:
             - docs/**
             - zensical.toml
             - .github/workflows/docs.yml
+            # Redeploy on a release so the version shown in the site header refreshes.
+            # release-please's "chore(main): release X.Y.Z" merge bumps these files, and
+            # any manual edit to them should also rebuild the docs.
+            - version.txt
+            - CHANGELOG.md
+            - custom_components/sungrow/manifest.json
+            - pyproject.toml
     workflow_dispatch: {}
 
 permissions:


### PR DESCRIPTION
## What

Widen the docs workflow's `push` path filter so a release triggers a fresh GitHub Pages deployment.

## Why

`docs.yml` only fired on changes to `docs/**`, `zensical.toml`, or itself. A `chore(main): release X.Y.Z` merge from release-please bumps `version.txt`, `CHANGELOG.md`, `manifest.json` and `pyproject.toml` — none of which were in the filter — so the site never rebuilt and the version shown in the header went stale after each release.

## Change

Added the release-bumped files to the `paths` filter:

- `version.txt`
- `CHANGELOG.md`
- `custom_components/sungrow/manifest.json`
- `pyproject.toml`

Now a release merge (or any manual edit to those files) redeploys the docs and refreshes the header version. No behavioural change to the build itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)