### PR TITLE
feat: signal-strength device class + connectivity icon

### DIFF
--- a/custom_components/sungrow/icons.json
+++ b/custom_components/sungrow/icons.json
@@ -1,5 +1,10 @@
 {
   "entity": {
+    "binary_sensor": {
+      "device_connectivity": {
+        "default": "mdi:connection"
+      }
+    },
     "number": {
       "charge_discharge_power": {
         "default": "mdi:battery-charging"

--- a/custom_components/sungrow/measure_points.py
+++ b/custom_components/sungrow/measure_points.py
@@ -155,6 +155,8 @@ def _classify_by_code(code: str) -> _ClassPair | None:
         return (None, _MEASUREMENT)
     if any(h in lowered for h in _SOC_HINTS):
         return (SensorDeviceClass.BATTERY, _MEASUREMENT)
+    if "signal_strength" in lowered or "signal strength" in lowered:
+        return (SensorDeviceClass.SIGNAL_STRENGTH, _MEASUREMENT)
     return None
 
 
@@ -286,7 +288,9 @@ def _classify_point(name: str, unit: str, point_id: str) -> _ClassPair:
         return (SensorDeviceClass.BATTERY, _MEASUREMENT)
     if "power factor" in lowered:
         return (SensorDeviceClass.POWER_FACTOR, _MEASUREMENT)
-    if tokens & _NUMERIC_NAME_TOKENS or "signal strength" in lowered:
+    if "signal strength" in lowered:
+        return (SensorDeviceClass.SIGNAL_STRENGTH, _MEASUREMENT)
+    if tokens & _NUMERIC_NAME_TOKENS:
         return (None, _MEASUREMENT)
     return (None, None)
 

--- a/custom_components/sungrow/sensor.py
+++ b/custom_components/sungrow/sensor.py
@@ -241,12 +241,18 @@ class SungrowSensor(CoordinatorEntity, SensorEntity):
             self._attr_native_unit_of_measurement = None
         elif self._scale_to_percent:
             self._attr_native_unit_of_measurement = PERCENTAGE
+        elif device_class == SensorDeviceClass.SIGNAL_STRENGTH:
+            # WLAN/wireless signal strength comes back with no unit; it's decibels.
+            self._attr_native_unit_of_measurement = unit or "dB"
         else:
             self._attr_native_unit_of_measurement = unit if unit else None
 
-        # Let HA choose the icon for sensors with a known device class; fall back to
-        # the solar panel icon only for unclassified sensors.
-        self._attr_icon = None if device_class else "mdi:solar-power-variant"
+        # Let HA pick the icon for classified sensors; a signal icon for signal
+        # strength, and the solar-panel fallback only for unclassified points.
+        if device_class == SensorDeviceClass.SIGNAL_STRENGTH:
+            self._attr_icon = "mdi:signal"
+        else:
+            self._attr_icon = None if device_class else "mdi:solar-power-variant"
 
     def _current_point(self) -> dict[str, Any] | None:
         """Return the current point payload for this sensor (plant-level source)."""

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -78,6 +78,17 @@ def _coord_with_devices(devices, data=None):
     return coordinator
 
 
+def test_signal_strength_sensor_gets_db_unit_and_signal_icon():
+    """WLAN/wireless signal strength classifies as SIGNAL_STRENGTH with a dB unit + signal icon."""
+    point = {"code": "wlan_signal_strength", "value": "-62", "unit": ""}
+    coordinator = _coord_with_devices([], data={"wlan_signal_strength": point})
+    sensor = SungrowSensor(coordinator, "wlan_signal_strength", "123", "Plant", point)
+    assert sensor._attr_device_class == SensorDeviceClass.SIGNAL_STRENGTH
+    assert sensor._attr_native_unit_of_measurement == "dB"
+    assert sensor._attr_icon == "mdi:signal"
+    assert sensor.native_value == -62.0
+
+
 def test_sensor_rehomes_to_singular_device():
     """A mapped point re-homes onto the single device of its type; unique_id unchanged."""
     inv = {


### PR DESCRIPTION
Polish for the per-device sensors that now appear (0.10.1+).

## Changes
- **WLAN / wireless signal strength** — classified as `SensorDeviceClass.SIGNAL_STRENGTH`, given a **`dB`** unit (the API returns none) and an **`mdi:signal`** icon instead of the generic solar fallback. Handled both via the catalog (point id `23014`/`23001`) and the code-based fallback (`signal_strength` in the code), so it works whether or not the point carries its numeric id.
- **Connectivity binary sensors** — default to **`mdi:connection`** (`icons.json` `binary_sensor.device_connectivity`).

## Tests
Signal-strength classification + unit + icon covered; 339 passed; ruff + format + mypy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)