### PR TITLE
feat: expand per-device diagnostic sensors (inverter grid health, meter) (#179)

### DIFF
--- a/custom_components/sungrow/const.py
+++ b/custom_components/sungrow/const.py
@@ -65,6 +65,22 @@ INVERTER_DIAGNOSTIC_POINTS: dict[str, str] = {
     "8": "mppt2_current",
     "9": "mppt3_voltage",
     "10": "mppt3_current",
+    # Grid-side health (#179). Per-phase voltages/currents, power quality and DC-link
+    # voltage — all live-confirmed on real hardware except the AFCI/insulation extras,
+    # which the per-device builder simply skips when a model doesn't report them.
+    "3": "total_running_time",
+    "18": "phase_a_voltage",
+    "19": "phase_b_voltage",
+    "20": "phase_c_voltage",
+    "21": "phase_a_current",
+    "22": "phase_b_current",
+    "23": "phase_c_current",
+    "25": "reactive_power",
+    "26": "power_factor",
+    "43": "apparent_power",
+    "95": "bus_voltage",
+    "90": "negative_voltage_to_ground",
+    "120": "afci_fault_count",
 }
 
 # Battery/ESS device-level measuring points surfaced as sensors for hybrid users (#154),
@@ -91,6 +107,26 @@ BATTERY_DIAGNOSTIC_CODES = frozenset({"battery_voltage", "battery_current", "bat
 COMM_MODULE_POINTS: dict[str, str] = {
     "23014": "wlan_signal_strength",
     "23001": "wireless_signal_strength",
+}
+
+# Energy-meter (device_type 7) measuring points surfaced as sensors when device sensors
+# are enabled (#179). Instantaneous power/PF/frequency and per-phase V/I/energy that the
+# plant-level realtime aggregate doesn't carry. Model-dependent — a meter that only
+# reports energy simply returns nothing for the power/phase points and they're skipped.
+METER_DEVICE_POINTS: dict[str, str] = {
+    "8018": "meter_active_power",
+    "8022": "meter_reactive_power",
+    "8026": "meter_apparent_power",
+    "8014": "meter_power_factor",
+    "8064": "meter_frequency",
+    "8000": "meter_phase_a_voltage",
+    "8001": "meter_phase_b_voltage",
+    "8002": "meter_phase_c_voltage",
+    "8006": "meter_phase_a_current",
+    "8007": "meter_phase_b_current",
+    "8008": "meter_phase_c_current",
+    "8030": "meter_forward_active_energy",
+    "8031": "meter_reverse_active_energy",
 }
 
 # Physical-device modelling (#158): map a plant realtime point code to the device

--- a/custom_components/sungrow/coordinator.py
+++ b/custom_components/sungrow/coordinator.py
@@ -26,6 +26,7 @@ from .const import (
     DEVICE_REFRESH_INTERVAL,
     DOMAIN,
     INVERTER_DIAGNOSTIC_POINTS,
+    METER_DEVICE_POINTS,
 )
 
 # Upper bound on a single poll's cloud calls, so a hung request can neither stall
@@ -333,6 +334,9 @@ class SungrowPlantCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             # Communication modules report WLAN/wireless signal strength (#149).
             if type_id == DeviceType.COMMUNICATION_MODULE.value:
                 extra.update(COMM_MODULE_POINTS)
+            # Energy meters report instantaneous power / PF / frequency / per-phase (#179).
+            if type_id == DeviceType.METER.value:
+                extra.update(METER_DEVICE_POINTS)
             try:
                 async with asyncio.timeout(self._poll_timeout):
                     result = await self.plants_service.async_get_device_realtime(

--- a/docs/SENSORS.md
+++ b/docs/SENSORS.md
@@ -104,8 +104,9 @@ Alongside the plant sensors, the integration adds **diagnostic** entities that d
 
 **Per-device diagnostic sensors** — surfaced when **Create per-device sensors** is enabled (Configure → options), polled per device type from the documented measure-point catalog:
 
-- **Inverter:** operating status, total DC power, internal temperature, grid frequency, array insulation resistance, and MPPT 1–3 voltage/current.
+- **Inverter:** operating status, total DC power, internal temperature, grid frequency, array insulation resistance, MPPT 1–3 voltage/current, and grid-side health — **per-phase voltage & current** (A/B/C), reactive & apparent power, power factor, DC bus voltage, on-grid running time, negative-voltage-to-ground and AFCI fault count. (Points a given model doesn't report are simply skipped.)
 - **Battery / ESS** (hybrid systems): battery level (SOC), state of health, voltage, current, temperature, and total charge/discharge energy. Health-oriented points (voltage, current, temperature, SOH) are marked *Diagnostic*; SOC and charge/discharge energy stay primary sensors for dashboards.
+- **Energy meter:** instantaneous active / reactive / apparent power, power factor, grid frequency, per-phase voltage & current, and forward/reverse (import/export) active energy. (A meter that only reports energy — e.g. the SGSmartMeter — surfaces just those.)
 - **Communication module (WiNet-S):** WLAN signal strength and wireless signal strength.
 
 ## Dispatch / control entities

--- a/tests/test_const.py
+++ b/tests/test_const.py
@@ -41,3 +41,32 @@ def test_config_key_names():
     assert CONF_APP_ID == "app_id"
     assert CONF_GATEWAY == "gateway"
     assert CONF_REDIRECT_URI == "redirect_uri"
+
+
+def test_inverter_diagnostic_points_include_grid_health():
+    """The inverter diagnostic map carries the #179 grid-side health points."""
+    from custom_components.sungrow.const import INVERTER_DIAGNOSTIC_POINTS as P
+
+    expected = {
+        "3": "total_running_time",
+        "18": "phase_a_voltage",
+        "21": "phase_a_current",
+        "25": "reactive_power",
+        "26": "power_factor",
+        "95": "bus_voltage",
+    }
+    for pid, code in expected.items():
+        assert P[pid] == code
+    # The pre-existing MPPT/operating-status points remain.
+    assert P["29"] == "operating_status"
+
+
+def test_meter_device_points_present():
+    """The meter map (#179) carries instantaneous power/PF/frequency + per-phase."""
+    from custom_components.sungrow.const import METER_DEVICE_POINTS as M
+
+    assert M["8018"] == "meter_active_power"
+    assert M["8014"] == "meter_power_factor"
+    assert M["8064"] == "meter_frequency"
+    assert M["8000"] == "meter_phase_a_voltage"
+    assert M["8006"] == "meter_phase_a_current"

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -527,6 +527,10 @@ async def test_device_data_requests_inverter_diagnostic_points(hass: HomeAssista
     assert extra["29"] == "operating_status"
     assert extra["14"] == "total_dc_power"
     assert "5" in extra  # MPPT1 voltage
+    # Grid-side health points added in #179.
+    assert extra["18"] == "phase_a_voltage"
+    assert extra["26"] == "power_factor"
+    assert extra["95"] == "bus_voltage"
 
 
 async def test_device_data_diagnostic_points_only_for_inverter(hass: HomeAssistant):
@@ -561,6 +565,25 @@ async def test_device_data_requests_battery_points_for_battery_device(hass: Home
     assert extra["58604"] == "battery_level"
     assert extra["58606"] == "battery_total_charge_energy"
     assert "29" not in extra  # not the inverter operating-status point
+
+
+async def test_device_data_requests_meter_points_for_meter_device(hass: HomeAssistant):
+    """A meter device is asked for the meter points, not the inverter/battery ones (#179)."""
+    plants = MagicMock()
+    plants.async_get_realtime_data = AsyncMock(return_value=MOCK_REALTIME_DATA)
+    plants.async_get_device_realtime = AsyncMock(return_value={})
+    devices = [{"uuid": "meter-1", "device_type": DeviceType.METER, "ps_key": "12345_7_1_1"}]
+    coordinator = SungrowPlantCoordinator(
+        hass, _make_entry({CONF_ENABLE_DEVICE_SENSORS: True}), plants, "12345", "Test Plant", devices
+    )
+
+    await coordinator._async_update_data()
+
+    extra = plants.async_get_device_realtime.await_args.kwargs["extra_measure_points"]
+    assert extra["8018"] == "meter_active_power"
+    assert extra["8064"] == "meter_frequency"
+    assert "29" not in extra  # not the inverter operating-status point
+    assert "58604" not in extra  # not the battery points
 
 
 async def test_device_data_ess_gets_both_inverter_and_battery_points(hass: HomeAssistant):


### PR DESCRIPTION
Closes #179. **Stacked on #158** (#184) — review/merge that first; base retargets to `main` on merge.

## What
Surfaces far more of the per-device diagnostic data iSolarCloud already returns. The inverter live-returns 26 points; we previously mapped 11.

## Inverter (`INVERTER_DIAGNOSTIC_POINTS`)
Added grid-side health: per-phase voltage/current `18–23`, reactive `25` / apparent `43` power, power factor `26`, DC bus voltage `95`, on-grid running time `3`, negative-voltage-to-ground `90`, AFCI fault count `120`. Points `3`/`18–23`/`25`/`26`/`43`/`95` are **live-confirmed** on a real SG3.6RS; `90`/`120` are doc-based and skipped when a model doesn't report them.

## Meter (new `METER_DEVICE_POINTS`)
Active/reactive/apparent power, power factor, frequency, per-phase V/I, and forward/reverse (import/export) energy — requested for `METER` devices in the coordinator's per-device fetch. Model-dependent: a meter that only reports energy surfaces just those (builder skips empty points).

## Notes
- All of this is **opt-in behind “Create per-device sensors”** and adds no new API calls beyond that path.
- Classification verified: phase V/I → voltage/current, reactive → reactive_power, PF → power_factor, bus → voltage, running time → duration, meter power/frequency → power/frequency.
- Lands on the correct device automatically thanks to #158.

## Tests
- Coordinator requests the new inverter points and the meter points for a `METER` device (and not cross-contaminating inverter/battery points).
- `const` map membership. Full suite: 327 passed; ruff + format + mypy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)