### PR TITLE
feat: icons for plant-detail sensors + power_fraction

### DIFF
--- a/custom_components/sungrow/sensor.py
+++ b/custom_components/sungrow/sensor.py
@@ -44,6 +44,10 @@ _DIAGNOSTIC_CODES = (
 # Sentinel unit: tariff sensors take their unit from the plant's currency at runtime.
 _CURRENCY_PER_KWH = "__currency_per_kwh__"
 
+# Per-code icon overrides for otherwise-unclassified plant points that read better with
+# a specific icon than the generic solar-panel fallback.
+_CODE_ICON_OVERRIDES = {"power_fraction": "mdi:gauge"}
+
 
 @dataclass(frozen=True)
 class PlantDetailSensor:
@@ -55,17 +59,31 @@ class PlantDetailSensor:
     state_class: SensorStateClass | None = None
     unit: str | None = None
     diagnostic: bool = True
+    icon: str | None = None
 
 
 # Plant-detail fields worth surfacing as their own sensors on the plant device (#178):
 # operational health (alarm/fault counts), the nameplate power, and the import/export
 # tariffs the plant is configured with. Fields absent from a given plant are skipped.
 PLANT_DETAIL_SENSORS: tuple[PlantDetailSensor, ...] = (
-    PlantDetailSensor("alarm_count", "Alarm Count", state_class=SensorStateClass.MEASUREMENT),
-    PlantDetailSensor("fault_count", "Fault Count", state_class=SensorStateClass.MEASUREMENT),
-    PlantDetailSensor("install_power", "Installed Power", SensorDeviceClass.POWER, SensorStateClass.MEASUREMENT, "W"),
-    PlantDetailSensor("ps_consumption_power_price_kwh", "Import Price", unit=_CURRENCY_PER_KWH, diagnostic=False),
-    PlantDetailSensor("ps_feedin_power_price_kwh", "Export Price", unit=_CURRENCY_PER_KWH, diagnostic=False),
+    PlantDetailSensor("alarm_count", "Alarm Count", state_class=SensorStateClass.MEASUREMENT, icon="mdi:alert-outline"),
+    PlantDetailSensor(
+        "fault_count", "Fault Count", state_class=SensorStateClass.MEASUREMENT, icon="mdi:alert-circle-outline"
+    ),
+    PlantDetailSensor(
+        "install_power",
+        "Installed Power",
+        SensorDeviceClass.POWER,
+        SensorStateClass.MEASUREMENT,
+        "W",
+        icon="mdi:solar-power",
+    ),
+    PlantDetailSensor(
+        "ps_consumption_power_price_kwh", "Import Price", unit=_CURRENCY_PER_KWH, diagnostic=False, icon="mdi:cash-plus"
+    ),
+    PlantDetailSensor(
+        "ps_feedin_power_price_kwh", "Export Price", unit=_CURRENCY_PER_KWH, diagnostic=False, icon="mdi:cash-minus"
+    ),
 )
 
 
@@ -248,9 +266,12 @@ class SungrowSensor(CoordinatorEntity, SensorEntity):
             self._attr_native_unit_of_measurement = unit if unit else None
 
         # Let HA pick the icon for classified sensors; a signal icon for signal
-        # strength, and the solar-panel fallback only for unclassified points.
+        # strength, a per-code override where one reads better, and the solar-panel
+        # fallback only for otherwise-unclassified points.
         if device_class == SensorDeviceClass.SIGNAL_STRENGTH:
             self._attr_icon = "mdi:signal"
+        elif point_code in _CODE_ICON_OVERRIDES:
+            self._attr_icon = _CODE_ICON_OVERRIDES[point_code]
         else:
             self._attr_icon = None if device_class else "mdi:solar-power-variant"
 
@@ -354,6 +375,7 @@ class SungrowPlantDetailSensor(CoordinatorEntity[SungrowPlantCoordinator], Senso
         self._attr_device_info = build_plant_device_info(plant_id, plant_name, console_url)
         self._attr_device_class = desc.device_class
         self._attr_state_class = desc.state_class
+        self._attr_icon = desc.icon
         if desc.diagnostic:
             self._attr_entity_category = EntityCategory.DIAGNOSTIC
         if desc.unit == _CURRENCY_PER_KWH:

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -89,6 +89,14 @@ def test_signal_strength_sensor_gets_db_unit_and_signal_icon():
     assert sensor.native_value == -62.0
 
 
+def test_power_fraction_gets_gauge_icon():
+    """A per-code override gives power_fraction a gauge icon, not the solar fallback."""
+    point = {"code": "power_fraction", "value": "0.83", "unit": ""}
+    coordinator = _coord_with_devices([], data={"power_fraction": point})
+    sensor = SungrowSensor(coordinator, "power_fraction", "123", "Plant", point)
+    assert sensor._attr_icon == "mdi:gauge"
+
+
 def test_sensor_rehomes_to_singular_device():
     """A mapped point re-homes onto the single device of its type; unique_id unchanged."""
     inv = {
@@ -143,15 +151,18 @@ def test_plant_detail_sensor_values_and_units():
     assert alarm.native_value == 2.0
     assert alarm._attr_unique_id == "123_detail_alarm_count"
     assert alarm._attr_device_info["identifiers"] == {(DOMAIN, "123")}
+    assert alarm._attr_icon == "mdi:alert-outline"
 
     power = SungrowPlantDetailSensor(coordinator, descs["install_power"], "123", "Plant", "http://x")
     assert power.native_value == 3600.0
     assert power._attr_native_unit_of_measurement == "W"
+    assert power._attr_icon == "mdi:solar-power"
 
     # Tariff sensor takes its unit from the plant's configured currency.
     price = SungrowPlantDetailSensor(coordinator, descs["ps_consumption_power_price_kwh"], "123", "Plant", "http://x")
     assert price.native_value == 0.3887
     assert price._attr_native_unit_of_measurement == "GBP/kWh"
+    assert price._attr_icon == "mdi:cash-plus"
 
 
 def test_plant_detail_sensor_absent_field_is_none():


### PR DESCRIPTION
Follow-up from the icon audit (the suggestions you approved). #196 handled WLAN signal + connectivity; this covers the plant-detail sensors that had no icon, plus `power_fraction`.

| Entity | Was | Now |
|---|---|---|
| `alarm_count` | (none) | `mdi:alert-outline` |
| `fault_count` | (none) | `mdi:alert-circle-outline` |
| `installed_power` | flash (power default) | `mdi:solar-power` |
| `import_price` | (none) | `mdi:cash-plus` |
| `export_price` | (none) | `mdi:cash-minus` |
| `power_fraction` | mdi:solar-power-variant | `mdi:gauge` |

## How
- Added an `icon` field to the `PlantDetailSensor` descriptor; `SungrowPlantDetailSensor` sets `_attr_icon` from it.
- A small `_CODE_ICON_OVERRIDES` map handles otherwise-unclassified plant points that read better with a specific icon (`power_fraction` → gauge).

## Tests
Icon assertions added to the plant-detail test + a `power_fraction` test. 340 passed; ruff + format + mypy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)