### PR TITLE
fix: never log the OAuth authorization code or raw callback params

### DIFF
--- a/custom_components/sungrow/__init__.py
+++ b/custom_components/sungrow/__init__.py
@@ -506,10 +506,14 @@ class SungrowAuthCallbackView(HomeAssistantView):
         state = params.get("state")
 
         if not code:
-            _LOGGER.warning("Callback received but missing code. Params: %s", params)
+            # Log only the parameter *names* — never their values. An external redirect
+            # could carry sensitive values, and users are told to enable debug logging.
+            _LOGGER.warning("Callback received but missing 'code'. Query params present: %s", list(params))
             return web.Response(text="Missing code parameter. Please try again.", status=400)
 
-        _LOGGER.debug("Callback received with code: %s, flow_id: %s, state: %s", code, flow_id, state)
+        # Never log the authorization code — it's a single-use credential that exchanges
+        # for tokens (mirrors the rule in config_flow.async_step_finish). Presence is implied.
+        _LOGGER.debug("Callback received with an authorization code (flow_id=%s, state=%s)", flow_id, state)
 
         # Signal the waiting future so the config flow's background task can
         # resume the flow cleanly.

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -517,6 +517,26 @@ class TestSungrowAuthCallbackView:
         assert future.done()
         assert future.result() == "auth_code_123"
 
+    async def test_callback_never_logs_the_authorization_code(self, hass: HomeAssistant, caplog):
+        """The authorization code is a credential and must never appear in logs.
+
+        Users are told to enable debug logging when troubleshooting, so a code logged
+        at debug would end up in the logs they share.
+        """
+        import asyncio
+        import logging
+
+        future: asyncio.Future[str] = asyncio.Future()
+        hass.data.setdefault("sungrow", {})["flows"] = {"flow_abc": future}
+        secret_code = "SUPER-SECRET-AUTH-CODE-xyz"
+        mock_request = make_mocked_request("GET", f"/api/sungrow_hass/callback?code={secret_code}&flow_id=flow_abc")
+        mock_request.app["hass"] = hass
+
+        with caplog.at_level(logging.DEBUG, logger="custom_components.sungrow"):
+            await self.view.get(mock_request)
+
+        assert secret_code not in caplog.text
+
     async def test_callback_flow_not_found(self, hass: HomeAssistant):
         """Test callback returns 400 when no pending flow future exists."""
         mock_request = make_mocked_request("GET", "/api/sungrow_hass/callback?code=auth_code&flow_id=bad_flow")


### PR DESCRIPTION
Follow-up to #210 (this commit was pushed just after that PR merged, so it didn't land).

The OAuth callback view logged the **authorization code** at debug and the full callback query params at warning. The code is a single-use credential that exchanges for tokens, and the troubleshooting guide tells users to enable debug logging — so it would land in the logs they share, contradicting `config_flow`'s own "never log the authorization code or tokens" rule.

Now logs only that a code arrived (with `flow_id`/`state` for correlation), and on a missing-code callback logs the parameter **names** only — never their values. Regression test asserts the code value never appears in the logs.

`ruff` + `format` + `mypy` + full `pytest` (**374 passed**) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)