### PR TITLE
fix: bump pysolarcloud to 0.10.3 — chunk realtime point_id_list (100-point cap)

### DIFF
--- a/custom_components/sungrow/manifest.json
+++ b/custom_components/sungrow/manifest.json
@@ -17,7 +17,7 @@
   ],
   "quality_scale": "platinum",
   "requirements": [
-    "sungrow-isolarcloud==0.10.2"
+    "sungrow-isolarcloud==0.10.3"
   ],
   "version": "3.3.0"
 }

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -10,4 +10,4 @@ ruff==0.15.20
 mypy==2.1.0
 
 # Component dependencies
-sungrow-isolarcloud==0.10.2
+sungrow-isolarcloud==0.10.3


### PR DESCRIPTION
Pins `sungrow-isolarcloud==0.10.3` (both `manifest.json` and `requirements_test.txt`).

## Why
[pysolarcloud #34](https://github.com/KRoperUK/pysolarcloud/pull/34) makes both realtime endpoints request `point_id_list` in **chunks of ≤100** and merge the results. This closes the remaining `result_code 010` edge case: a **hybrid/ESS inverter** (inverter diagnostics + battery points) or anyone adding many `extra_measure_points` could still aggregate past the API's 100-point cap and fail the whole device/plant fetch. Sets of ≤100 still make exactly one request (no behavioural change).

The common trigger was already fixed by 0.10.2 (rc11); this is the durable, size-independent fix.

## Verification
- Installed 0.10.3, confirmed the chunking path is present.
- `ruff`, `mypy`, full `pytest` (357 passed) green against the real 0.10.3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)