### PR TITLE
fix: bump pysolarcloud to 0.10.2 — restore inverter per-device sensors

### DIFF
--- a/custom_components/sungrow/manifest.json
+++ b/custom_components/sungrow/manifest.json
@@ -17,7 +17,7 @@
   ],
   "quality_scale": "platinum",
   "requirements": [
-    "sungrow-isolarcloud==0.10.1"
+    "sungrow-isolarcloud==0.10.2"
   ],
   "version": "3.3.0"
 }

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -10,4 +10,4 @@ ruff==0.15.20
 mypy==2.1.0
 
 # Component dependencies
-sungrow-isolarcloud==0.10.1
+sungrow-isolarcloud==0.10.2


### PR DESCRIPTION
Second half of the per-device-sensor fix. 0.10.1 fixed the nested `device_point` parsing (meter/comm sensors started appearing); this fixes why the **inverter's** don't.

## Root cause (pysolarcloud 0.10.2 / KRoperUK/pysolarcloud#32)
`getDeviceRealTimeData` caps `point_id_list` at **100** (`result_code 010`). `async_get_device_realtime` padded every device query with the **74 plant measure points**, so the inverter's ~40 diagnostic points (MPPT, strings, temps, phase V/I) made **74 + 40 = 114 → rejected**, and the whole call failed silently. Meter (74+13) and comm (74+2) stayed under 100, which is exactly why *their* sensors appeared but the inverter's didn't. 0.10.2 sends only the requested points.

## Change
Pin `0.10.1 → 0.10.2` (manifest + requirements_test).

## Verified live
With 0.10.2 the inverter returns `{string_1_voltage: 73.8, string_2_voltage: 73.8, mppt1_voltage: ..., ...}` instead of erroring. Once merged + a dev build cut, the inverter's Diagnostic section fills in (strings, MPPT, temps, phase V/I, bus voltage, etc.).

## Tests
339 passed; ruff + mypy(strict) clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)