### PR TITLE
feat: local Modbus client + SG-RS register map (#159 phase 1)

### DIFF
--- a/custom_components/sungrow/modbus.py
+++ b/custom_components/sungrow/modbus.py
@@ -1,0 +1,80 @@
+"""Local Modbus transport for Sungrow inverters via the WiNet-S dongle (#159).
+
+Reads realtime data straight from the inverter over Modbus TCP instead of (or
+alongside) the iSolarCloud API — fast (~10 ms), unmetered, and offline-capable.
+Holds a single persistent connection and serialises reads: the WiNet-S is happiest
+with one Modbus conversation at a time. The decoded output matches the cloud
+transport's ``{code: {value, unit, ...}}`` shape (tagged ``source="modbus"``) so both
+sources feed the same entities.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from typing import Any
+
+from pymodbus.client import AsyncModbusTcpClient
+
+from .modbus_registers import REGISTER_MAPS, block_bounds, decode_registers
+
+_LOGGER = logging.getLogger(__name__)
+
+DEFAULT_PORT = 502
+DEFAULT_UNIT = 1
+CONNECT_TIMEOUT = 5
+
+
+class SungrowModbusError(Exception):
+    """A local Modbus connection or read failed."""
+
+
+class SungrowModbusClient:
+    """Read realtime data from one Sungrow inverter over local Modbus TCP."""
+
+    def __init__(
+        self,
+        host: str,
+        *,
+        port: int = DEFAULT_PORT,
+        unit: int = DEFAULT_UNIT,
+        model: str = "sg_rs",
+    ) -> None:
+        """Initialize the client for a WiNet-S host (one inverter)."""
+        self.host = host
+        self.port = port
+        self.unit = unit
+        self.model = model
+        self._client = AsyncModbusTcpClient(host, port=port, timeout=CONNECT_TIMEOUT)
+        # Serialise reads onto the single connection the WiNet-S expects.
+        self._lock = asyncio.Lock()
+
+    async def async_read_realtime(self) -> dict[str, dict[str, Any]]:
+        """Read and decode the model's realtime input registers.
+
+        Returns ``{code: {"code", "value", "unit", "source": "modbus"}}``. Raises
+        :class:`SungrowModbusError` on connection/read failure so the caller can fall
+        back to the cloud transport.
+        """
+        points = REGISTER_MAPS.get(self.model)
+        if not points:
+            raise SungrowModbusError(f"No Modbus register map for model {self.model!r}")
+        start, count = block_bounds(points)
+        async with self._lock:
+            registers = await self._read_input(start, count)
+        return decode_registers(points, start, registers)
+
+    async def _read_input(self, address: int, count: int) -> list[int]:
+        """Read a contiguous input-register block, connecting/reconnecting as needed."""
+        if not self._client.connected and not await self._client.connect():
+            raise SungrowModbusError(f"Could not connect to {self.host}:{self.port}")
+        result = await self._client.read_input_registers(address, count=count, device_id=self.unit)
+        if result.isError():
+            # Drop the connection so the next read reconnects cleanly.
+            self._client.close()
+            raise SungrowModbusError(f"Modbus read at {address} (count {count}) failed: {result}")
+        return list(result.registers)
+
+    def close(self) -> None:
+        """Close the underlying connection."""
+        self._client.close()

--- a/custom_components/sungrow/modbus_registers.py
+++ b/custom_components/sungrow/modbus_registers.py
@@ -1,0 +1,112 @@
+"""Sungrow WiNet-S local Modbus register maps (#159).
+
+Maps documented Sungrow Modbus registers to the same measure-point **codes** the
+cloud transport emits, so entities are identical regardless of which source a value
+comes from. Addresses here are the **on-the-wire** address, which is the documented
+register number minus one (doc 5000 -> wire 4999). 32-bit values are low-word-first.
+
+The SG-RS input-register set below was validated against a live SG3.6RS + WiNet-S.
+Other models (SH hybrids, larger three-phase inverters) add their own maps, selected
+at runtime by the device-type code in register 5000.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+# Modbus function codes.
+FUNC_INPUT = 4  # read input registers (readings)
+FUNC_HOLDING = 3  # read holding registers (config/control)
+
+
+@dataclass(frozen=True)
+class ModbusPoint:
+    """One decoded value read from the inverter over Modbus.
+
+    ``address`` is the on-the-wire register address (documented number - 1).
+    ``code`` matches the cloud transport's measure-point code so both sources feed
+    the same entity. ``data_type`` is one of ``u16``/``s16``/``u32``/``s32``;
+    32-bit types consume two registers (low word first). The displayed value is the
+    raw register value multiplied by ``scale``.
+    """
+
+    address: int
+    code: str
+    data_type: str
+    scale: float
+    unit: str | None = None
+
+    @property
+    def register_count(self) -> int:
+        """Number of 16-bit registers this point occupies (1 or 2)."""
+        return 2 if self.data_type in ("u32", "s32") else 1
+
+
+# String-inverter (SG-RS) input registers — Modbus function 0x04. Codes are reused
+# from the cloud/diagnostic point set so a value read locally lands on the same
+# entity as its cloud counterpart.
+SG_RS_INPUT_POINTS: tuple[ModbusPoint, ...] = (
+    ModbusPoint(4999, "device_type_code", "u16", 1, None),
+    ModbusPoint(5002, "daily_yield", "u16", 0.1, "kWh"),
+    ModbusPoint(5003, "total_yield", "u32", 1, "kWh"),
+    ModbusPoint(5007, "internal_temperature", "s16", 0.1, "°C"),
+    ModbusPoint(5010, "mppt1_voltage", "u16", 0.1, "V"),
+    ModbusPoint(5011, "mppt1_current", "u16", 0.1, "A"),
+    ModbusPoint(5012, "mppt2_voltage", "u16", 0.1, "V"),
+    ModbusPoint(5013, "mppt2_current", "u16", 0.1, "A"),
+    ModbusPoint(5016, "total_dc_power", "u32", 1, "W"),
+    ModbusPoint(5018, "phase_a_voltage", "u16", 0.1, "V"),
+    ModbusPoint(5030, "total_active_power", "s32", 1, "W"),
+    ModbusPoint(5035, "grid_frequency", "u16", 0.1, "Hz"),
+)
+
+# Register maps keyed by inverter family. Extended per-model as they're validated.
+REGISTER_MAPS: dict[str, tuple[ModbusPoint, ...]] = {
+    "sg_rs": SG_RS_INPUT_POINTS,
+}
+
+
+def decode_registers(
+    points: tuple[ModbusPoint, ...], block_start: int, registers: list[int]
+) -> dict[str, dict[str, Any]]:
+    """Decode a contiguous input-register block into ``{code: {value, unit, ...}}``.
+
+    ``registers`` is the raw 16-bit values read starting at ``block_start``. Each
+    point is decoded from its offset within the block; a point that falls outside the
+    block is skipped. The returned shape mirrors the cloud transport's per-point dict
+    (``code``/``value``/``unit``) plus a ``source`` marker so the origin is accountable.
+    """
+    out: dict[str, dict[str, Any]] = {}
+    for point in points:
+        offset = point.address - block_start
+        if offset < 0 or offset + point.register_count > len(registers):
+            continue
+        raw = _combine(registers, offset, point.data_type)
+        out[point.code] = {
+            "code": point.code,
+            "value": round(raw * point.scale, 3),
+            "unit": point.unit,
+            "source": "modbus",
+        }
+    return out
+
+
+def _combine(registers: list[int], offset: int, data_type: str) -> int:
+    """Combine one/two registers into a signed/unsigned integer (32-bit low word first)."""
+    if data_type in ("u32", "s32"):
+        value = registers[offset] + (registers[offset + 1] << 16)
+        bits = 32
+    else:
+        value = registers[offset]
+        bits = 16
+    if data_type in ("s16", "s32") and value >= (1 << (bits - 1)):
+        value -= 1 << bits
+    return value
+
+
+def block_bounds(points: tuple[ModbusPoint, ...]) -> tuple[int, int]:
+    """Return ``(start_address, count)`` covering every point in one contiguous read."""
+    start = min(p.address for p in points)
+    end = max(p.address + p.register_count for p in points)
+    return start, end - start

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -11,3 +11,4 @@ mypy==2.1.0
 
 # Component dependencies
 sungrow-isolarcloud==0.10.3
+pymodbus==3.13.1

--- a/tests/test_modbus.py
+++ b/tests/test_modbus.py
@@ -1,0 +1,160 @@
+"""Tests for the local Modbus transport (#159)."""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from custom_components.sungrow.modbus import SungrowModbusClient, SungrowModbusError
+from custom_components.sungrow.modbus_registers import (
+    SG_RS_INPUT_POINTS,
+    ModbusPoint,
+    block_bounds,
+    decode_registers,
+)
+
+# ---------------------------------------------------------------------------
+# Register decoding (pure functions)
+# ---------------------------------------------------------------------------
+
+
+def test_decode_types_and_scales():
+    """u16/s16/u32/s32 decode with the right sign, word order (low first) and scale."""
+    points = (
+        ModbusPoint(0, "u16_scaled", "u16", 0.1, "Hz"),
+        ModbusPoint(1, "s16_neg", "s16", 0.1, "°C"),
+        ModbusPoint(2, "u32_low_first", "u32", 1, "Wh"),
+        ModbusPoint(4, "s32_neg", "s32", 1, "W"),
+    )
+    # u16=499 -> 49.9 ; s16=65486 (=-50) -> -5.0 ; u32=[300,1] -> 300+65536 ; s32=[0,0xFFFF]=-65536
+    registers = [499, 65486, 300, 1, 0, 0xFFFF]
+    out = decode_registers(points, 0, registers)
+    assert out["u16_scaled"]["value"] == 49.9
+    assert out["s16_neg"]["value"] == -5.0
+    assert out["u32_low_first"]["value"] == 300 + 65536
+    assert out["s32_neg"]["value"] == -65536
+    # Shape matches the cloud transport + carries the source marker.
+    assert out["u16_scaled"] == {"code": "u16_scaled", "value": 49.9, "unit": "Hz", "source": "modbus"}
+
+
+def test_decode_skips_points_outside_the_block():
+    """A point whose registers fall outside the read block is skipped, not mis-decoded."""
+    points = (ModbusPoint(10, "in", "u16", 1, None), ModbusPoint(99, "out", "u16", 1, None))
+    out = decode_registers(points, 10, [42])
+    assert "in" in out and out["in"]["value"] == 42
+    assert "out" not in out
+
+
+def test_block_bounds_covers_all_points_in_one_read():
+    """block_bounds spans from the lowest address to past the highest (incl. 32-bit width)."""
+    start, count = block_bounds(SG_RS_INPUT_POINTS)
+    assert start == 4999  # device_type_code
+    # Highest point is grid_frequency at 5035 (1 register) -> end 5036.
+    assert start + count == 5036
+    assert count == 37
+
+
+def test_sg_rs_map_decodes_a_realistic_frame():
+    """A realistic SG-RS input-register frame decodes to sane, correctly-scaled values."""
+    start, count = block_bounds(SG_RS_INPUT_POINTS)
+    regs = [0] * count
+
+    def put(addr, *values):
+        for i, v in enumerate(values):
+            regs[addr - start + i] = v
+
+    put(4999, 9732)  # device type
+    put(5002, 389)  # daily yield 38.9 kWh
+    put(5003, 6305, 0)  # total yield 6305 kWh (u32 low-first)
+    put(5007, 472)  # internal temp 47.2 C
+    put(5016, 300, 0)  # total DC power 300 W
+    put(5018, 2404)  # phase A voltage 240.4 V
+    put(5030, 259, 0)  # total active power 259 W
+    put(5035, 499)  # grid frequency 49.9 Hz
+
+    out = decode_registers(SG_RS_INPUT_POINTS, start, regs)
+    assert out["daily_yield"]["value"] == 38.9
+    assert out["total_yield"]["value"] == 6305
+    assert out["internal_temperature"]["value"] == 47.2
+    assert out["total_dc_power"]["value"] == 300
+    assert out["phase_a_voltage"]["value"] == 240.4
+    assert out["total_active_power"]["value"] == 259
+    assert out["grid_frequency"]["value"] == 49.9  # regression: scale is ×0.1, not ×0.01
+
+
+# ---------------------------------------------------------------------------
+# SungrowModbusClient (pymodbus mocked)
+# ---------------------------------------------------------------------------
+
+
+def _mock_client_cls(registers, *, connected=True, connect_ok=True, is_error=False):
+    """Patch AsyncModbusTcpClient with a stub whose read returns ``registers``."""
+    inner = MagicMock()
+    inner.connected = connected
+    inner.connect = AsyncMock(return_value=connect_ok)
+    result = MagicMock()
+    result.isError.return_value = is_error
+    result.registers = registers
+    inner.read_input_registers = AsyncMock(return_value=result)
+    inner.close = MagicMock()
+    cls = MagicMock(return_value=inner)
+    return cls, inner
+
+
+async def test_read_realtime_returns_decoded_points():
+    """A successful read yields the decoded SG-RS points tagged source=modbus."""
+    start, count = block_bounds(SG_RS_INPUT_POINTS)
+    regs = [0] * count
+    regs[5035 - start] = 499  # grid frequency
+    cls, inner = _mock_client_cls(regs)
+    with patch("custom_components.sungrow.modbus.AsyncModbusTcpClient", cls):
+        client = SungrowModbusClient("10.0.0.1", unit=1)
+        data = await client.async_read_realtime()
+    assert data["grid_frequency"]["value"] == 49.9
+    assert data["grid_frequency"]["source"] == "modbus"
+    inner.read_input_registers.assert_awaited_once()
+
+
+async def test_read_connects_when_not_connected():
+    """The client connects before reading if the socket isn't up yet."""
+    cls, inner = _mock_client_cls([0] * block_bounds(SG_RS_INPUT_POINTS)[1], connected=False)
+    with patch("custom_components.sungrow.modbus.AsyncModbusTcpClient", cls):
+        await SungrowModbusClient("10.0.0.1").async_read_realtime()
+    inner.connect.assert_awaited_once()
+
+
+async def test_connect_failure_raises():
+    """A failed connect raises SungrowModbusError."""
+    cls, _ = _mock_client_cls([], connected=False, connect_ok=False)
+    with (
+        patch("custom_components.sungrow.modbus.AsyncModbusTcpClient", cls),
+        pytest.raises(SungrowModbusError, match="Could not connect"),
+    ):
+        await SungrowModbusClient("10.0.0.1").async_read_realtime()
+
+
+async def test_read_error_raises_and_drops_connection():
+    """A Modbus error result raises and closes the connection so the next read reconnects."""
+    cls, inner = _mock_client_cls([0] * 37, is_error=True)
+    with (
+        patch("custom_components.sungrow.modbus.AsyncModbusTcpClient", cls),
+        pytest.raises(SungrowModbusError, match="failed"),
+    ):
+        await SungrowModbusClient("10.0.0.1").async_read_realtime()
+    inner.close.assert_called_once()
+
+
+async def test_unknown_model_raises():
+    """An unmapped model raises rather than silently returning nothing."""
+    cls, _ = _mock_client_cls([])
+    with patch("custom_components.sungrow.modbus.AsyncModbusTcpClient", cls):
+        client = SungrowModbusClient("10.0.0.1", model="sh_hybrid_not_yet_mapped")
+        with pytest.raises(SungrowModbusError, match="register map"):
+            await client.async_read_realtime()
+
+
+async def test_read_passes_configured_unit_as_device_id():
+    """The configured unit id is forwarded to pymodbus as device_id."""
+    cls, inner = _mock_client_cls([0] * block_bounds(SG_RS_INPUT_POINTS)[1])
+    with patch("custom_components.sungrow.modbus.AsyncModbusTcpClient", cls):
+        await SungrowModbusClient("10.0.0.1", unit=3).async_read_realtime()
+    assert inner.read_input_registers.await_args.kwargs["device_id"] == 3


### PR DESCRIPTION
First building block for the optional local Modbus (WiNet-S) transport (#159). Standalone, tested, and **live-validated against a real SG3.6RS + WiNet-S** — not wired into the config flow / coordinator yet (that's the next phase with the transport modes + per-device source merge + config-flow rework).

## What's here
- **`modbus_registers.py`** — `ModbusPoint` + the SG-RS input-register map. Each register maps to the **same measure-point `code` the cloud emits**, so a value read locally lands on the same entity. Addresses are on-the-wire (doc reg − 1); 32-bit values low-word-first. `decode_registers()` returns the cloud's `{code: {value, unit, ...}}` shape **plus `source="modbus"`** so provenance is accountable.
- **`modbus.py`** — `SungrowModbusClient` over `pymodbus` `AsyncModbusTcpClient`: one persistent, serialized connection, one block read per poll, reconnect on error.

## Live validation
Ran the actual client against the inverter — all 12 points decode correctly (daily 38.9 kWh, temp 47.2 °C, MPPT2 390 V / 0.7 A, DC 300 W, AC 259 W, 240.4 V, **grid 49.9 Hz**). Live-testing caught the grid-frequency scale (×0.1, not ×0.01) — now regression-tested.

## Tests
Decode types/scales/word-order, block bounds, a realistic SG-RS frame, and the client (connect, read, error→reconnect, unknown model, unit→device_id). `ruff` + `format` + `mypy` + full `pytest` (**383 passed**) green.

Part of #159.

🤖 Generated with [Claude Code](https://claude.com/claude-code)