### PR TITLE
feat: time-limited auto-revert for forced dispatch (#157)

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ Custom component that integrates Sungrow inverters via the iSolarCloud API into 
 - **Plant health & tariffs** — plant-wide alarm/fault counts, nameplate power, and your configured import/export electricity prices, surfaced as sensors on the plant device.
 - **Custom measure points** — request additional iSolarCloud point IDs (e.g. battery charge/discharge power or EV charger values) via the options flow.
 - **Dispatch / control entities** — number and select entities for charge/discharge command, power, SOC limits, forced charging, and export/active-power limiting, with automatic EMS heartbeat when dispatching. Battery-only controls are hidden on PV-only plants so they can't be triggered on a system without a battery.
+- **Safer dispatch (auto-revert)** — set a **Forced Dispatch Duration** and a forced charge/discharge automatically reverts to *Stop* after that long (surviving restarts), so a command can't silently persist and curtail your solar. Leave it at 0 to keep the legacy always-on behaviour.
 - **Resilient polling** — rides out brief network/API hiccups instead of flapping every entity to *unavailable*, and automatically backs off the polling interval when iSolarCloud rate-limits the account.
 - **Guided repairs** — surfaces iSolarCloud whitelist (E918/E919) and rate-limit (E998/E999) rejections as actionable Home Assistant **Repairs** with fix instructions.
 - **Config Flow** — set up entirely through the Home Assistant UI.

--- a/custom_components/sungrow/coordinator.py
+++ b/custom_components/sungrow/coordinator.py
@@ -183,6 +183,11 @@ class SungrowPlantCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         # once at setup; defaults True (fail-open) so a failed check never hides a
         # real battery user's controls.
         self.has_battery: bool = True
+        # How long (minutes) a forced Charge/Discharge command stays active before the
+        # command select auto-reverts it to Stop, so a forced command can't silently
+        # persist and curtail PV (#157/#148). 0 disables auto-revert (legacy behaviour).
+        # Owned by the "Forced Dispatch Duration" number; read by the command select.
+        self.forced_dispatch_duration_minutes: float = 0
 
     async def _async_update_data(self) -> dict[str, Any]:
         """Fetch data from the API for this plant."""

--- a/custom_components/sungrow/icons.json
+++ b/custom_components/sungrow/icons.json
@@ -30,6 +30,9 @@
       },
       "pf": {
         "default": "mdi:angle-acute"
+      },
+      "forced_dispatch_duration": {
+        "default": "mdi:timer-sand"
       }
     },
     "select": {

--- a/custom_components/sungrow/number.py
+++ b/custom_components/sungrow/number.py
@@ -197,6 +197,10 @@ def _build_numbers(coordinator: SungrowPlantCoordinator, control: Control) -> li
         if param in _RATED_POWER_PARAMS and max_power != meta["native_max_value"]:
             meta = {**meta, "native_max_value": max_power}
         entities.append(SungrowDispatchNumber(coordinator, control, target, param, meta))
+    # The forced-dispatch auto-revert timeout only makes sense alongside the battery
+    # charge/discharge controls, so gate it on the same has_battery check (#157/#148).
+    if coordinator.has_battery:
+        entities.append(SungrowForcedDispatchDurationNumber(coordinator, target))
     return entities
 
 
@@ -288,3 +292,49 @@ class SungrowDispatchNumber(CoordinatorEntity[SungrowPlantCoordinator], RestoreN
         # command select (Charge/Discharge start it, Stop stops it), so writing power
         # — even 0 — never arms or re-arms dispatch here (see #112).
         self._attr_native_value = value
+
+
+# Default duration (minutes) for a forced Charge/Discharge before auto-revert (#157).
+DEFAULT_FORCED_DISPATCH_DURATION = 0  # 0 = auto-revert disabled (legacy behaviour)
+
+
+class SungrowForcedDispatchDurationNumber(CoordinatorEntity[SungrowPlantCoordinator], RestoreNumber):
+    """Local number controlling the forced-dispatch auto-revert timeout (#157).
+
+    Unlike the other dispatch numbers this writes *nothing* to the inverter — it only
+    records, on the coordinator, how long a forced Charge/Discharge command may stay
+    active before the command select reverts it to Stop. 0 disables auto-revert.
+    """
+
+    _attr_has_entity_name = True
+    _attr_translation_key = "forced_dispatch_duration"
+    _attr_native_min_value = 0
+    _attr_native_max_value = 1440  # 24 h
+    _attr_native_step = 5
+    _attr_native_unit_of_measurement = "min"
+    _attr_mode = NumberMode.BOX
+    _attr_entity_category = EntityCategory.CONFIG
+
+    def __init__(self, coordinator: SungrowPlantCoordinator, device: dict[str, Any]) -> None:
+        """Initialize the forced-dispatch duration number."""
+        super().__init__(coordinator)
+        self.device_uuid = str(device["uuid"])
+        # Identifies the entity (like the dispatch numbers) though it writes no param.
+        self.param = "forced_dispatch_duration"
+        self._attr_unique_id = f"{coordinator.plant_id}_{self.device_uuid}_forced_dispatch_duration"
+        self._attr_device_info = build_device_info(device, coordinator.plant_id, fallback_name=coordinator.plant_name)
+        self._attr_native_value = DEFAULT_FORCED_DISPATCH_DURATION
+        coordinator.forced_dispatch_duration_minutes = DEFAULT_FORCED_DISPATCH_DURATION
+
+    async def async_added_to_hass(self) -> None:
+        """Restore the configured duration and publish it to the coordinator."""
+        await super().async_added_to_hass()
+        last = await self.async_get_last_number_data()
+        if last is not None and last.native_value is not None:
+            self._attr_native_value = last.native_value
+        self.coordinator.forced_dispatch_duration_minutes = self._attr_native_value or 0
+
+    async def async_set_native_value(self, value: float) -> None:
+        """Store the new duration locally and publish it to the coordinator."""
+        self._attr_native_value = value
+        self.coordinator.forced_dispatch_duration_minutes = value

--- a/custom_components/sungrow/select.py
+++ b/custom_components/sungrow/select.py
@@ -3,14 +3,16 @@
 from __future__ import annotations
 
 import logging
+import time
 from typing import Any
 
 from homeassistant.components.select import SelectEntity
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import EntityCategory
-from homeassistant.core import HomeAssistant, callback
+from homeassistant.core import CALLBACK_TYPE, HomeAssistant, callback
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.event import async_call_later
 from homeassistant.helpers.restore_state import RestoreEntity
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 from pysolarcloud import PySolarCloudException
@@ -155,6 +157,10 @@ class SungrowDispatchSelect(CoordinatorEntity[SungrowPlantCoordinator], RestoreE
         self._attr_device_info = build_device_info(device, coordinator.plant_id, fallback_name=coordinator.plant_name)
         self._attr_options = list(self.options_map.keys())
         self._attr_entity_category = meta.get("entity_category")
+        # Auto-revert timer for forced Charge/Discharge (#157). Only the command select
+        # uses these; other selects leave them unset.
+        self._revert_cancel: CALLBACK_TYPE | None = None
+        self._revert_deadline: float | None = None
 
     async def async_added_to_hass(self) -> None:
         """Restore the last selected option across restarts.
@@ -175,6 +181,13 @@ class SungrowDispatchSelect(CoordinatorEntity[SungrowPlantCoordinator], RestoreE
             if self.param == "charge_discharge_command" and last.state in {"Charge", "Discharge"}:
                 entry = self.coordinator.config_entry
                 assert entry is not None
+                # Restore the auto-revert deadline first (#157): if the forced command
+                # already timed out while HA was down, revert to Stop instead of resuming
+                # dispatch; otherwise resume the heartbeat and re-arm for the time left.
+                deadline = self._restore_revert_deadline(last.attributes.get("revert_at"))
+                if deadline is not None and deadline <= time.time():
+                    await self._do_revert()
+                    return
                 await async_start_heartbeat(
                     self.hass,
                     entry,
@@ -182,6 +195,23 @@ class SungrowDispatchSelect(CoordinatorEntity[SungrowPlantCoordinator], RestoreE
                     self.device_uuid,
                     interval=60,
                 )
+                if deadline is not None:
+                    self._arm_revert(deadline=deadline)
+
+    async def async_will_remove_from_hass(self) -> None:
+        """Cancel the auto-revert timer when the command select is removed."""
+        self._cancel_revert()
+        await super().async_will_remove_from_hass()
+
+    @staticmethod
+    def _restore_revert_deadline(raw: Any) -> float | None:
+        """Parse a restored ``revert_at`` epoch attribute, or None if absent/invalid."""
+        if raw is None:
+            return None
+        try:
+            return float(raw)
+        except (TypeError, ValueError):
+            return None
 
     async def async_select_option(self, option: str) -> None:
         """Update the dispatch parameter on the inverter."""
@@ -209,10 +239,74 @@ class SungrowDispatchSelect(CoordinatorEntity[SungrowPlantCoordinator], RestoreE
                 self.device_uuid,
                 interval=60,
             )
+            # Arm the auto-revert so this forced command can't silently persist (#157).
+            self._arm_revert()
         elif self.param == "charge_discharge_command" and option == "Stop":
             await async_stop_heartbeat(self.hass, entry, self.coordinator.plant_id)
+            self._cancel_revert()
 
     # NOTE: the heartbeat is deliberately NOT stopped from async_will_remove_from_hass.
     # All ~13 dispatch entities share one heartbeat keyed by plant_id, so stopping it
     # on any single entity's removal (e.g. disabling "SOC Upper Limit") would kill
     # dispatch for the whole plant. Teardown is handled once by async_unload_entry (#112).
+
+    @property
+    def extra_state_attributes(self) -> dict[str, Any] | None:
+        """Expose the pending auto-revert deadline so it survives a restart (#157)."""
+        if self.param == "charge_discharge_command" and self._revert_deadline is not None:
+            return {"revert_at": self._revert_deadline}
+        return None
+
+    def _revert_seconds(self) -> float:
+        """Configured auto-revert timeout in seconds (0 = disabled)."""
+        try:
+            minutes = float(getattr(self.coordinator, "forced_dispatch_duration_minutes", 0) or 0)
+        except (TypeError, ValueError):
+            return 0.0
+        return minutes * 60
+
+    def _arm_revert(self, *, deadline: float | None = None) -> None:
+        """Schedule the revert-to-Stop, replacing any pending one.
+
+        ``deadline`` (epoch seconds) is supplied when restoring across a restart;
+        otherwise it's computed from the configured duration. A duration of 0 disables
+        auto-revert and leaves nothing scheduled.
+        """
+        self._cancel_revert()
+        if deadline is None:
+            seconds = self._revert_seconds()
+            if seconds <= 0:
+                return
+            deadline = time.time() + seconds
+        self._revert_deadline = deadline
+        delay = max(0.0, deadline - time.time())
+        self._revert_cancel = async_call_later(self.hass, delay, self._handle_revert)
+
+    @callback
+    def _handle_revert(self, _now: Any) -> None:
+        """async_call_later fired — run the async revert."""
+        self._revert_cancel = None
+        self.hass.async_create_task(self._do_revert())
+
+    async def _do_revert(self) -> None:
+        """Revert a forced Charge/Discharge to Stop and stop the heartbeat (#157)."""
+        _LOGGER.info("Forced-dispatch timeout for %s: reverting to Stop", self.device_uuid)
+        stop_option = "Stop"
+        try:
+            await self.control.async_update_parameters(self.device_uuid, {self.param: self.options_map[stop_option]})
+        except PySolarCloudException as err:
+            _LOGGER.warning("Auto-revert to Stop failed for %s: %s", self.device_uuid, err)
+        entry = self.coordinator.config_entry
+        if entry is not None:
+            await async_stop_heartbeat(self.hass, entry, self.coordinator.plant_id)
+        self._revert_deadline = None
+        self._revert_cancel = None
+        self._attr_current_option = stop_option
+        self.async_write_ha_state()
+
+    def _cancel_revert(self) -> None:
+        """Cancel any pending auto-revert."""
+        self._revert_deadline = None
+        if self._revert_cancel is not None:
+            self._revert_cancel()
+            self._revert_cancel = None

--- a/custom_components/sungrow/strings.json
+++ b/custom_components/sungrow/strings.json
@@ -119,6 +119,9 @@
       },
       "pf": {
         "name": "Power Factor"
+      },
+      "forced_dispatch_duration": {
+        "name": "Forced Dispatch Duration"
       }
     },
     "select": {

--- a/custom_components/sungrow/translations/en.json
+++ b/custom_components/sungrow/translations/en.json
@@ -119,6 +119,9 @@
       },
       "pf": {
         "name": "Power Factor"
+      },
+      "forced_dispatch_duration": {
+        "name": "Forced Dispatch Duration"
       }
     },
     "select": {

--- a/docs/SENSORS.md
+++ b/docs/SENSORS.md
@@ -143,12 +143,15 @@ If your inverter / ESS supports parameter configuration, the integration also cr
 | Reactive Power Mode | `reactive_power_regulation_mode` | Off / Power Factor / Q(t) / Q(P) / Q(U) | — |
 | Reactive Power Ratio Q(t) | `q_t` | −60–60 % | — |
 | Power Factor | `pf` | −1 to 1 | — |
+| Forced Dispatch Duration | *(local)* | 0–1440 min (0 = off) | ✅ |
 
 The power sliders (charge/discharge power, export limit power) are sized to the device's **rated power**, parsed from its model code (e.g. `SG3.6RS` → 3.6 kW), falling back to 5000 W when the rating can't be derived.
 
 The **reactive-power** controls work together: set **Reactive Power Mode** first, then the relevant value — **Power Factor** only takes effect in *Power Factor* mode, and **Reactive Power Ratio Q(t)** only in *Q(t)* mode. These are grid-quality controls and are available on PV-only plants too (they aren't battery-gated).
 
 When you set **Charge/Discharge Command** to *Charge* or *Discharge*, the integration automatically starts sending the External EMS heartbeat (param `10017`) every 60 seconds so the inverter stays in dispatch mode. Selecting **Stop** turns the heartbeat off. If you remove the dispatch entities, the heartbeat is also stopped.
+
+> **Auto-revert (safety).** Set **Forced Dispatch Duration** to a number of minutes and a forced *Charge*/*Discharge* automatically reverts to **Stop** after that long — so a forced command can't silently persist and curtail your solar (the [#148](https://github.com/KRoperUK/sungrow-hass/issues/148) footgun). The countdown survives a Home Assistant restart (if it expires while HA is down, the command reverts on startup). Leave it at **0** to keep the legacy behaviour (a forced command stays until you change it). It's a local control — it writes nothing to the inverter itself.
 
 > Dispatch support requires the correct iSolarCloud API plan and firmware. The integration will only create dispatch entities if it can discover a compatible inverter or ESS device for the plant.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -31,6 +31,8 @@ inverters** through the **iSolarCloud** cloud API, using the
 - **Dispatch / control** — number and select entities for charge/discharge command, power, SOC
   limits, forced charging and export/active-power limiting, with an automatic EMS heartbeat while
   dispatching. Battery controls are hidden on PV-only plants.
+- **Safer dispatch** — an optional **Forced Dispatch Duration** auto-reverts a forced
+  charge/discharge to *Stop* after a set time (surviving restarts), so it can't silently persist.
 - **Resilient polling** — rides out brief API/network hiccups instead of flapping unavailable, and
   auto-backs-off when rate-limited.
 - **Guided repairs** — whitelist and rate-limit rejections surface as actionable Home Assistant

--- a/tests/test_dispatch.py
+++ b/tests/test_dispatch.py
@@ -36,6 +36,9 @@ def _coordinator_with(plant_id, plant_name):
     # Default to a battery plant so the full dispatch set is built; the no-battery
     # gating tests (#148) override this to False.
     coordinator.has_battery = True
+    # Auto-revert off by default (a MagicMock would otherwise read as a truthy duration
+    # and arm the timer); the #157 revert tests set a real value.
+    coordinator.forced_dispatch_duration_minutes = 0
     return coordinator
 
 
@@ -67,7 +70,7 @@ async def test_number_setup_creates_entities_for_ess_device(hass: HomeAssistant)
     added = []
     await number_setup_entry(hass, entry, lambda entities: added.extend(entities))
 
-    assert len(added) == len(DISPATCH_NUMBERS)
+    assert len(added) == len(DISPATCH_NUMBERS) + 1  # + forced_dispatch_duration (#157)
     power = next(e for e in added if e.param == "charge_discharge_power")
     assert power._attr_device_class == NumberDeviceClass.POWER
     assert power._attr_native_unit_of_measurement == "W"
@@ -119,7 +122,7 @@ async def test_number_setup_falls_back_to_inverter(hass: HomeAssistant):
     added = []
     await number_setup_entry(hass, entry, lambda entities: added.extend(entities))
 
-    assert len(added) == len(DISPATCH_NUMBERS)
+    assert len(added) == len(DISPATCH_NUMBERS) + 1  # + forced_dispatch_duration (#157)
 
 
 @pytest.mark.parametrize(("uuid_in", "uuid_str"), [(4841885, "4841885"), ("already-str", "already-str")])
@@ -254,7 +257,7 @@ async def test_dispatch_full_set_with_battery(hass: HomeAssistant):
     await number_setup_entry(hass, entry, lambda e: numbers.extend(e))
     await select_setup_entry(hass, entry, lambda e: selects.extend(e))
 
-    assert {e.param for e in numbers} == set(DISPATCH_NUMBERS)
+    assert {e.param for e in numbers} == set(DISPATCH_NUMBERS) | {"forced_dispatch_duration"}
     assert {e.param for e in selects} == set(DISPATCH_SELECTS)
 
 
@@ -887,6 +890,134 @@ async def test_restored_charge_command_resumes_heartbeat(hass: HomeAssistant):
     assert mock_start.call_args.args[3] == "ess-1"
 
 
+# ---------------------------------------------------------------------------
+# Forced-dispatch auto-revert (#157)
+# ---------------------------------------------------------------------------
+
+
+async def test_forced_dispatch_duration_number_is_local(hass: HomeAssistant):
+    """The duration number stores its value on the coordinator, writing nothing to the API."""
+    from custom_components.sungrow.number import SungrowForcedDispatchDurationNumber
+
+    entry = MockConfigEntry(domain=DOMAIN, data=MOCK_CONFIG_DATA.copy())
+    entry.add_to_hass(hass)
+    data = _setup_entry_data(entry, [{"uuid": "ess-1", "device_type": "ENERGY_STORAGE_SYSTEM"}])
+    number = SungrowForcedDispatchDurationNumber(data.coordinators[0], {"uuid": "ess-1"})
+
+    await number.async_set_native_value(30)
+
+    assert number.native_value == 30
+    assert data.coordinators[0].forced_dispatch_duration_minutes == 30
+    data.control.async_update_parameters.assert_not_called()
+
+
+async def test_charge_arms_autorevert_and_stop_cancels(hass: HomeAssistant):
+    """Selecting Charge arms the auto-revert (with a persisted deadline); Stop cancels it."""
+    entry = MockConfigEntry(domain=DOMAIN, data=MOCK_CONFIG_DATA.copy())
+    entry.add_to_hass(hass)
+    data = _setup_entry_data(entry, [{"uuid": "ess-1", "device_type": "ENERGY_STORAGE_SYSTEM"}])
+    data.coordinators[0].forced_dispatch_duration_minutes = 10
+
+    added: list = []
+    await select_setup_entry(hass, entry, lambda e: added.extend(e))
+    command = next(e for e in added if e.param == "charge_discharge_command")
+    command.hass = hass
+
+    with (
+        patch("custom_components.sungrow.select.async_start_heartbeat", new=AsyncMock()),
+        patch("custom_components.sungrow.select.async_stop_heartbeat", new=AsyncMock()),
+    ):
+        await command.async_select_option("Charge")
+        assert command._revert_deadline is not None
+        assert command.extra_state_attributes == {"revert_at": command._revert_deadline}
+
+        await command.async_select_option("Stop")
+        assert command._revert_deadline is None
+        assert command.extra_state_attributes is None
+
+
+async def test_autorevert_writes_stop_and_stops_heartbeat(hass: HomeAssistant):
+    """When the revert fires it writes Stop, stops the heartbeat and updates the UI (#157)."""
+    entry = MockConfigEntry(domain=DOMAIN, data=MOCK_CONFIG_DATA.copy())
+    entry.add_to_hass(hass)
+    data = _setup_entry_data(entry, [{"uuid": "ess-1", "device_type": "ENERGY_STORAGE_SYSTEM"}])
+
+    added: list = []
+    await select_setup_entry(hass, entry, lambda e: added.extend(e))
+    command = next(e for e in added if e.param == "charge_discharge_command")
+    command.hass = hass
+    command.async_write_ha_state = MagicMock()
+    command._attr_current_option = "Charge"
+
+    with patch("custom_components.sungrow.select.async_stop_heartbeat", new=AsyncMock()) as mock_stop:
+        await command._do_revert()
+
+    data.control.async_update_parameters.assert_awaited_with("ess-1", {"charge_discharge_command": "204"})
+    mock_stop.assert_awaited_once()
+    assert command.current_option == "Stop"
+    assert command._revert_deadline is None
+
+
+async def test_restored_command_reverts_when_deadline_passed(hass: HomeAssistant):
+    """A forced command whose deadline passed while HA was down reverts to Stop on restore."""
+    import time
+
+    from homeassistant.core import State
+    from homeassistant.helpers.update_coordinator import CoordinatorEntity
+
+    entry = MockConfigEntry(domain=DOMAIN, data=MOCK_CONFIG_DATA.copy())
+    entry.add_to_hass(hass)
+    data = _setup_entry_data(entry, [{"uuid": "ess-1", "device_type": "ENERGY_STORAGE_SYSTEM"}])
+
+    added: list = []
+    await select_setup_entry(hass, entry, lambda e: added.extend(e))
+    command = next(e for e in added if e.param == "charge_discharge_command")
+    command.hass = hass
+    command.async_write_ha_state = MagicMock()
+    command.async_get_last_state = AsyncMock(return_value=State("select.x", "Charge", {"revert_at": time.time() - 10}))
+
+    with (
+        patch.object(CoordinatorEntity, "async_added_to_hass", new=AsyncMock()),
+        patch("custom_components.sungrow.select.async_start_heartbeat", new=AsyncMock()) as mock_start,
+        patch("custom_components.sungrow.select.async_stop_heartbeat", new=AsyncMock()),
+    ):
+        await command.async_added_to_hass()
+
+    # Reverted, not resumed: Stop written, heartbeat never started.
+    data.control.async_update_parameters.assert_awaited_with("ess-1", {"charge_discharge_command": "204"})
+    mock_start.assert_not_awaited()
+    assert command.current_option == "Stop"
+
+
+async def test_restored_command_rearms_when_deadline_future(hass: HomeAssistant):
+    """A forced command still within its window resumes dispatch and re-arms the revert."""
+    import time
+
+    from homeassistant.core import State
+    from homeassistant.helpers.update_coordinator import CoordinatorEntity
+
+    entry = MockConfigEntry(domain=DOMAIN, data=MOCK_CONFIG_DATA.copy())
+    entry.add_to_hass(hass)
+    _setup_entry_data(entry, [{"uuid": "ess-1", "device_type": "ENERGY_STORAGE_SYSTEM"}])
+
+    added: list = []
+    await select_setup_entry(hass, entry, lambda e: added.extend(e))
+    command = next(e for e in added if e.param == "charge_discharge_command")
+    command.hass = hass
+    future = time.time() + 300
+    command.async_get_last_state = AsyncMock(return_value=State("select.x", "Charge", {"revert_at": future}))
+
+    with (
+        patch.object(CoordinatorEntity, "async_added_to_hass", new=AsyncMock()),
+        patch("custom_components.sungrow.select.async_start_heartbeat", new=AsyncMock()) as mock_start,
+    ):
+        await command.async_added_to_hass()
+
+    mock_start.assert_awaited_once()  # dispatch resumed
+    assert command._revert_deadline == future  # re-armed for the remaining time
+    command._cancel_revert()  # avoid a lingering scheduled callback in the test
+
+
 async def test_restored_stop_command_leaves_heartbeat_off(hass: HomeAssistant):
     """A restored 'Stop' command must not start the heartbeat (#112)."""
     from homeassistant.core import State
@@ -935,13 +1066,13 @@ async def test_number_dynamic_add_when_device_appears(hass: HomeAssistant):
     for cb in listeners:
         cb()
 
-    assert len(added) == len(DISPATCH_NUMBERS)
+    assert len(added) == len(DISPATCH_NUMBERS) + 1  # + forced_dispatch_duration (#157)
     assert all(e.device_uuid == "ess-1" for e in added)
 
     # Firing again must not duplicate the controls.
     for cb in listeners:
         cb()
-    assert len(added) == len(DISPATCH_NUMBERS)
+    assert len(added) == len(DISPATCH_NUMBERS) + 1  # + forced_dispatch_duration (#157)
 
 
 async def test_select_dynamic_add_when_device_appears(hass: HomeAssistant):


### PR DESCRIPTION
Partially closes #157 (the safe, doable half). Based on `main`.

## Why
A forced Charge/Discharge currently persists **indefinitely** (60 s EMS heartbeat + restore-across-restart). On the wrong system that silently curtails PV for days — the [#148](https://github.com/KRoperUK/sungrow-hass/issues/148) footgun.

## What
- **New `Forced Dispatch Duration` number** (0–1440 min, battery-gated, `CONFIG`). It's **local** — writes nothing to the inverter, just records the timeout on the coordinator. **0 = off** (legacy behaviour, so existing setups are unchanged).
- The **Charge/Discharge Command** select now **auto-reverts to Stop** after that many minutes:
  - selecting Charge/Discharge arms a timer (alongside the heartbeat); selecting Stop cancels it;
  - when it fires it writes **Stop** and stops the heartbeat and updates the UI;
  - the deadline is persisted (`revert_at` attribute) so it **survives a restart** — if it expired while HA was down, the command reverts on startup rather than resuming dispatch.

## Why not the clean mode-select
#157 proposed a `Self-consumption / Force charge / Force discharge / Stop` select via param `10003` (Energy Management Mode). pysolarcloud documents that **the API rejects `10003` as a validation error**, so it stays out; this delivers the same safety guarantee using the existing charge/discharge registers + the revert timer. (The `10082–10086` external-dispatch variants are Logger1000/EMS-only.)

## Tests
- Duration number is local (stores on coordinator, no API write).
- Charge arms the revert + exposes `revert_at`; Stop cancels it.
- Firing writes `charge_discharge_command=204` (Stop) + stops heartbeat + sets the option to Stop.
- Restart: an expired deadline reverts to Stop (doesn't resume); a future deadline resumes dispatch and re-arms.
- Full suite: **337 passed**; ruff + format + mypy clean; strings/icons in sync.

🤖 Generated with [Claude Code](https://claude.com/claude-code)