### PR TITLE
fix: bump pysolarcloud to 0.10.1 — restore all per-device sensors

### DIFF
--- a/custom_components/sungrow/manifest.json
+++ b/custom_components/sungrow/manifest.json
@@ -17,7 +17,7 @@
   ],
   "quality_scale": "platinum",
   "requirements": [
-    "sungrow-isolarcloud==0.10.0"
+    "sungrow-isolarcloud==0.10.1"
   ],
   "version": "3.3.0"
 }

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -10,4 +10,4 @@ ruff==0.15.20
 mypy==2.1.0
 
 # Component dependencies
-sungrow-isolarcloud==0.10.0
+sungrow-isolarcloud==0.10.1


### PR DESCRIPTION
Fixes the reason per-device sensors never appear even with **Create per-device sensors** enabled.

## Root cause (pysolarcloud, fixed in 0.10.1 / KRoperUK/pysolarcloud#30)
`getDeviceRealTimeData` nests each device under a `device_point` key:
```json
{"device_point_list": [ {"device_point": {"uuid": 4841885, "p96": "60.2", ...}} ]}
```
`async_get_device_realtime` read `uuid` at the **top level** (where it's `None`) → `if not uuid: continue` → **skipped every device → returned `{}`**. So the coordinator got nothing and **zero per-device sensors were ever created** — this silently broke the *entire* per-device diagnostic path (MPPT, strings, temperatures, phase V/I, battery cell health, meter points, WLAN signal — #149/#154/#179/#180/#189), not just one feature.

## Change
Bump the pin `0.10.0 → 0.10.1` (manifest + requirements_test).

## Verified
Against a live SG3.6RS with 0.10.1, `async_get_device_realtime` returns `{4841885: {mppt1_voltage: 59.4, string_1_voltage: 60.2, ...}}` instead of `{}`. Once this lands and a dev build is cut, per-device sensors appear under each device's Diagnostic section (with the option enabled).

## Tests
338 passed; ruff + mypy(strict) clean. (Tests mock pysolarcloud, so the pin bump is orthogonal to them — the fix is validated in the pysolarcloud PR + live.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)