### PR TITLE
feat: acronym names, diagnostic icons & integer counts for device sensors

### DIFF
--- a/custom_components/sungrow/measure_points.py
+++ b/custom_components/sungrow/measure_points.py
@@ -157,6 +157,10 @@ def _classify_by_code(code: str) -> _ClassPair | None:
         return (SensorDeviceClass.BATTERY, _MEASUREMENT)
     if "signal_strength" in lowered or "signal strength" in lowered:
         return (SensorDeviceClass.SIGNAL_STRENGTH, _MEASUREMENT)
+    if "count" in lowered:
+        # Dimensionless integer tallies (e.g. afci_fault_count) graph as a plain
+        # numeric measurement instead of falling through to a text sensor.
+        return (None, _MEASUREMENT)
     return None
 
 

--- a/custom_components/sungrow/measure_points_data.py
+++ b/custom_components/sungrow/measure_points_data.py
@@ -810,4 +810,18 @@ CODE_ALIASES: dict[str, str] = {
     "micro_yield_today": "Microinverter Yield Today",
     "micro_power_factor": "Microinverter Power Factor",
     "micro_running_status": "Microinverter Running Status",
+    # Per-device diagnostic codes whose acronyms/initialisms the generic
+    # title-caser would mangle ("Mppt1", "Wlan", "Afci", "Dc", "Id").
+    "mppt1_voltage": "MPPT1 Voltage",
+    "mppt1_current": "MPPT1 Current",
+    "mppt2_voltage": "MPPT2 Voltage",
+    "mppt2_current": "MPPT2 Current",
+    "mppt3_voltage": "MPPT3 Voltage",
+    "mppt3_current": "MPPT3 Current",
+    "total_dc_power": "Total DC Power",
+    "negative_voltage_to_ground": "Negative Voltage to Ground",
+    "afci_fault_count": "AFCI Fault Count",
+    "wlan_signal_strength": "WLAN Signal Strength",
+    "battery_dc_contactor_status": "Battery DC Contactor Status",
+    "battery_fault_module_id": "Battery Fault Module ID",
 }

--- a/custom_components/sungrow/sensor.py
+++ b/custom_components/sungrow/sensor.py
@@ -44,9 +44,20 @@ _DIAGNOSTIC_CODES = (
 # Sentinel unit: tariff sensors take their unit from the plant's currency at runtime.
 _CURRENCY_PER_KWH = "__currency_per_kwh__"
 
-# Per-code icon overrides for otherwise-unclassified plant points that read better with
-# a specific icon than the generic solar-panel fallback.
-_CODE_ICON_OVERRIDES = {"power_fraction": "mdi:gauge"}
+# Per-code icon overrides for points that read better with a specific icon than the
+# generic solar-panel fallback (or the class default). Applies regardless of
+# classification, so status/count points get a fitting glyph too.
+_CODE_ICON_OVERRIDES = {
+    "power_fraction": "mdi:gauge",
+    "array_insulation_resistance": "mdi:omega",
+    "afci_fault_count": "mdi:flash-alert",
+    "battery_operation_status": "mdi:battery-sync",
+    "battery_fault_module_id": "mdi:alert-circle",
+}
+
+# Dimensionless integer tallies displayed without a fractional part (issue-driven:
+# a fault count of "3" reads better than "3.0").
+_INTEGER_COUNT_CODES = frozenset({"afci_fault_count"})
 
 
 @dataclass(frozen=True)
@@ -60,15 +71,26 @@ class PlantDetailSensor:
     unit: str | None = None
     diagnostic: bool = True
     icon: str | None = None
+    integer: bool = False
 
 
 # Plant-detail fields worth surfacing as their own sensors on the plant device (#178):
 # operational health (alarm/fault counts), the nameplate power, and the import/export
 # tariffs the plant is configured with. Fields absent from a given plant are skipped.
 PLANT_DETAIL_SENSORS: tuple[PlantDetailSensor, ...] = (
-    PlantDetailSensor("alarm_count", "Alarm Count", state_class=SensorStateClass.MEASUREMENT, icon="mdi:alert-outline"),
     PlantDetailSensor(
-        "fault_count", "Fault Count", state_class=SensorStateClass.MEASUREMENT, icon="mdi:alert-circle-outline"
+        "alarm_count",
+        "Alarm Count",
+        state_class=SensorStateClass.MEASUREMENT,
+        icon="mdi:alert-outline",
+        integer=True,
+    ),
+    PlantDetailSensor(
+        "fault_count",
+        "Fault Count",
+        state_class=SensorStateClass.MEASUREMENT,
+        icon="mdi:alert-circle-outline",
+        integer=True,
     ),
     PlantDetailSensor(
         "install_power",
@@ -78,11 +100,16 @@ PLANT_DETAIL_SENSORS: tuple[PlantDetailSensor, ...] = (
         "W",
         icon="mdi:solar-power",
     ),
+    # Import price is money paid (cash-minus); export price is money earned (cash-plus).
     PlantDetailSensor(
-        "ps_consumption_power_price_kwh", "Import Price", unit=_CURRENCY_PER_KWH, diagnostic=False, icon="mdi:cash-plus"
+        "ps_consumption_power_price_kwh",
+        "Import Price",
+        unit=_CURRENCY_PER_KWH,
+        diagnostic=False,
+        icon="mdi:cash-minus",
     ),
     PlantDetailSensor(
-        "ps_feedin_power_price_kwh", "Export Price", unit=_CURRENCY_PER_KWH, diagnostic=False, icon="mdi:cash-minus"
+        "ps_feedin_power_price_kwh", "Export Price", unit=_CURRENCY_PER_KWH, diagnostic=False, icon="mdi:cash-plus"
     ),
 )
 
@@ -275,6 +302,10 @@ class SungrowSensor(CoordinatorEntity, SensorEntity):
         else:
             self._attr_icon = None if device_class else "mdi:solar-power-variant"
 
+        # Integer tallies (fault counts) show no decimal places.
+        if point_code in _INTEGER_COUNT_CODES:
+            self._attr_suggested_display_precision = 0
+
     def _current_point(self) -> dict[str, Any] | None:
         """Return the current point payload for this sensor (plant-level source)."""
         data = self.coordinator.data
@@ -376,6 +407,8 @@ class SungrowPlantDetailSensor(CoordinatorEntity[SungrowPlantCoordinator], Senso
         self._attr_device_class = desc.device_class
         self._attr_state_class = desc.state_class
         self._attr_icon = desc.icon
+        if desc.integer:
+            self._attr_suggested_display_precision = 0
         if desc.diagnostic:
             self._attr_entity_category = EntityCategory.DIAGNOSTIC
         if desc.unit == _CURRENCY_PER_KWH:
@@ -385,12 +418,14 @@ class SungrowPlantDetailSensor(CoordinatorEntity[SungrowPlantCoordinator], Senso
             self._attr_native_unit_of_measurement = desc.unit
 
     @property
-    def native_value(self) -> float | str | None:
+    def native_value(self) -> float | int | str | None:
         """Return the current value of the plant-detail field."""
         raw = self.coordinator.plant_detail.get(self._desc.key)
         if raw is None or str(raw).strip() == "":
             return None
         try:
-            return float(raw)
+            num = float(raw)
         except (TypeError, ValueError):
             return str(raw)
+        # Counts (alarm/fault) are whole numbers, not floats.
+        return int(num) if self._desc.integer else num

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -46,6 +46,8 @@ from .conftest import MOCK_CONFIG_DATA
         ("%", "battery_soc", SensorDeviceClass.BATTERY, SensorStateClass.MEASUREMENT),
         # Generic percentage gets a state class but no device class.
         ("%", "efficiency", None, SensorStateClass.MEASUREMENT),
+        # Dimensionless integer tallies graph as a measurement, not text.
+        ("", "afci_fault_count", None, SensorStateClass.MEASUREMENT),
         # Unknown / empty units.
         ("", "status", None, None),
         (None, "status", None, None),
@@ -148,7 +150,10 @@ def test_plant_detail_sensor_values_and_units():
     descs = {d.key: d for d in PLANT_DETAIL_SENSORS}
 
     alarm = SungrowPlantDetailSensor(coordinator, descs["alarm_count"], "123", "Plant", "http://x")
-    assert alarm.native_value == 2.0
+    # Counts are whole numbers, displayed without a fractional part.
+    assert alarm.native_value == 2
+    assert isinstance(alarm.native_value, int)
+    assert alarm._attr_suggested_display_precision == 0
     assert alarm._attr_unique_id == "123_detail_alarm_count"
     assert alarm._attr_device_info["identifiers"] == {(DOMAIN, "123")}
     assert alarm._attr_icon == "mdi:alert-outline"
@@ -158,11 +163,12 @@ def test_plant_detail_sensor_values_and_units():
     assert power._attr_native_unit_of_measurement == "W"
     assert power._attr_icon == "mdi:solar-power"
 
-    # Tariff sensor takes its unit from the plant's configured currency.
+    # Tariff sensor takes its unit from the plant's configured currency; import
+    # price is money paid (cash-minus).
     price = SungrowPlantDetailSensor(coordinator, descs["ps_consumption_power_price_kwh"], "123", "Plant", "http://x")
     assert price.native_value == 0.3887
     assert price._attr_native_unit_of_measurement == "GBP/kWh"
-    assert price._attr_icon == "mdi:cash-plus"
+    assert price._attr_icon == "mdi:cash-minus"
 
 
 def test_plant_detail_sensor_absent_field_is_none():
@@ -172,6 +178,81 @@ def test_plant_detail_sensor_absent_field_is_none():
     desc = next(d for d in PLANT_DETAIL_SENSORS if d.key == "fault_count")
     sensor = SungrowPlantDetailSensor(coordinator, desc, "123", "Plant", "http://x")
     assert sensor.native_value is None
+
+
+def test_fault_count_is_integer():
+    """Fault count is a whole number, displayed without decimals."""
+    coordinator = MagicMock()
+    coordinator.plant_detail = {"fault_count": 4}
+    desc = next(d for d in PLANT_DETAIL_SENSORS if d.key == "fault_count")
+    sensor = SungrowPlantDetailSensor(coordinator, desc, "123", "Plant", "http://x")
+    assert sensor.native_value == 4
+    assert isinstance(sensor.native_value, int)
+    assert sensor._attr_suggested_display_precision == 0
+
+
+def test_export_price_icon_is_cash_plus():
+    """Export price is money earned (cash-plus); import price is money paid (cash-minus)."""
+    coordinator = MagicMock()
+    coordinator.plant_detail = {"ps_feedin_power_price_kwh": "0.15", "power_price_unit": "GBP"}
+    desc = next(d for d in PLANT_DETAIL_SENSORS if d.key == "ps_feedin_power_price_kwh")
+    sensor = SungrowPlantDetailSensor(coordinator, desc, "123", "Plant", "http://x")
+    assert sensor._attr_icon == "mdi:cash-plus"
+
+
+# ---------------------------------------------------------------------------
+# Per-device diagnostic naming, icons & classification (aesthetics)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("code", "point_id", "expected_name"),
+    [
+        ("mppt1_voltage", "5", "MPPT1 Voltage"),
+        ("mppt2_current", "8", "MPPT2 Current"),
+        ("mppt3_voltage", "9", "MPPT3 Voltage"),
+        ("total_dc_power", "14", "Total DC Power"),
+        ("negative_voltage_to_ground", "90", "Negative Voltage to Ground"),
+        ("afci_fault_count", "120", "AFCI Fault Count"),
+        ("wlan_signal_strength", "23014", "WLAN Signal Strength"),
+        ("battery_dc_contactor_status", "58635", "Battery DC Contactor Status"),
+        ("battery_fault_module_id", "58636", "Battery Fault Module ID"),
+    ],
+)
+def test_acronym_display_names(code, point_id, expected_name):
+    """Acronym/initialism codes keep their capitalisation instead of being title-cased."""
+    point = {"id": point_id, "code": code, "value": "1", "unit": ""}
+    coordinator = _coord_with_devices([], data={code: point})
+    sensor = SungrowSensor(coordinator, code, "123", "Plant", point)
+    assert sensor._attr_name == expected_name
+
+
+@pytest.mark.parametrize(
+    ("code", "point_id", "unit", "expected_icon"),
+    [
+        ("array_insulation_resistance", "94", "kΩ", "mdi:omega"),
+        ("afci_fault_count", "120", "", "mdi:flash-alert"),
+        ("battery_operation_status", "58608", "", "mdi:battery-sync"),
+        ("battery_fault_module_id", "58636", "", "mdi:alert-circle"),
+    ],
+)
+def test_diagnostic_icon_overrides(code, point_id, unit, expected_icon):
+    """Otherwise-unclassified diagnostics get a fitting icon instead of the solar fallback."""
+    point = {"id": point_id, "code": code, "value": "1", "unit": unit}
+    coordinator = _coord_with_devices([], data={code: point})
+    sensor = SungrowSensor(coordinator, code, "123", "Plant", point)
+    assert sensor._attr_icon == expected_icon
+
+
+def test_afci_fault_count_is_integer_measurement():
+    """AFCI fault count graphs as a whole-number measurement, not a text sensor."""
+    point = {"id": "120", "code": "afci_fault_count", "value": "3", "unit": ""}
+    coordinator = _coord_with_devices([], data={"afci_fault_count": point})
+    sensor = SungrowSensor(coordinator, "afci_fault_count", "123", "Plant", point)
+    assert sensor._attr_device_class is None
+    assert sensor._attr_state_class == SensorStateClass.MEASUREMENT
+    assert sensor._attr_suggested_display_precision == 0
+    assert sensor.native_value == 3.0
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Aesthetic polish for the per-device diagnostic sensors — all cosmetic/classification, no behavioural change to polling.

## Changes
- **Acronym display names** (`CODE_ALIASES`): codes keep their capitalisation instead of the title-caser mangling them — `MPPT1/2/3 Voltage & Current`, `WLAN Signal Strength`, `AFCI Fault Count`, `Total DC Power`, `Battery DC Contactor Status`, `Battery Fault Module ID`, `Negative Voltage to Ground` (was "Mppt1"/"Wlan"/"Dc"/"Id").
- **Diagnostic icons** (`_CODE_ICON_OVERRIDES`): `array_insulation_resistance` → `mdi:omega`, `afci_fault_count` → `mdi:flash-alert`, `battery_operation_status` → `mdi:battery-sync`, `battery_fault_module_id` → `mdi:alert-circle`.
- **`afci_fault_count` numeric**: a `count` rule in `_classify_by_code` classifies it `(None, MEASUREMENT)` so it graphs as a whole number rather than falling through to a text sensor (display precision 0).
- **Integer counts**: `Alarm Count` / `Fault Count` plant-detail sensors now return `int`, displayed with no decimals.
- **Tariff icons swapped**: `Export Price` = money earned → `mdi:cash-plus`; `Import Price` = money paid → `mdi:cash-minus`.

## Tests
- New: acronym-name parametrize, icon-override parametrize, `afci_fault_count` numeric+precision, integer `Fault Count`, export-price icon; plus a `count`→MEASUREMENT case in `test_infer_device_class`.
- Updated the plant-detail test for the swapped import icon + integer alarm count.
- `ruff`, `ruff format`, `mypy`, full `pytest` (357 passed) all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)