### PR TITLE
feat: surface operating-status reason on the Fault binary sensor (#182)

### DIFF
--- a/custom_components/sungrow/binary_sensor.py
+++ b/custom_components/sungrow/binary_sensor.py
@@ -19,6 +19,7 @@ from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from . import build_device_info
 from .coordinator import SungrowPlantCoordinator
+from .measure_points import resolve_enum_value
 
 # Read-only, updated in bulk by the coordinator.
 PARALLEL_UPDATES = 0
@@ -133,10 +134,28 @@ class SungrowDeviceFaultBinarySensor(CoordinatorEntity[SungrowPlantCoordinator],
 
     @property
     def extra_state_attributes(self) -> dict[str, Any]:
-        """Expose the raw fault status for troubleshooting."""
+        """Expose the raw fault status plus a human-readable operating-status reason."""
         device = self._device() or {}
         status = device.get("dev_fault_status")
-        return {"fault_status": str(getattr(status, "name", status)) if status is not None else None}
+        return {
+            "fault_status": str(getattr(status, "name", status)) if status is not None else None,
+            "operating_status": self._operating_status_reason(),
+        }
+
+    def _operating_status_reason(self) -> str | None:
+        """Human-readable operating status for this device, if reported (#182).
+
+        Sourced from the operating-status measure point (inverter point 29 / ESS 13146)
+        the coordinator always fetches, so it explains *why* a device is in a problem
+        state ("Shut down due to faults", "Low insulation resistance", ...). ``None`` for
+        devices that report no operating status (battery/meter/comm) or when the
+        per-device endpoint is unavailable.
+        """
+        device_data = getattr(self.coordinator, "device_data", None) or {}
+        point = device_data.get(self.device_uuid, {}).get("operating_status")
+        if not isinstance(point, dict):
+            return None
+        return resolve_enum_value(str(point.get("id") or ""), point.get("value"))
 
 
 class SungrowDeviceConnectivityBinarySensor(CoordinatorEntity[SungrowPlantCoordinator], BinarySensorEntity):

--- a/custom_components/sungrow/const.py
+++ b/custom_components/sungrow/const.py
@@ -48,6 +48,14 @@ MAX_SCAN_INTERVAL = 86400
 # always on the first poll) so newly added/removed devices are still picked up.
 DEVICE_REFRESH_INTERVAL = 900
 
+# Operating-status measuring point per inverter family (#182). Always requested — even
+# when per-device sensors are off — so the Fault binary sensor can surface a
+# human-readable reason ("Shut down due to faults", "Low insulation resistance", ...).
+# Inverters report status on point 29, ESS/hybrids on 13146; both resolve via the shared
+# operating-status enum.
+INVERTER_OPERATING_STATUS_POINT: dict[str, str] = {"29": "operating_status"}
+ESS_OPERATING_STATUS_POINT: dict[str, str] = {"13146": "operating_status"}
+
 # Inverter/ESS device-level measuring points surfaced as diagnostic sensors (#149),
 # requested per-device when device sensors are enabled. Maps the documented inverter
 # point ID -> a stable code. Every ID is already in the measure-point catalog, so it

--- a/custom_components/sungrow/coordinator.py
+++ b/custom_components/sungrow/coordinator.py
@@ -25,7 +25,9 @@ from .const import (
     DEFAULT_SCAN_INTERVAL,
     DEVICE_REFRESH_INTERVAL,
     DOMAIN,
+    ESS_OPERATING_STATUS_POINT,
     INVERTER_DIAGNOSTIC_POINTS,
+    INVERTER_OPERATING_STATUS_POINT,
     METER_DEVICE_POINTS,
 )
 
@@ -228,8 +230,11 @@ class SungrowPlantCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         # the plant-level diagnostic sensors (#178). Throttled and best-effort.
         await self._async_maybe_refresh_plant_detail()
 
-        if self.enable_device_sensors:
-            self.device_data = await self._async_fetch_device_data()
+        # Always fetch per-device data: even with per-device sensors off, we request
+        # each inverter/ESS device's operating status so the Fault binary sensor can
+        # show a human-readable reason (#182). The heavy diagnostic sets are still gated
+        # on the option inside the fetch.
+        self.device_data = await self._async_fetch_device_data()
 
         # pysolarcloud is untyped, so the realtime payload is Any.
         return cast("dict[str, Any]", all_plants_data.get(self.plant_id, {}))
@@ -365,20 +370,34 @@ class SungrowPlantCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                 for d in self.devices
                 if getattr(d.get("device_type"), "value", d.get("device_type")) == type_id and d.get("ps_key")
             ]
-            # Inverter/ESS devices also report the diagnostic points (operating status,
-            # MPPT, DC power, ...); request them on top of any user-configured extras (#149).
-            # Battery/ESS devices likewise report battery points (SOC, temp, SOH, ...) (#154).
-            extra = dict(self.extra_measure_points)
-            if type_id in (DeviceType.INVERTER.value, DeviceType.ENERGY_STORAGE_SYSTEM.value):
-                extra.update(INVERTER_DIAGNOSTIC_POINTS)
-            if type_id in (DeviceType.BATTERY.value, DeviceType.ENERGY_STORAGE_SYSTEM.value):
-                extra.update(BATTERY_DEVICE_POINTS)
-            # Communication modules report WLAN/wireless signal strength (#149).
-            if type_id == DeviceType.COMMUNICATION_MODULE.value:
-                extra.update(COMM_MODULE_POINTS)
-            # Energy meters report instantaneous power / PF / frequency / per-phase (#179).
-            if type_id == DeviceType.METER.value:
-                extra.update(METER_DEVICE_POINTS)
+            extra: dict[str, str] = {}
+            # Always request the operating-status point for inverters/ESS so the Fault
+            # binary sensor can surface a reason regardless of the device-sensor option
+            # (#182). Inverters use point 29, ESS/hybrids 13146.
+            if type_id == DeviceType.ENERGY_STORAGE_SYSTEM.value:
+                extra.update(ESS_OPERATING_STATUS_POINT)
+            elif type_id == DeviceType.INVERTER.value:
+                extra.update(INVERTER_OPERATING_STATUS_POINT)
+            # The full diagnostic/battery/meter/comm sets (and user extras) are only
+            # fetched when the user has opted into per-device sensors (#149/#154/#179).
+            # With the option on, an unmapped device type still gets a best-effort fetch
+            # (extra=None -> the default measure points) as before.
+            if self.enable_device_sensors:
+                extra.update(self.extra_measure_points)
+                if type_id in (DeviceType.INVERTER.value, DeviceType.ENERGY_STORAGE_SYSTEM.value):
+                    extra.update(INVERTER_DIAGNOSTIC_POINTS)
+                if type_id in (DeviceType.BATTERY.value, DeviceType.ENERGY_STORAGE_SYSTEM.value):
+                    extra.update(BATTERY_DEVICE_POINTS)
+                # Communication modules report WLAN/wireless signal strength (#149).
+                if type_id == DeviceType.COMMUNICATION_MODULE.value:
+                    extra.update(COMM_MODULE_POINTS)
+                # Energy meters report instantaneous power / PF / frequency / per-phase (#179).
+                if type_id == DeviceType.METER.value:
+                    extra.update(METER_DEVICE_POINTS)
+            elif not extra:
+                # Device sensors off and this type reports no operating status
+                # (battery/meter/comm/unknown) — nothing to fetch, skip it.
+                continue
             try:
                 async with asyncio.timeout(self._poll_timeout):
                     result = await self.plants_service.async_get_device_realtime(

--- a/tests/test_binary_sensor.py
+++ b/tests/test_binary_sensor.py
@@ -21,13 +21,14 @@ from custom_components.sungrow.const import DOMAIN
 from .conftest import MOCK_CONFIG_DATA
 
 
-def _coordinator_with(devices):
+def _coordinator_with(devices, device_data=None):
     coordinator = MagicMock()
     coordinator.plant_id = "12345"
     coordinator.plant_name = "Test Plant"
     coordinator.config_entry = MagicMock()
     coordinator.last_update_success = True
     coordinator.devices = devices
+    coordinator.device_data = device_data or {}
     return coordinator
 
 
@@ -74,6 +75,34 @@ async def test_fault_binary_sensor_created_per_device(hass: HomeAssistant):
     assert fault["inv-1"].is_on is False
     assert fault["meter-1"].is_on is True
     assert fault["meter-1"].extra_state_attributes["fault_status"] == "FAULT"
+
+
+def test_fault_sensor_surfaces_operating_status_reason():
+    """The Fault sensor exposes a human-readable operating-status reason (#182)."""
+    devices = [{"uuid": "inv-1", "device_name": "Inverter1", "dev_fault_status": DeviceFaultStaus.FAULT}]
+    device_data = {"inv-1": {"operating_status": {"id": "29", "code": "operating_status", "value": "21760"}}}
+    coordinator = _coordinator_with(devices, device_data=device_data)
+    sensor = SungrowDeviceFaultBinarySensor(coordinator, devices[0])
+    attrs = sensor.extra_state_attributes
+    assert attrs["fault_status"] == "FAULT"
+    assert attrs["operating_status"] == "Shut down due to faults"
+
+
+def test_fault_sensor_operating_status_reason_for_ess():
+    """ESS/hybrid operating status resolves via point 13146, not the inverter point (#182)."""
+    devices = [{"uuid": "ess-1", "device_name": "Hybrid", "dev_fault_status": DeviceFaultStaus.ALARM}]
+    device_data = {"ess-1": {"operating_status": {"id": "13146", "code": "operating_status", "value": "37120"}}}
+    coordinator = _coordinator_with(devices, device_data=device_data)
+    sensor = SungrowDeviceFaultBinarySensor(coordinator, devices[0])
+    assert sensor.extra_state_attributes["operating_status"] == "Running with alarm"
+
+
+def test_fault_sensor_operating_status_none_when_not_reported():
+    """Devices with no operating-status reading expose operating_status=None (#182)."""
+    devices = [{"uuid": "meter-1", "device_name": "Meter1", "dev_fault_status": DeviceFaultStaus.NORMAL}]
+    coordinator = _coordinator_with(devices)  # empty device_data
+    sensor = SungrowDeviceFaultBinarySensor(coordinator, devices[0])
+    assert sensor.extra_state_attributes["operating_status"] is None
 
 
 async def test_fault_binary_sensor_unavailable_when_device_gone(hass: HomeAssistant):

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -453,7 +453,7 @@ async def test_device_data_fetched_when_enabled(hass: HomeAssistant):
 
 
 async def test_device_data_not_fetched_when_disabled(hass: HomeAssistant):
-    """With the option off, per-device realtime is never requested."""
+    """With the option off, a non-inverter device (no operating status) isn't requested."""
     plants = MagicMock()
     plants.async_get_realtime_data = AsyncMock(return_value=MOCK_REALTIME_DATA)
     plants.async_get_device_realtime = AsyncMock(return_value={})
@@ -464,6 +464,41 @@ async def test_device_data_not_fetched_when_disabled(hass: HomeAssistant):
 
     assert coordinator.device_data == {}
     plants.async_get_device_realtime.assert_not_awaited()
+
+
+async def test_operating_status_fetched_for_inverter_when_disabled(hass: HomeAssistant):
+    """Even with device sensors off, an inverter's operating status is fetched (#182).
+
+    This is what lets the Fault binary sensor show a reason without the full device-
+    sensor set enabled; only the single operating-status point is requested.
+    """
+    plants = MagicMock()
+    plants.async_get_realtime_data = AsyncMock(return_value=MOCK_REALTIME_DATA)
+    plants.async_get_device_realtime = AsyncMock(
+        return_value={"inv-1": {"operating_status": {"id": "29", "code": "operating_status", "value": "64"}}}
+    )
+    devices = [{"uuid": "inv-1", "device_type": DeviceType.INVERTER, "ps_key": "12345_1_1_1"}]
+    coordinator = SungrowPlantCoordinator(hass, _make_entry(), plants, "12345", "Test Plant", devices)
+
+    await coordinator._async_update_data()
+
+    extra = plants.async_get_device_realtime.await_args.kwargs["extra_measure_points"]
+    assert extra == {"29": "operating_status"}  # only operating status, none of the heavy sets
+    assert coordinator.device_data["inv-1"]["operating_status"]["value"] == "64"
+
+
+async def test_operating_status_uses_13146_for_ess_when_disabled(hass: HomeAssistant):
+    """ESS/hybrid operating status is requested on point 13146, not the inverter point (#182)."""
+    plants = MagicMock()
+    plants.async_get_realtime_data = AsyncMock(return_value=MOCK_REALTIME_DATA)
+    plants.async_get_device_realtime = AsyncMock(return_value={})
+    devices = [{"uuid": "ess-1", "device_type": DeviceType.ENERGY_STORAGE_SYSTEM, "ps_key": "12345_14_1_1"}]
+    coordinator = SungrowPlantCoordinator(hass, _make_entry(), plants, "12345", "Test Plant", devices)
+
+    await coordinator._async_update_data()
+
+    extra = plants.async_get_device_realtime.await_args.kwargs["extra_measure_points"]
+    assert extra == {"13146": "operating_status"}
 
 
 async def test_device_data_best_effort_on_error(hass: HomeAssistant):


### PR DESCRIPTION
Closes #182.

## Problem
The per-device Fault binary sensor exposed only the coarse `dev_fault_status` (`FAULT`/`ALARM`/`NORMAL`), so users saw a bare "problem" with no indication of *why*.

## Key finding
The specific Appendix 9 fault code (inverter `60001–60064`, ESS `13801–13896`) **isn't retrievable via this cloud API** — there's no fault/alarm-list endpoint in the entire OpenAPI, and no realtime measure point carries the code. So instead of a lookup that would never fire, this surfaces the best "why" the API *does* provide: the device's **Operating Status** (point `29` inverter / `13146` ESS), whose enum includes fault-relevant states like *Shut down due to faults*, *Low insulation resistance*, *Operation fault*, *Running with alarm*.

## Changes
- **Coordinator** always fetches each inverter/ESS device's operating-status point — even when per-device sensors are **off** — so the reason works regardless of the option. Inverters use `29`, ESS/hybrids `13146` (previously only `29` was ever sent, so hybrids got nothing). The heavy diagnostic sets stay gated on the option; a device type with nothing to fetch is skipped (no wasted call).
- **Fault binary sensor** gains an `operating_status` attribute with the human-readable label, reusing the existing operating-status enum. `None` for devices that report no status (battery/meter/comm) or when the per-device endpoint is unavailable.

## Scope (YAGNI)
- No Appendix 9 code→text table (the code never arrives over this API).
- No pysolarcloud change — stays in the integration.

## Tests
- Fault sensor exposes the mapped label (inverter `29` and ESS `13146`); `None` when absent.
- Coordinator fetches operating status even with device sensors **disabled**, requesting only that point; uses `13146` for ESS; still skips a non-inverter device when off.
- `ruff`, `ruff format`, `mypy`, full `pytest` (362 passed) all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)