### PR TITLE
fix: keep rate-limit backoff on transient errors; fix ESS operating-status collision

### DIFF
--- a/custom_components/sungrow/coordinator.py
+++ b/custom_components/sungrow/coordinator.py
@@ -203,10 +203,15 @@ class SungrowPlantCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         except Exception as err:
             if is_auth_error(err):
                 raise ConfigEntryAuthFailed(f"Authentication with iSolarCloud failed: {err}") from err
-            # Surface actionable errors (whitelist, rate limit) as HA Repairs (#153).
-            self._async_manage_repairs(err)
-            # Back off the poll interval while rate-limited so we stop hammering the API (#156).
-            self._adjust_poll_backoff(rate_limited=is_rate_limit_error(err))
+            # Surface actionable errors (whitelist, rate limit) as HA Repairs (#153) and
+            # back off the poll interval while rate-limited (#156). Deliberately raise-only:
+            # a transient error (e.g. a network TimeoutError) that interleaves with an
+            # active rate-limit must NOT dismiss the still-valid Repair or reset the
+            # back-off and resume hammering the API — only a *successful* poll clears the
+            # Repairs and restores the interval.
+            self._async_raise_repair(err)
+            if is_rate_limit_error(err):
+                self._adjust_poll_backoff(rate_limited=True)
             # Transient failure (a timeout arrives here as TimeoutError). Rather than flap
             # every entity to "unavailable" on a brief cloud hiccup, keep serving the
             # last-good data while a recent success is still within the grace window (#152);
@@ -217,7 +222,8 @@ class SungrowPlantCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             # A timeout arrives here as TimeoutError and is treated as transient.
             raise UpdateFailed(describe_api_error(err) or f"Error communicating with iSolarCloud API: {err}") from err
 
-        self._async_manage_repairs(None)
+        # Success: the plant recovered, so clear any Repairs and restore the interval.
+        self._async_clear_repairs()
         self._adjust_poll_backoff(rate_limited=False)
         self._last_successful_update = self.hass.loop.time()
 
@@ -266,28 +272,34 @@ class SungrowPlantCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                 self._base_update_interval,
             )
 
-    def _async_manage_repairs(self, err: Exception | None) -> None:
-        """Raise or clear Repair issues for actionable iSolarCloud errors (#153).
+    def _async_raise_repair(self, err: Exception) -> None:
+        """Raise the Repair matching this error's actionable code, if any (#153).
 
-        Called on every poll: creates the matching Repair when a known actionable code
-        occurs and clears the rest, so a recovered plant automatically dismisses its issue.
+        Only *creates* the matching issue; it never clears others, so a transient error
+        (a plain ``TimeoutError`` has no code) can't dismiss a still-valid rate-limit or
+        whitelist Repair. Repairs are cleared only on a successful poll, via
+        :meth:`_async_clear_repairs`.
         """
         code = err.error if isinstance(err, PySolarCloudException) else None
+        if code is None:
+            return
         for key, codes in _REPAIR_CODES.items():
-            issue_id = f"{key}_{self.plant_id}"
             if code in codes:
                 ir.async_create_issue(
                     self.hass,
                     DOMAIN,
-                    issue_id,
+                    f"{key}_{self.plant_id}",
                     is_fixable=False,
                     severity=ir.IssueSeverity.WARNING,
                     translation_key=key,
                     translation_placeholders={"plant": self.plant_name},
                     learn_more_url=_REPAIR_LEARN_MORE,
                 )
-            else:
-                ir.async_delete_issue(self.hass, DOMAIN, issue_id)
+
+    def _async_clear_repairs(self) -> None:
+        """Clear all managed Repair issues — called on a successful poll (#153)."""
+        for key in _REPAIR_CODES:
+            ir.async_delete_issue(self.hass, DOMAIN, f"{key}_{self.plant_id}")
 
     async def _async_maybe_refresh_devices(self) -> None:
         """Refresh the device list periodically rather than on every poll (saves quota).
@@ -385,7 +397,13 @@ class SungrowPlantCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             if self.enable_device_sensors:
                 extra.update(self.extra_measure_points)
                 if type_id in (DeviceType.INVERTER.value, DeviceType.ENERGY_STORAGE_SYSTEM.value):
-                    extra.update(INVERTER_DIAGNOSTIC_POINTS)
+                    diagnostic = INVERTER_DIAGNOSTIC_POINTS
+                    if type_id == DeviceType.ENERGY_STORAGE_SYSTEM.value:
+                        # An ESS reports operating status on 13146 (already requested above);
+                        # drop the inverter point 29 so the two don't collide on the shared
+                        # "operating_status" code and silently overwrite each other (#182).
+                        diagnostic = {pid: code for pid, code in INVERTER_DIAGNOSTIC_POINTS.items() if pid != "29"}
+                    extra.update(diagnostic)
                 if type_id in (DeviceType.BATTERY.value, DeviceType.ENERGY_STORAGE_SYSTEM.value):
                     extra.update(BATTERY_DEVICE_POINTS)
                 # Communication modules report WLAN/wireless signal strength (#149).

--- a/custom_components/sungrow/quality_scale.yaml
+++ b/custom_components/sungrow/quality_scale.yaml
@@ -155,9 +155,10 @@ rules:
     comment: >-
       Developer-Portal whitelist rejections (E918/E919) and API quota/rate-limit
       rejections (E998/E999) surface as actionable Home Assistant Repairs via the
-      coordinator's _async_manage_repairs, and clear automatically once the plant
-      recovers (#153). Invalid/expired credentials are handled separately through
-      the reauthentication flow (ConfigEntryAuthFailed -> async_step_reauth).
+      coordinator's _async_raise_repair, and clear automatically once the plant
+      recovers (_async_clear_repairs on a successful poll) (#153). Invalid/expired
+      credentials are handled separately through the reauthentication flow
+      (ConfigEntryAuthFailed -> async_step_reauth).
   stale-devices:
     status: done
     comment: >-

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -223,6 +223,39 @@ async def test_non_rate_limit_error_does_not_back_off(hass: HomeAssistant):
     assert coordinator.update_interval == base
 
 
+async def test_transient_error_preserves_rate_limit_backoff_and_repair(hass: HomeAssistant):
+    """A transient error during an active rate-limit must not reset the backoff or clear the Repair.
+
+    Regression: a single interleaved ConnectionError/TimeoutError used to snap the
+    interval back to base and dismiss the rate_limited Repair, so the integration
+    immediately resumed 5-minute polling and re-tripped the quota (#153/#156).
+    """
+    plants = MagicMock()
+    plants.async_get_realtime_data = AsyncMock(side_effect=PySolarCloudException.from_response({"result_code": "E999"}))
+    coordinator = SungrowPlantCoordinator(hass, _make_entry({CONF_SCAN_INTERVAL: 300}), plants, "12345", "Test Plant")
+    base = coordinator.update_interval
+    registry = ir.async_get(hass)
+
+    # Rate-limited: back off and raise the Repair.
+    with pytest.raises(UpdateFailed):
+        await coordinator._async_update_data()
+    assert coordinator.update_interval == base * 2
+    assert registry.async_get_issue(DOMAIN, "rate_limited_12345") is not None
+
+    # A transient network error must NOT undo the backoff or clear the Repair.
+    plants.async_get_realtime_data = AsyncMock(side_effect=ConnectionError("blip"))
+    with pytest.raises(UpdateFailed):
+        await coordinator._async_update_data()
+    assert coordinator.update_interval == base * 2
+    assert registry.async_get_issue(DOMAIN, "rate_limited_12345") is not None
+
+    # Only a real success restores the interval and clears the Repair.
+    plants.async_get_realtime_data = AsyncMock(return_value=MOCK_REALTIME_DATA)
+    await coordinator._async_update_data()
+    assert coordinator.update_interval == base
+    assert registry.async_get_issue(DOMAIN, "rate_limited_12345") is None
+
+
 async def test_transient_failure_keeps_last_good_within_grace(hass: HomeAssistant):
     """A brief poll failure keeps the last-good data instead of flapping unavailable (#152)."""
     plants = MagicMock()
@@ -501,6 +534,29 @@ async def test_operating_status_uses_13146_for_ess_when_disabled(hass: HomeAssis
     assert extra == {"13146": "operating_status"}
 
 
+async def test_ess_operating_status_avoids_point29_collision(hass: HomeAssistant):
+    """An ESS with device sensors ON requests 13146 for operating status, not point 29.
+
+    Both 29 and 13146 map to the "operating_status" code, so requesting both would let
+    one silently overwrite the other in the per-device merge, flapping the reason (#182).
+    """
+    plants = MagicMock()
+    plants.async_get_realtime_data = AsyncMock(return_value=MOCK_REALTIME_DATA)
+    plants.async_get_device_realtime = AsyncMock(return_value={})
+    devices = [{"uuid": "ess-1", "device_type": DeviceType.ENERGY_STORAGE_SYSTEM, "ps_key": "12345_14_1_1"}]
+    coordinator = SungrowPlantCoordinator(
+        hass, _make_entry({CONF_ENABLE_DEVICE_SENSORS: True}), plants, "12345", "Test Plant", devices
+    )
+
+    await coordinator._async_update_data()
+
+    extra = plants.async_get_device_realtime.await_args.kwargs["extra_measure_points"]
+    assert extra["13146"] == "operating_status"
+    assert "29" not in extra  # inverter operating-status point dropped for ESS (no collision)
+    # The rest of the inverter diagnostic set is still requested.
+    assert extra["14"] == "total_dc_power"
+
+
 async def test_device_data_best_effort_on_error(hass: HomeAssistant):
     """A failing device type is skipped without failing the whole update."""
     plants = MagicMock()
@@ -634,7 +690,9 @@ async def test_device_data_ess_gets_both_inverter_and_battery_points(hass: HomeA
     await coordinator._async_update_data()
 
     extra = plants.async_get_device_realtime.await_args.kwargs["extra_measure_points"]
-    assert "29" in extra  # inverter operating status
+    assert "13146" in extra  # ESS operating status (inverter point 29 dropped to avoid a collision)
+    assert "29" not in extra
+    assert "14" in extra  # inverter DC power — the rest of the diagnostic set still applies
     assert "58604" in extra  # battery level
 
 


### PR DESCRIPTION
Two robustness bugs surfaced by an audit of the coordinator (both verified against the code + existing tests).

## 1. Transient error wiped the rate-limit backoff & Repair (medium)
On **any** non-auth exception the poll path called `_async_manage_repairs(err)` and `_adjust_poll_backoff(rate_limited=is_rate_limit_error(err))`. For a plain `TimeoutError`/`ConnectionError` the code is `None`, so it:
- **cleared every Repair** (including a still-valid `rate_limited` one), and
- **reset the interval to base**.

So a single transient blip while rate-limited snapped polling back to 5 min and re-tripped the quota — undoing #153/#156.

**Fix:** Repairs/backoff are cleared or reset **only on a successful poll**. Split `_async_manage_repairs` into `_async_raise_repair` (create-only, never clears) for the error path and `_async_clear_repairs` for success; the error path backs off only for genuine rate-limit errors.

## 2. ESS operating-status collision (medium-low, from #182)
An ESS/hybrid with per-device sensors on requested **both** point `29` (from `INVERTER_DIAGNOSTIC_POINTS`) and `13146` (ESS operating status) — both mapping to the `operating_status` code. pysolarcloud keys per-device results by code, so one silently overwrote the other and the Fault reason could flap between polls. **Fix:** drop point `29` for ESS (`13146` is authoritative).

## Deferred (audit findings judged not clear bugs)
- **Device-fetch rate-limit errors are best-effort:** the *next* main poll catches the rate-limit and backs off, and while backed off the failing main poll means the device fetch never runs — so it self-corrects within a cycle.
- **Throttled device/plant-detail refresh rate-limits failures too:** that's a deliberate quota-saving trade-off, not a bug.

## Tests
- New: transient-error-preserves-backoff-and-Repair regression; ESS-avoids-point-29-collision. Updated the ESS both-points test for the fix.
- Existing repair/backoff/whitelist contract tests still pass.
- `ruff` + `format` + `mypy` + full `pytest` (**369 passed**) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)