### PR TITLE
feat: add reactive-power / power-factor dispatch controls (#181)

### DIFF
--- a/custom_components/sungrow/icons.json
+++ b/custom_components/sungrow/icons.json
@@ -24,6 +24,12 @@
       },
       "active_power_limit_ratio": {
         "default": "mdi:speedometer"
+      },
+      "q_t": {
+        "default": "mdi:sine-wave"
+      },
+      "pf": {
+        "default": "mdi:angle-acute"
       }
     },
     "select": {
@@ -41,6 +47,9 @@
       },
       "battery_first": {
         "default": "mdi:battery-heart-variant"
+      },
+      "reactive_power_regulation_mode": {
+        "default": "mdi:sine-wave"
       }
     }
   }

--- a/custom_components/sungrow/manifest.json
+++ b/custom_components/sungrow/manifest.json
@@ -17,7 +17,7 @@
   ],
   "quality_scale": "platinum",
   "requirements": [
-    "sungrow-isolarcloud==0.9.1"
+    "sungrow-isolarcloud==0.10.0"
   ],
   "version": "3.3.0"
 }

--- a/custom_components/sungrow/number.py
+++ b/custom_components/sungrow/number.py
@@ -143,6 +143,27 @@ DISPATCH_NUMBERS: dict[str, dict[str, Any]] = {
         "mode": NumberMode.SLIDER,
         "entity_category": EntityCategory.CONFIG,
     },
+    # Reactive power ratio Q(t) as a signed percentage (API range -600..600 = -60..60%).
+    # Only takes effect when the Reactive Power Mode select is set to Q(t). Applies to
+    # PV and hybrid inverters, so not battery-gated.
+    "q_t": {
+        "native_unit_of_measurement": "%",
+        "native_min_value": -60,
+        "native_max_value": 60,
+        "native_step": 1,
+        "mode": NumberMode.SLIDER,
+        "entity_category": EntityCategory.CONFIG,
+    },
+    # Power factor setpoint (API range -1000..1000 = -1..1). Only takes effect when the
+    # Reactive Power Mode select is set to PF.
+    "pf": {
+        "device_class": NumberDeviceClass.POWER_FACTOR,
+        "native_min_value": -1,
+        "native_max_value": 1,
+        "native_step": 0.01,
+        "mode": NumberMode.BOX,
+        "entity_category": EntityCategory.CONFIG,
+    },
 }
 
 # Watt-valued power parameters whose slider maximum is sized to the device's rating.

--- a/custom_components/sungrow/select.py
+++ b/custom_components/sungrow/select.py
@@ -61,6 +61,18 @@ DISPATCH_SELECTS: dict[str, dict[str, Any]] = {
         "entity_category": EntityCategory.CONFIG,
         "battery_only": True,
     },
+    # Reactive power regulation mode (Appendix 10, param 10009). Gates the Q(t) and Power
+    # Factor numbers. Applies to PV and hybrid inverters, so not battery-gated.
+    "reactive_power_regulation_mode": {
+        "options_map": {
+            "Off": "85",
+            "Power Factor": "161",
+            "Reactive Power Ratio Q(t)": "162",
+            "Q(P) Curve": "163",
+            "Q(U) Curve": "164",
+        },
+        "entity_category": EntityCategory.CONFIG,
+    },
 }
 
 

--- a/custom_components/sungrow/strings.json
+++ b/custom_components/sungrow/strings.json
@@ -113,6 +113,12 @@
       },
       "active_power_limit_ratio": {
         "name": "Active Power Limit"
+      },
+      "q_t": {
+        "name": "Reactive Power Ratio Q(t)"
+      },
+      "pf": {
+        "name": "Power Factor"
       }
     },
     "select": {
@@ -130,6 +136,9 @@
       },
       "battery_first": {
         "name": "Battery First Mode"
+      },
+      "reactive_power_regulation_mode": {
+        "name": "Reactive Power Mode"
       }
     }
   },

--- a/custom_components/sungrow/translations/en.json
+++ b/custom_components/sungrow/translations/en.json
@@ -113,6 +113,12 @@
       },
       "active_power_limit_ratio": {
         "name": "Active Power Limit"
+      },
+      "q_t": {
+        "name": "Reactive Power Ratio Q(t)"
+      },
+      "pf": {
+        "name": "Power Factor"
       }
     },
     "select": {
@@ -130,6 +136,9 @@
       },
       "battery_first": {
         "name": "Battery First Mode"
+      },
+      "reactive_power_regulation_mode": {
+        "name": "Reactive Power Mode"
       }
     }
   },

--- a/docs/SENSORS.md
+++ b/docs/SENSORS.md
@@ -140,8 +140,13 @@ If your inverter / ESS supports parameter configuration, the integration also cr
 | Export Limit (%) | `feed_in_limitation_ratio` | 0–100 % | — |
 | Active Power Limiting | `limited_power_switch` | Disable / Enable | — |
 | Active Power Limit | `active_power_limit_ratio` | 0–100 % | — |
+| Reactive Power Mode | `reactive_power_regulation_mode` | Off / Power Factor / Q(t) / Q(P) / Q(U) | — |
+| Reactive Power Ratio Q(t) | `q_t` | −60–60 % | — |
+| Power Factor | `pf` | −1 to 1 | — |
 
 The power sliders (charge/discharge power, export limit power) are sized to the device's **rated power**, parsed from its model code (e.g. `SG3.6RS` → 3.6 kW), falling back to 5000 W when the rating can't be derived.
+
+The **reactive-power** controls work together: set **Reactive Power Mode** first, then the relevant value — **Power Factor** only takes effect in *Power Factor* mode, and **Reactive Power Ratio Q(t)** only in *Q(t)* mode. These are grid-quality controls and are available on PV-only plants too (they aren't battery-gated).
 
 When you set **Charge/Discharge Command** to *Charge* or *Discharge*, the integration automatically starts sending the External EMS heartbeat (param `10017`) every 60 seconds so the inverter stays in dispatch mode. Selecting **Stop** turns the heartbeat off. If you remove the dispatch entities, the heartbeat is also stopped.
 

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -10,4 +10,4 @@ ruff==0.15.20
 mypy==2.1.0
 
 # Component dependencies
-sungrow-isolarcloud==0.9.1
+sungrow-isolarcloud==0.10.0

--- a/tests/test_dispatch.py
+++ b/tests/test_dispatch.py
@@ -195,9 +195,11 @@ GRID_SIDE_NUMBERS = {
     "feed_in_limitation_value",
     "feed_in_limitation_ratio",
     "active_power_limit_ratio",
+    "q_t",
+    "pf",
 }
 BATTERY_ONLY_SELECTS = {"charge_discharge_command", "forced_charging", "battery_first"}
-GRID_SIDE_SELECTS = {"feed_in_limitation", "limited_power_switch"}
+GRID_SIDE_SELECTS = {"feed_in_limitation", "limited_power_switch", "reactive_power_regulation_mode"}
 
 
 def test_battery_only_sets_partition_dispatch_dicts():
@@ -671,6 +673,16 @@ async def test_param_write_encodings(hass: HomeAssistant):
     await by_param["forced_charging_target_soc_2"].async_set_native_value(80)
     data.control.async_update_parameters.assert_awaited_with("ess-1", {"forced_charging_target_soc_2": "80"})
 
+    # Reactive power ratio Q(t) is tenths of a percent, signed (x10) (#181).
+    await by_param["q_t"].async_set_native_value(30)
+    data.control.async_update_parameters.assert_awaited_with("ess-1", {"q_t": "300"})
+    await by_param["q_t"].async_set_native_value(-60)
+    data.control.async_update_parameters.assert_awaited_with("ess-1", {"q_t": "-600"})
+
+    # Power factor is thousandths, signed (x1000) (#181).
+    await by_param["pf"].async_set_native_value(0.9)
+    data.control.async_update_parameters.assert_awaited_with("ess-1", {"pf": "900"})
+
 
 async def test_new_selects_write_verified_codes(hass: HomeAssistant):
     """Feed-in / battery-first selects write the device-verified enable/disable codes."""
@@ -690,6 +702,12 @@ async def test_new_selects_write_verified_codes(hass: HomeAssistant):
     await by_param["battery_first"].async_select_option("Disable")
     data.control.async_update_parameters.assert_awaited_with("ess-1", {"battery_first": "85"})
     assert by_param["battery_first"]._attr_entity_category == EntityCategory.CONFIG
+
+    # Reactive power mode writes the Appendix 10 enum code (#181).
+    await by_param["reactive_power_regulation_mode"].async_select_option("Reactive Power Ratio Q(t)")
+    data.control.async_update_parameters.assert_awaited_with("ess-1", {"reactive_power_regulation_mode": "162"})
+    await by_param["reactive_power_regulation_mode"].async_select_option("Off")
+    data.control.async_update_parameters.assert_awaited_with("ess-1", {"reactive_power_regulation_mode": "85"})
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Partially closes #181 (reactive/PF half). Requires **pysolarcloud 0.10.0** (KRoperUK/pysolarcloud#28), pinned here.

## What
Now that pysolarcloud ships `PARAMETER_SPECS` for the reactive params, expose them as HA dispatch entities on the inverter/ESS device:

| Entity | Param | Range → encoding |
|---|---|---|
| **Reactive Power Mode** (select) | `reactive_power_regulation_mode` (10009) | Off / PF / Q(t) / Q(P) / Q(U) → 85/161/162/163/164 |
| **Reactive Power Ratio Q(t)** (number) | `q_t` (10010) | −60…60 % → ×10 |
| **Power Factor** (number) | `pf` (10036) | −1…1 → ×1000 |

- **Not battery-gated** — grid-quality controls that apply to PV-only and hybrid inverters alike.
- The **mode gates the values**: Power Factor only takes effect in PF mode, Q(t) only in Q(t) mode (documented; entities are independent like the existing feed-in pair).
- Adds `icons.json` + `strings.json`/`translations` entries and bumps the `sungrow-isolarcloud` pin to **0.10.0**.

## Deliberately excluded
ESS max charge/discharge power (`10091`/`10092`) — their raw scale depends on an E900-gated per-device limit, so they stay out of pysolarcloud's `config_parameters` and aren't exposed here (see #181 discussion).

## Tests
- Q(t) encodes ×10 signed (30→`300`, −60→`-600`); PF ×1000 (0.9→`900`); mode select writes `162`/`85`.
- The battery-vs-grid-side partition guard now classifies all three as grid-side; the "hidden on PV-only" tests confirm they remain on battery-less plants.
- Full suite: **332 passed**; ruff + format + mypy clean; strings/icons in sync.

🤖 Generated with [Claude Code](https://claude.com/claude-code)