### PR TITLE
fix: harden the EMS heartbeat lifecycle against reload/unload races

### DIFF
--- a/custom_components/sungrow/__init__.py
+++ b/custom_components/sungrow/__init__.py
@@ -358,12 +358,17 @@ async def async_setup_entry(hass: HomeAssistant, entry: SungrowConfigEntry) -> b
 
 async def async_unload_entry(hass: HomeAssistant, entry: SungrowConfigEntry) -> bool:
     """Unload a config entry."""
-    heartbeats = entry.runtime_data.heartbeats
-    for heartbeat in list(heartbeats.values()):
-        await _stop_heartbeat(heartbeat)
-    heartbeats.clear()
-
-    return await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
+    # Unload the platforms first: only tear down the heartbeats if that succeeds. Stopping
+    # them up front would strand an active Charge/Discharge dispatch without its keepalive
+    # (the inverter times out of External-EMS mode) while the entry stays LOADED on a
+    # failed unload.
+    unloaded = await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
+    if unloaded:
+        heartbeats = entry.runtime_data.heartbeats
+        for heartbeat in list(heartbeats.values()):
+            await _stop_heartbeat(heartbeat)
+        heartbeats.clear()
+    return unloaded
 
 
 def _known_device_ids(entry: SungrowConfigEntry) -> set[tuple[str, str]]:
@@ -435,12 +440,6 @@ async def async_start_heartbeat(
     data = entry.runtime_data
     heartbeats = data.heartbeats
 
-    # Stop any existing loop for this plant and wait for it to exit before
-    # starting a new one, so two loops never run for the same device.
-    existing = heartbeats.pop(plant_id, None)
-    if existing is not None:
-        await _stop_heartbeat(existing)
-
     stop_event = asyncio.Event()
     control: Control = data.control
     # Tracked by the config entry so HA cancels it automatically on unload.
@@ -449,7 +448,14 @@ async def async_start_heartbeat(
         control.heartbeat_loop(device_uuid, interval, stop_event),
         name=f"sungrow-heartbeat-{plant_id}",
     )
+    # Publish the new loop into the map BEFORE awaiting the old one's stop, so two
+    # concurrent starts can't interleave across that await and orphan a task (a task
+    # left running but no longer in `heartbeats`). Whichever start runs last owns the
+    # map; every task it displaces is stopped by the displacing call.
+    existing = heartbeats.get(plant_id)
     heartbeats[plant_id] = (stop_event, task)
+    if existing is not None:
+        await _stop_heartbeat(existing)
 
 
 async def async_stop_heartbeat(hass: HomeAssistant, entry: SungrowConfigEntry, plant_id: str) -> None:

--- a/custom_components/sungrow/select.py
+++ b/custom_components/sungrow/select.py
@@ -161,6 +161,9 @@ class SungrowDispatchSelect(CoordinatorEntity[SungrowPlantCoordinator], RestoreE
         # uses these; other selects leave them unset.
         self._revert_cancel: CALLBACK_TYPE | None = None
         self._revert_deadline: float | None = None
+        # Set once the entity is removed (e.g. an entry reload) so an already-fired
+        # auto-revert task doesn't act on the plant after this instance is gone (#157).
+        self._removed = False
 
     async def async_added_to_hass(self) -> None:
         """Restore the last selected option across restarts.
@@ -200,6 +203,7 @@ class SungrowDispatchSelect(CoordinatorEntity[SungrowPlantCoordinator], RestoreE
 
     async def async_will_remove_from_hass(self) -> None:
         """Cancel the auto-revert timer when the command select is removed."""
+        self._removed = True
         self._cancel_revert()
         await super().async_will_remove_from_hass()
 
@@ -290,6 +294,11 @@ class SungrowDispatchSelect(CoordinatorEntity[SungrowPlantCoordinator], RestoreE
 
     async def _do_revert(self) -> None:
         """Revert a forced Charge/Discharge to Stop and stop the heartbeat (#157)."""
+        if self._removed:
+            # The timer fired, but the entity was removed (e.g. an entry reload) before
+            # this task ran. Acting now would stop a freshly-restored heartbeat and write
+            # state on a dead entity, so bail out — the new instance owns the heartbeat.
+            return
         _LOGGER.info("Forced-dispatch timeout for %s: reverting to Stop", self.device_uuid)
         stop_option = "Stop"
         try:

--- a/tests/test_dispatch.py
+++ b/tests/test_dispatch.py
@@ -958,6 +958,39 @@ async def test_autorevert_writes_stop_and_stops_heartbeat(hass: HomeAssistant):
     assert command._revert_deadline is None
 
 
+async def test_autorevert_after_removal_is_noop(hass: HomeAssistant):
+    """A revert task firing after the entity is removed must not touch the plant (#157).
+
+    On an entry reload the auto-revert timer can fire before the queued _do_revert runs;
+    acting then would stop the freshly-restored heartbeat and write state on a dead entity.
+    """
+    from homeassistant.helpers.update_coordinator import CoordinatorEntity
+
+    entry = MockConfigEntry(domain=DOMAIN, data=MOCK_CONFIG_DATA.copy())
+    entry.add_to_hass(hass)
+    data = _setup_entry_data(entry, [{"uuid": "ess-1", "device_type": "ENERGY_STORAGE_SYSTEM"}])
+
+    added: list = []
+    await select_setup_entry(hass, entry, lambda e: added.extend(e))
+    command = next(e for e in added if e.param == "charge_discharge_command")
+    command.hass = hass
+    command.async_write_ha_state = MagicMock()
+    command._attr_current_option = "Charge"
+
+    # Removal (e.g. an entry reload) sets the guard flag.
+    with patch.object(CoordinatorEntity, "async_will_remove_from_hass", new=AsyncMock()):
+        await command.async_will_remove_from_hass()
+    assert command._removed is True
+
+    with patch("custom_components.sungrow.select.async_stop_heartbeat", new=AsyncMock()) as mock_stop:
+        await command._do_revert()
+
+    # No effect on the plant: heartbeat untouched, no Stop written, no state write.
+    mock_stop.assert_not_awaited()
+    data.control.async_update_parameters.assert_not_awaited()
+    command.async_write_ha_state.assert_not_called()
+
+
 async def test_restored_command_reverts_when_deadline_passed(hass: HomeAssistant):
     """A forced command whose deadline passed while HA was down reverts to Stop on restore."""
     import time

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -18,6 +18,7 @@ from custom_components.sungrow import (
     async_setup,
     async_start_heartbeat,
     async_stop_heartbeat,
+    async_unload_entry,
     resolve_point_device,
 )
 from custom_components.sungrow.const import CONF_SCAN_INTERVAL, DOMAIN
@@ -213,6 +214,31 @@ async def test_unload_cancels_running_heartbeat(hass: HomeAssistant, mock_setup_
 
     assert stop_event.is_set()
     assert task.done()
+
+
+async def test_unload_keeps_heartbeat_when_platform_unload_fails(
+    hass: HomeAssistant, mock_setup_auth, mock_plants_service
+):
+    """A failed platform unload leaves the heartbeats running (the entry stays LOADED)."""
+    entry = MockConfigEntry(domain=DOMAIN, data=MOCK_CONFIG_DATA.copy(), unique_id="test_app_id")
+    entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+
+    stop_event = asyncio.Event()
+    task = entry.async_create_background_task(hass, stop_event.wait(), name="test-heartbeat")
+    entry.runtime_data.heartbeats["12345"] = (stop_event, task)
+
+    with patch.object(hass.config_entries, "async_unload_platforms", new=AsyncMock(return_value=False)):
+        result = await async_unload_entry(hass, entry)
+
+    assert result is False
+    # Heartbeat untouched: not stopped, still tracked — dispatch keepalive survives.
+    assert not stop_event.is_set()
+    assert "12345" in entry.runtime_data.heartbeats
+
+    stop_event.set()
+    await task  # clean up the lingering task
 
 
 async def test_setup_entry_no_tokens_triggers_reauth(hass: HomeAssistant, mock_setup_auth, mock_plants_service):


### PR DESCRIPTION
Three issues found in a focused audit of the dispatch EMS-heartbeat lifecycle (`__init__.py` + `select.py`), verified against the code and existing tests.

## 1. Auto-revert can stop a freshly-restored heartbeat after a reload (the dispatch footgun)
`_handle_revert` is a `@callback` that fire-and-forgets an **untracked** `_do_revert` task. Sequence: forced Charge with auto-revert → timer fires → `_do_revert` queued → **entry reload** unloads/reloads before it runs → the *old* entity's `_do_revert` calls `async_stop_heartbeat` on the **new** heartbeat (inverter silently drops out of External-EMS mode while the UI still shows Charge) and `async_write_ha_state()` on a removed entity (HA error). **Fix:** a `_removed` flag set in `async_will_remove_from_hass` makes a late `_do_revert` no-op — the new instance owns the heartbeat.

## 2. Concurrent `async_start_heartbeat` could orphan a task
It awaited the old loop's stop *between* popping and re-inserting into the `heartbeats` map, so two interleaved starts could leave a task running but untracked. **Fix:** publish the new loop into the map **before** awaiting the old stop. (Low — callers are serialised by `PARALLEL_UPDATES=1`; the orphan was still entry-tracked so unload cancelled it — but the reorder is free.)

## 3. `async_unload_entry` tore down heartbeats before knowing the unload succeeded
It stopped+cleared the heartbeats first, then unloaded platforms. A failed platform unload left the entry `LOADED` with the keepalive gone → active dispatch silently times out. **Fix:** unload platforms first; only tear down heartbeats when that returns truthy.

## Verified clean (not touched)
Shared-heartbeat-not-stopped-on-single-entity-removal (intentional, #112), token persistence, the callback-view registration, and partial-setup safety.

## Tests
- New: late `_do_revert` after removal is a no-op; failed platform unload keeps the heartbeat tracked.
- Existing heartbeat/unload/revert contract tests still pass.
- `ruff` + `format` + `mypy` + full `pytest` (**369 passed**) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)