### PR TITLE
fix: mark write-only dispatch controls as assumed_state

### DIFF
--- a/custom_components/sungrow/number.py
+++ b/custom_components/sungrow/number.py
@@ -234,6 +234,11 @@ class SungrowDispatchNumber(CoordinatorEntity[SungrowPlantCoordinator], RestoreN
     """Number entity for a Sungrow dispatch parameter."""
 
     _attr_has_entity_name = True
+    # Dispatch parameters are write-only: the API doesn't read the current setpoint back
+    # (getDevPropertyPointValue is permission-gated), so the value shown is the last one
+    # we commanded — an assumption, not a device reading. Unset until first set/restored,
+    # which correctly reads as "unknown" per HA's entity-unavailable guidance.
+    _attr_assumed_state = True
 
     def __init__(
         self,

--- a/custom_components/sungrow/select.py
+++ b/custom_components/sungrow/select.py
@@ -132,6 +132,9 @@ class SungrowDispatchSelect(CoordinatorEntity[SungrowPlantCoordinator], RestoreE
     """Select entity for a Sungrow dispatch parameter."""
 
     _attr_has_entity_name = True
+    # Write-only: the inverter's current dispatch mode isn't read back from the API, so
+    # the shown option is the last one we commanded — an assumption, not a device reading.
+    _attr_assumed_state = True
 
     def __init__(
         self,

--- a/tests/test_dispatch.py
+++ b/tests/test_dispatch.py
@@ -19,7 +19,7 @@ from custom_components.sungrow import (
     select_dispatch_device,
 )
 from custom_components.sungrow.const import DOMAIN
-from custom_components.sungrow.number import DISPATCH_NUMBERS
+from custom_components.sungrow.number import DISPATCH_NUMBERS, SungrowDispatchNumber
 from custom_components.sungrow.number import async_setup_entry as number_setup_entry
 from custom_components.sungrow.select import DISPATCH_SELECTS
 from custom_components.sungrow.select import async_setup_entry as select_setup_entry
@@ -74,6 +74,31 @@ async def test_number_setup_creates_entities_for_ess_device(hass: HomeAssistant)
     power = next(e for e in added if e.param == "charge_discharge_power")
     assert power._attr_device_class == NumberDeviceClass.POWER
     assert power._attr_native_unit_of_measurement == "W"
+
+
+async def test_dispatch_controls_report_assumed_state(hass: HomeAssistant):
+    """Write-only device controls report assumed_state; the HA-internal timer does not.
+
+    The API doesn't read the current setpoint back (getDevPropertyPointValue is gated),
+    so the value shown is the last one we commanded — an assumption, not a device reading.
+    The forced-dispatch-duration timer is HA-internal, so its value is genuinely known.
+    """
+    entry = MockConfigEntry(domain=DOMAIN, data=MOCK_CONFIG_DATA.copy())
+    entry.add_to_hass(hass)
+    devices = [{"uuid": "dev-uuid-1", "device_type": "ENERGY_STORAGE_SYSTEM", "device_name": "Inverter 1"}]
+    _setup_entry_data(entry, devices)
+
+    numbers: list = []
+    await number_setup_entry(hass, entry, lambda e: numbers.extend(e))
+    selects: list = []
+    await select_setup_entry(hass, entry, lambda e: selects.extend(e))
+
+    # Every device-commanding number is assumed-state; the auto-revert timer is not.
+    for e in numbers:
+        assert e.assumed_state is isinstance(e, SungrowDispatchNumber), type(e).__name__
+    assert selects, "expected dispatch selects for an ESS device"
+    for e in selects:
+        assert e.assumed_state is True
 
 
 def test_select_dispatch_device_matches_all_representations():


### PR DESCRIPTION
Grounded in the HA developer docs (`docs/core/entity.md`): `assumed_state` should be `True` when *"the state is based on our assumption instead of reading it from the device."*

The dispatch **number** and **select** controls are write-only — iSolarCloud doesn't read the current setpoint back (`getDevPropertyPointValue` is permission-gated), so the value HA shows is the **last one we commanded**, not a device reading. Set `_attr_assumed_state = True` on `SungrowDispatchNumber` and `SungrowDispatchSelect` so HA and the UI treat the value as an assumption.

The **forced-dispatch-duration** number is excluded — it's an HA-internal auto-revert timer whose value is genuinely known.

## Context (live inspection)
On a live SG3.6RS the reactive-power controls (`power_factor`, `reactive_power_ratio_q_t`, `reactive_power_mode`) read `unknown` until first set. That is **correct** per HA's `entity-unavailable` rule — *"If we can successfully fetch data but are temporarily missing a few pieces of data, we should mark the entity state as unknown instead"* (of unavailable). So the right refinement is `assumed_state`, **not** hiding or force-defaulting them (which would misrepresent the device).

## Tests
- New: every device-commanding number/select reports `assumed_state=True`; the forced-dispatch-duration timer does not.
- `ruff` + `format` + `mypy` + full `pytest` (**368 passed**) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)