### PR TITLE
ci(docs): narrow deploy trigger + retry transient Pages failures

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -8,12 +8,11 @@ on:
             - zensical.toml
             - .github/workflows/docs.yml
             # Redeploy on a release so the version shown in the site header refreshes.
-            # release-please's "chore(main): release X.Y.Z" merge bumps these files, and
-            # any manual edit to them should also rebuild the docs.
+            # release-please bumps these on the "chore(main): release X.Y.Z" merge. Kept
+            # to release-only files so ordinary manifest/pyproject edits (e.g. a
+            # dependency-pin bump) don't trigger an otherwise-pointless docs redeploy.
             - version.txt
             - CHANGELOG.md
-            - custom_components/sungrow/manifest.json
-            - pyproject.toml
     workflow_dispatch: {}
 
 permissions:
@@ -30,7 +29,7 @@ jobs:
     deploy:
         environment:
             name: github-pages
-            url: ${{ steps.deployment.outputs.page_url }}
+            url: ${{ steps.deployment.outputs.page_url || steps.deployment_retry.outputs.page_url }}
         runs-on: ubuntu-latest
         timeout-minutes: 10
         steps:
@@ -59,6 +58,15 @@ jobs:
               with:
                   path: site
 
+            # GitHub Pages occasionally returns a transient "Deployment failed, try
+            # again later" from its backend even though the build/upload succeeded, so
+            # the first attempt is allowed to fail and is retried once before the job is.
             - name: Deploy to GitHub Pages
               id: deployment
+              uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5.0.0
+              continue-on-error: true
+
+            - name: Deploy to GitHub Pages (retry)
+              id: deployment_retry
+              if: steps.deployment.outcome == 'failure'
               uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5.0.0


### PR DESCRIPTION
Fixes the intermittent **Docs** workflow failures (`Deployment failed, try again later`).

## Diagnosis
The build/upload succeed every time; only GitHub's final Pages deploy step intermittently fails with a transient backend error. It surfaced more because docs deploy fires on nearly every merge — most feature PRs touch `docs/SENSORS.md`, and #177 also added `manifest.json`/`pyproject.toml` (so even a dependency-pin bump like #194 triggered a redeploy).

## Changes
- **A — narrow the trigger:** drop `manifest.json` and `pyproject.toml`; keep `version.txt` + `CHANGELOG.md` (release-please bumps them on release, preserving the "redeploy on release so the header version refreshes" intent) plus `docs/**` + `zensical.toml`. Non-release manifest/pyproject edits no longer trigger a pointless deploy.
- **B — retry the deploy:** the first `deploy-pages` attempt is `continue-on-error`, retried once via the same pinned official action; the environment URL falls back to the retry's output. No new/third-party actions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)