### PR TITLE
fix: normalise the ℃ unit glyph to °C; record tariff sensors as statistics

### DIFF
--- a/custom_components/sungrow/measure_points.py
+++ b/custom_components/sungrow/measure_points.py
@@ -92,6 +92,23 @@ def _classify_by_unit(unit: str | None) -> _ClassPair | None:
     return _UNIT_CLASS_MAP.get(unit.strip().lower())
 
 
+# iSolarCloud returns some units as single Unicode glyphs — e.g. ``℃`` (U+2103) and
+# ``℉`` (U+2109) — that Home Assistant rejects as invalid for the matching device class
+# ("expected one of ['K', '°F', '°C']"). Normalise them to the canonical HA spelling so
+# the device class stays valid and unit conversion / statistics work.
+_UNIT_ALIASES: dict[str, str] = {
+    "℃": "°C",
+    "℉": "°F",
+}
+
+
+def normalize_unit(unit: str | None) -> str | None:
+    """Return the canonical Home Assistant spelling of an API unit glyph (unchanged if none)."""
+    if not unit:
+        return unit
+    return _UNIT_ALIASES.get(unit.strip(), unit)
+
+
 def resolve_enum_options(point_id: str) -> tuple[str, ...] | None:
     """Return the distinct enum labels for an enum point, else ``None``."""
     mapping = ENUM_MAPS.get(point_id)

--- a/custom_components/sungrow/sensor.py
+++ b/custom_components/sungrow/sensor.py
@@ -23,6 +23,7 @@ from .const import (
 from .coordinator import SungrowPlantCoordinator
 from .measure_points import (
     PERCENT_FRACTION_POINT_IDS,
+    normalize_unit,
     resolve_classification,
     resolve_enum_options,
     resolve_enum_value,
@@ -101,15 +102,23 @@ PLANT_DETAIL_SENSORS: tuple[PlantDetailSensor, ...] = (
         icon="mdi:solar-power",
     ),
     # Import price is money paid (cash-minus); export price is money earned (cash-plus).
+    # MEASUREMENT so the rate is recorded as long-term statistics — useful for
+    # time-of-use / agile tariffs that change through the day.
     PlantDetailSensor(
         "ps_consumption_power_price_kwh",
         "Import Price",
+        state_class=SensorStateClass.MEASUREMENT,
         unit=_CURRENCY_PER_KWH,
         diagnostic=False,
         icon="mdi:cash-minus",
     ),
     PlantDetailSensor(
-        "ps_feedin_power_price_kwh", "Export Price", unit=_CURRENCY_PER_KWH, diagnostic=False, icon="mdi:cash-plus"
+        "ps_feedin_power_price_kwh",
+        "Export Price",
+        state_class=SensorStateClass.MEASUREMENT,
+        unit=_CURRENCY_PER_KWH,
+        diagnostic=False,
+        icon="mdi:cash-plus",
     ),
 )
 
@@ -270,8 +279,10 @@ class SungrowSensor(CoordinatorEntity, SensorEntity):
 
         # Infer device class / state class so the Energy dashboard and history graphs
         # work out of the box (issue #19), including the dimensionless points that
-        # report no unit (SOC, SOH, power factor, PR, counts) (issue #105).
-        unit = init_data.get("unit")
+        # report no unit (SOC, SOH, power factor, PR, counts) (issue #105). The API
+        # sometimes reports a unit as a single Unicode glyph (e.g. ``℃``) that HA
+        # rejects for its device class, so normalise it first.
+        unit = normalize_unit(init_data.get("unit"))
         device_class, state_class = resolve_classification(unit, point_code, point_id)
         self._attr_device_class = device_class
         self._attr_state_class = state_class

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -99,6 +99,20 @@ def test_power_fraction_gets_gauge_icon():
     assert sensor._attr_icon == "mdi:gauge"
 
 
+def test_temperature_unit_glyph_normalized():
+    """The API's ℃ glyph (U+2103) is normalised to HA-valid °C for the temperature class.
+
+    HA rejects the single-glyph ℃ as an invalid unit for the temperature device class
+    ("expected one of ['K', '°F', '°C']"), which logged a warning on every inverter.
+    """
+    point = {"id": "4", "code": "internal_temperature", "value": "57.1", "unit": "℃"}
+    coordinator = _coord_with_devices([], data={"internal_temperature": point})
+    sensor = SungrowSensor(coordinator, "internal_temperature", "123", "Plant", point)
+    assert sensor._attr_native_unit_of_measurement == "°C"
+    assert sensor._attr_device_class == SensorDeviceClass.TEMPERATURE
+    assert sensor.native_value == 57.1
+
+
 def test_sensor_rehomes_to_singular_device():
     """A mapped point re-homes onto the single device of its type; unique_id unchanged."""
     inv = {
@@ -169,6 +183,8 @@ def test_plant_detail_sensor_values_and_units():
     assert price.native_value == 0.3887
     assert price._attr_native_unit_of_measurement == "GBP/kWh"
     assert price._attr_icon == "mdi:cash-minus"
+    # Recorded as statistics so time-of-use tariff changes graph over time.
+    assert price._attr_state_class == SensorStateClass.MEASUREMENT
 
 
 def test_plant_detail_sensor_absent_field_is_none():


### PR DESCRIPTION
Two fixes surfaced by inspecting a **live instance** (SG3.6RS + WiNet-S + SGSmartMeter, HA 2026.1.2).

## 1. Invalid temperature unit `℃` (bug)
The instance logged, on every poll:
> Entity `…inverter_internal_temperature` is using native unit of measurement `℃` which is not a valid unit for the device class ('temperature'); expected one of `['K', '°F', '°C']`

iSolarCloud returns the unit as the **single glyph `℃` (U+2103)**, not `°C` (`°` + `C`). The value read fine (57.1) but HA rejected the unit for the temperature device class, breaking unit conversion and spamming the log. Fix: normalise `℃ → °C` (and `℉ → °F`) when reading the unit. Classification already recognised the glyph — only the native unit string was wrong.

## 2. Tariff sensors weren't recorded as statistics
`Import Price` / `Export Price` are numeric (`GBP/kWh`) but had **no `state_class`**, so they were excluded from long-term statistics. Set `MEASUREMENT` so time-of-use / agile tariffs graph over time.

## Live inspection also confirmed (no action needed)
- **0 unavailable entities**; 66 entities across 4 devices, all healthy.
- The **Fault reason** (#201) works live: the inverter Fault sensor shows `operating_status = "Grid-connected operation"`; meter/comm correctly show `None`.

## Tests
- New: `℃ → °C` normalisation (unit + temperature device class); tariff `state_class == MEASUREMENT`.
- `ruff` + `format` + `mypy` + full `pytest` (**368 passed**) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)