### PR TITLE
feat: opt-in local Modbus transport with cloud merge (#159 phase 2)

### DIFF
--- a/custom_components/sungrow/config_flow.py
+++ b/custom_components/sungrow/config_flow.py
@@ -20,6 +20,7 @@ from .const import (
     CONF_ENABLE_DEVICE_SENSORS,
     CONF_EXTRA_MEASURE_POINTS,
     CONF_GATEWAY,
+    CONF_MODBUS_HOST,
     CONF_REDIRECT_URI,
     CONF_SCAN_INTERVAL,
     DEFAULT_SCAN_INTERVAL,
@@ -525,11 +526,14 @@ class SungrowOptionsFlow(config_entries.OptionsFlowWithReload):
                 _LOGGER.warning("Invalid extra measure points input: %s", exc)
             else:
                 data = {**user_input, CONF_EXTRA_MEASURE_POINTS: extras}
+                # Normalise the Modbus host; blank/whitespace means "cloud only".
+                data[CONF_MODBUS_HOST] = (user_input.get(CONF_MODBUS_HOST) or "").strip()
                 return self.async_create_entry(title="", data=data)
 
         current_interval = self.config_entry.options.get(CONF_SCAN_INTERVAL, DEFAULT_SCAN_INTERVAL)
         current_extras = self.config_entry.options.get(CONF_EXTRA_MEASURE_POINTS, {})
         current_device_sensors = self.config_entry.options.get(CONF_ENABLE_DEVICE_SENSORS, False)
+        current_modbus_host = self.config_entry.options.get(CONF_MODBUS_HOST, "")
         extras_str = ",".join(f"{pid}={code}" for pid, code in current_extras.items())
         return self.async_show_form(
             step_id="init",
@@ -545,6 +549,12 @@ class SungrowOptionsFlow(config_entries.OptionsFlowWithReload):
                         description={"suggested_value": extras_str},
                     ): str,
                     vol.Optional(CONF_ENABLE_DEVICE_SENSORS, default=current_device_sensors): bool,
+                    # Optional local Modbus transport (#159): the WiNet-S IP/host. Empty = cloud only.
+                    vol.Optional(
+                        CONF_MODBUS_HOST,
+                        default=current_modbus_host,
+                        description={"suggested_value": current_modbus_host},
+                    ): str,
                 }
             ),
             errors=errors,

--- a/custom_components/sungrow/const.py
+++ b/custom_components/sungrow/const.py
@@ -16,6 +16,14 @@ CONF_EXTRA_MEASURE_POINTS = "extra_measure_points"
 # own realtime points and expose them as sensors under that device. Off by default
 # to avoid extra API calls / entity clutter for users who only need plant data.
 CONF_ENABLE_DEVICE_SENSORS = "enable_device_sensors"
+# Opt-in local Modbus transport (#159): the WiNet-S dongle's IP/host. When set, the
+# coordinator reads fast local values over Modbus TCP and merges them over the cloud
+# data (Modbus preferred). Empty -> cloud only (default). Port/unit default to 502/1.
+CONF_MODBUS_HOST = "modbus_host"
+CONF_MODBUS_PORT = "modbus_port"
+CONF_MODBUS_UNIT = "modbus_unit"
+DEFAULT_MODBUS_PORT = 502
+DEFAULT_MODBUS_UNIT = 1
 
 GATEWAYS = {
     "Europe": "https://gateway.isolarcloud.eu",

--- a/custom_components/sungrow/coordinator.py
+++ b/custom_components/sungrow/coordinator.py
@@ -21,7 +21,12 @@ from .const import (
     COMM_MODULE_POINTS,
     CONF_ENABLE_DEVICE_SENSORS,
     CONF_EXTRA_MEASURE_POINTS,
+    CONF_MODBUS_HOST,
+    CONF_MODBUS_PORT,
+    CONF_MODBUS_UNIT,
     CONF_SCAN_INTERVAL,
+    DEFAULT_MODBUS_PORT,
+    DEFAULT_MODBUS_UNIT,
     DEFAULT_SCAN_INTERVAL,
     DEVICE_REFRESH_INTERVAL,
     DOMAIN,
@@ -190,6 +195,25 @@ class SungrowPlantCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         # persist and curtail PV (#157/#148). 0 disables auto-revert (legacy behaviour).
         # Owned by the "Forced Dispatch Duration" number; read by the command select.
         self.forced_dispatch_duration_minutes: float = 0
+        # Optional local Modbus transport (#159): when a WiNet-S host is configured, the
+        # coordinator reads fast local values and merges them over the cloud data
+        # (Modbus preferred). None -> cloud only. Built lazily to avoid importing
+        # pymodbus for cloud-only installs.
+        self._modbus_client = self._build_modbus_client(config_entry)
+
+    @staticmethod
+    def _build_modbus_client(config_entry: ConfigEntry) -> Any:
+        """Return a SungrowModbusClient if a Modbus host is configured, else None."""
+        host = config_entry.options.get(CONF_MODBUS_HOST)
+        if not host:
+            return None
+        from .modbus import SungrowModbusClient
+
+        return SungrowModbusClient(
+            str(host),
+            port=int(config_entry.options.get(CONF_MODBUS_PORT, DEFAULT_MODBUS_PORT)),
+            unit=int(config_entry.options.get(CONF_MODBUS_UNIT, DEFAULT_MODBUS_UNIT)),
+        )
 
     async def _async_update_data(self) -> dict[str, Any]:
         """Fetch data from the API for this plant."""
@@ -243,7 +267,27 @@ class SungrowPlantCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         self.device_data = await self._async_fetch_device_data()
 
         # pysolarcloud is untyped, so the realtime payload is Any.
-        return cast("dict[str, Any]", all_plants_data.get(self.plant_id, {}))
+        cloud_data = cast("dict[str, Any]", all_plants_data.get(self.plant_id, {}))
+        # Overlay fast local Modbus values (Modbus preferred) when configured (#159).
+        return await self._async_apply_modbus(cloud_data)
+
+    async def _async_apply_modbus(self, cloud_data: dict[str, Any]) -> dict[str, Any]:
+        """Overlay live Modbus values onto the cloud data (Modbus preferred), if configured.
+
+        Best-effort: any Modbus failure keeps the cloud data, so the local transport can
+        never take the plant offline — it only ever supplies fresher values.
+        """
+        if self._modbus_client is None:
+            return cloud_data
+        from .modbus import merge_realtime
+
+        try:
+            async with asyncio.timeout(self._poll_timeout):
+                local = await self._modbus_client.async_read_realtime()
+        except Exception as err:  # pylint: disable=broad-except  (best-effort: fall back to cloud)
+            _LOGGER.debug("Local Modbus read failed for %s; using cloud data: %s", self.plant_name, err)
+            return cloud_data
+        return merge_realtime(cloud_data, local)
 
     def _within_availability_grace(self) -> bool:
         """True while the last successful poll is recent enough to keep serving stale data."""

--- a/custom_components/sungrow/manifest.json
+++ b/custom_components/sungrow/manifest.json
@@ -13,11 +13,13 @@
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/KRoperUK/sungrow-hass/issues",
   "loggers": [
+    "pymodbus",
     "pysolarcloud"
   ],
   "quality_scale": "platinum",
   "requirements": [
-    "sungrow-isolarcloud==0.10.3"
+    "sungrow-isolarcloud==0.10.3",
+    "pymodbus>=3.6.0"
   ],
   "version": "3.4.1"
 }

--- a/custom_components/sungrow/modbus.py
+++ b/custom_components/sungrow/modbus.py
@@ -29,6 +29,28 @@ class SungrowModbusError(Exception):
     """A local Modbus connection or read failed."""
 
 
+def merge_realtime(cloud: dict[str, dict[str, Any]], modbus: dict[str, dict[str, Any]]) -> dict[str, dict[str, Any]]:
+    """Merge cloud and local-Modbus realtime, **Modbus preferred**, tagging provenance.
+
+    The cloud provides the structure (each point's ``id``/``name``, used for naming and
+    enum/device-class resolution) and any points Modbus doesn't expose; where both carry
+    a code, the live Modbus value (and its unit) win. Every returned point carries a
+    ``source`` (``"cloud"`` or ``"modbus"``) so the origin of each reading is accountable.
+    """
+    merged: dict[str, dict[str, Any]] = {code: {**point, "source": "cloud"} for code, point in cloud.items()}
+    for code, mpoint in modbus.items():
+        if code in merged:
+            merged[code] = {
+                **merged[code],
+                "value": mpoint["value"],
+                "unit": mpoint.get("unit") or merged[code].get("unit"),
+                "source": "modbus",
+            }
+        else:
+            merged[code] = dict(mpoint)
+    return merged
+
+
 class SungrowModbusClient:
     """Read realtime data from one Sungrow inverter over local Modbus TCP."""
 

--- a/custom_components/sungrow/sensor.py
+++ b/custom_components/sungrow/sensor.py
@@ -353,6 +353,18 @@ class SungrowSensor(CoordinatorEntity, SensorEntity):
         # Capacity-factor ratios are reported as a 0–1 fraction but shown as "%".
         return num * 100 if self._scale_to_percent else num
 
+    @property
+    def extra_state_attributes(self) -> dict[str, Any] | None:
+        """Expose which transport (``cloud``/``modbus``) provided the current value (#159).
+
+        Only present once a point has been through the Modbus merge — i.e. when local
+        Modbus is configured. Cloud-only points carry no source, so this stays ``None``
+        and the entities keep their attribute-free payload (no recorder bloat).
+        """
+        point = self._current_point()
+        source = point.get("source") if point else None
+        return {"source": source} if source else None
+
 
 class SungrowDeviceSensor(SungrowSensor):
     """A sensor for a specific device (EV charger, meter, extra battery) under a plant.

--- a/custom_components/sungrow/strings.json
+++ b/custom_components/sungrow/strings.json
@@ -65,7 +65,8 @@
         "data": {
           "scan_interval": "Polling interval (seconds)",
           "extra_measure_points": "Extra measure points (point_id=code, comma separated)",
-          "enable_device_sensors": "Create per-device sensors (EV chargers, meters, extra batteries)"
+          "enable_device_sensors": "Create per-device sensors (EV chargers, meters, extra batteries)",
+          "modbus_host": "Local Modbus host (WiNet-S IP) — optional; leave blank for cloud only"
         }
       }
     }

--- a/custom_components/sungrow/translations/cy.json
+++ b/custom_components/sungrow/translations/cy.json
@@ -65,7 +65,8 @@
         "data": {
           "scan_interval": "Cyfwng holi (eiliadau)",
           "extra_measure_points": "Pwyntiau mesur ychwanegol (point_id=code, wedi'u gwahanu gan atalnodau)",
-          "enable_device_sensors": "Creu synwyryddion fesul dyfais (gwefrwyr EV, mesuryddion, batris ychwanegol)"
+          "enable_device_sensors": "Creu synwyryddion fesul dyfais (gwefrwyr EV, mesuryddion, batris ychwanegol)",
+          "modbus_host": "Gwesteiwr Modbus lleol (IP y WiNet-S) — dewisol; gadewch yn wag ar gyfer cwmwl yn unig"
         }
       }
     }

--- a/custom_components/sungrow/translations/de.json
+++ b/custom_components/sungrow/translations/de.json
@@ -65,7 +65,8 @@
         "data": {
           "scan_interval": "Abfrageintervall (Sekunden)",
           "extra_measure_points": "Zusätzliche Messpunkte (point_id=code, durch Kommata getrennt)",
-          "enable_device_sensors": "Sensoren pro Gerät erstellen (EV-Ladegeräte, Zähler, zusätzliche Batterien)"
+          "enable_device_sensors": "Sensoren pro Gerät erstellen (EV-Ladegeräte, Zähler, zusätzliche Batterien)",
+          "modbus_host": "Lokaler Modbus-Host (WiNet-S-IP) — optional; für reinen Cloud-Betrieb leer lassen"
         }
       }
     }

--- a/custom_components/sungrow/translations/en.json
+++ b/custom_components/sungrow/translations/en.json
@@ -65,7 +65,8 @@
         "data": {
           "scan_interval": "Polling interval (seconds)",
           "extra_measure_points": "Extra measure points (point_id=code, comma separated)",
-          "enable_device_sensors": "Create per-device sensors (EV chargers, meters, extra batteries)"
+          "enable_device_sensors": "Create per-device sensors (EV chargers, meters, extra batteries)",
+          "modbus_host": "Local Modbus host (WiNet-S IP) — optional; leave blank for cloud only"
         }
       }
     }

--- a/custom_components/sungrow/translations/es.json
+++ b/custom_components/sungrow/translations/es.json
@@ -65,7 +65,8 @@
         "data": {
           "scan_interval": "Intervalo de sondeo (segundos)",
           "extra_measure_points": "Puntos de medición adicionales (point_id=code, separados por comas)",
-          "enable_device_sensors": "Crear sensores por dispositivo (cargadores de VE, contadores, baterías adicionales)"
+          "enable_device_sensors": "Crear sensores por dispositivo (cargadores de VE, contadores, baterías adicionales)",
+          "modbus_host": "Host Modbus local (IP del WiNet-S) — opcional; déjelo en blanco para usar solo la nube"
         }
       }
     }

--- a/custom_components/sungrow/translations/fr.json
+++ b/custom_components/sungrow/translations/fr.json
@@ -65,7 +65,8 @@
         "data": {
           "scan_interval": "Intervalle d'interrogation (secondes)",
           "extra_measure_points": "Points de mesure supplémentaires (point_id=code, séparés par des virgules)",
-          "enable_device_sensors": "Créer des capteurs par appareil (bornes de recharge EV, compteurs, batteries supplémentaires)"
+          "enable_device_sensors": "Créer des capteurs par appareil (bornes de recharge EV, compteurs, batteries supplémentaires)",
+          "modbus_host": "Hôte Modbus local (IP du WiNet-S) — optionnel ; laisser vide pour le cloud uniquement"
         }
       }
     }

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -21,6 +21,7 @@ from custom_components.sungrow.const import (
     CONF_APP_SECRET,
     CONF_EXTRA_MEASURE_POINTS,
     CONF_GATEWAY,
+    CONF_MODBUS_HOST,
     CONF_REDIRECT_URI,
     CONF_SCAN_INTERVAL,
     DOMAIN,
@@ -636,6 +637,24 @@ async def test_options_flow_parses_extra_measure_points(hass: HomeAssistant, moc
         "99999": "battery_charge_power",
         "99998": "battery_discharge_power",
     }
+
+
+async def test_options_flow_stores_and_trims_modbus_host(hass: HomeAssistant, mock_setup_auth, mock_plants_service):
+    """The Modbus host option is stored, whitespace-trimmed; blank means cloud-only (#159)."""
+    entry = MockConfigEntry(domain=DOMAIN, data=MOCK_CONFIG_DATA.copy(), unique_id="test_app_id")
+    entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+
+    result = await hass.config_entries.options.async_init(entry.entry_id)
+    result2 = await hass.config_entries.options.async_configure(
+        result["flow_id"],
+        user_input={CONF_SCAN_INTERVAL: 30, CONF_MODBUS_HOST: "  192.168.1.93  "},
+    )
+    await hass.async_block_till_done()
+
+    assert result2["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
+    assert entry.options[CONF_MODBUS_HOST] == "192.168.1.93"
 
 
 async def test_options_flow_rejects_invalid_extra_measure_points(

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -14,6 +14,9 @@ from pysolarcloud.plants import DeviceType
 from custom_components.sungrow.const import (
     CONF_ENABLE_DEVICE_SENSORS,
     CONF_EXTRA_MEASURE_POINTS,
+    CONF_MODBUS_HOST,
+    CONF_MODBUS_PORT,
+    CONF_MODBUS_UNIT,
     CONF_SCAN_INTERVAL,
     DEVICE_REFRESH_INTERVAL,
     DOMAIN,
@@ -762,3 +765,61 @@ async def test_plant_detail_best_effort_on_error(hass: HomeAssistant):
     await coordinator._async_update_data()  # must not raise
 
     assert coordinator.plant_detail == {}
+
+
+# ---------------------------------------------------------------------------
+# Local Modbus transport (#159)
+# ---------------------------------------------------------------------------
+
+
+async def test_build_modbus_client_from_options(hass: HomeAssistant):
+    """A configured Modbus host builds a client with the given host/port/unit."""
+    entry = _make_entry({CONF_MODBUS_HOST: "10.0.0.5", CONF_MODBUS_PORT: 1502, CONF_MODBUS_UNIT: 2})
+    client = SungrowPlantCoordinator._build_modbus_client(entry)
+    assert client is not None
+    assert (client.host, client.port, client.unit) == ("10.0.0.5", 1502, 2)
+
+
+def test_no_modbus_client_when_host_blank():
+    """No host (or a blank host) means cloud-only: no Modbus client."""
+    assert SungrowPlantCoordinator._build_modbus_client(_make_entry()) is None
+    assert SungrowPlantCoordinator._build_modbus_client(_make_entry({CONF_MODBUS_HOST: ""})) is None
+
+
+async def test_apply_modbus_merges_over_cloud(hass: HomeAssistant):
+    """Configured Modbus overlays its value over the cloud value and tags provenance."""
+    coordinator = SungrowPlantCoordinator(hass, _make_entry(), MagicMock(), "12345", "Test Plant")
+    coordinator._modbus_client = MagicMock()
+    coordinator._modbus_client.async_read_realtime = AsyncMock(
+        return_value={
+            "total_active_power": {"code": "total_active_power", "value": 256, "unit": "W", "source": "modbus"}
+        }
+    )
+    cloud = {
+        "total_active_power": {"code": "total_active_power", "value": "250", "unit": "W"},
+        "daily_yield": {"code": "daily_yield", "value": "38"},
+    }
+    merged = await coordinator._async_apply_modbus(cloud)
+    assert merged["total_active_power"]["value"] == 256
+    assert merged["total_active_power"]["source"] == "modbus"
+    assert merged["daily_yield"]["source"] == "cloud"
+
+
+async def test_apply_modbus_falls_back_to_cloud_on_error(hass: HomeAssistant):
+    """A Modbus read failure keeps the cloud data untouched (never takes the plant offline)."""
+    from custom_components.sungrow.modbus import SungrowModbusError
+
+    coordinator = SungrowPlantCoordinator(hass, _make_entry(), MagicMock(), "12345", "Test Plant")
+    coordinator._modbus_client = MagicMock()
+    coordinator._modbus_client.async_read_realtime = AsyncMock(side_effect=SungrowModbusError("boom"))
+    cloud = {"total_active_power": {"code": "total_active_power", "value": "250"}}
+    merged = await coordinator._async_apply_modbus(cloud)
+    assert merged == cloud  # unchanged; no source tags added
+
+
+async def test_apply_modbus_noop_without_client(hass: HomeAssistant):
+    """Cloud-only (no Modbus host) returns the cloud data unchanged."""
+    coordinator = SungrowPlantCoordinator(hass, _make_entry(), MagicMock(), "12345", "Test Plant")
+    assert coordinator._modbus_client is None
+    cloud = {"x": {"value": "1"}}
+    assert await coordinator._async_apply_modbus(cloud) is cloud

--- a/tests/test_modbus.py
+++ b/tests/test_modbus.py
@@ -4,7 +4,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
-from custom_components.sungrow.modbus import SungrowModbusClient, SungrowModbusError
+from custom_components.sungrow.modbus import SungrowModbusClient, SungrowModbusError, merge_realtime
 from custom_components.sungrow.modbus_registers import (
     SG_RS_INPUT_POINTS,
     ModbusPoint,
@@ -158,3 +158,32 @@ async def test_read_passes_configured_unit_as_device_id():
     with patch("custom_components.sungrow.modbus.AsyncModbusTcpClient", cls):
         await SungrowModbusClient("10.0.0.1", unit=3).async_read_realtime()
     assert inner.read_input_registers.await_args.kwargs["device_id"] == 3
+
+
+# ---------------------------------------------------------------------------
+# merge_realtime (cloud + modbus, Modbus preferred, provenance)
+# ---------------------------------------------------------------------------
+
+
+def test_merge_prefers_modbus_and_tags_provenance():
+    """Shared codes take the Modbus value/unit; every point carries its source."""
+    cloud = {
+        "total_active_power": {"code": "total_active_power", "value": "250", "unit": "W", "id": "5031", "name": "AC"},
+        "daily_yield": {"code": "daily_yield", "value": "38.0", "unit": "kWh"},
+    }
+    modbus = {"total_active_power": {"code": "total_active_power", "value": 256, "unit": "W", "source": "modbus"}}
+    merged = merge_realtime(cloud, modbus)
+    # Modbus value wins for the shared code, and cloud metadata (id/name) is kept.
+    assert merged["total_active_power"]["value"] == 256
+    assert merged["total_active_power"]["source"] == "modbus"
+    assert merged["total_active_power"]["id"] == "5031"
+    # Cloud-only point is retained and tagged cloud.
+    assert merged["daily_yield"]["value"] == "38.0"
+    assert merged["daily_yield"]["source"] == "cloud"
+
+
+def test_merge_adds_modbus_only_points():
+    """A point only Modbus exposes is added to the merged result."""
+    merged = merge_realtime({}, {"grid_frequency": {"code": "grid_frequency", "value": 49.9, "source": "modbus"}})
+    assert merged["grid_frequency"]["value"] == 49.9
+    assert merged["grid_frequency"]["source"] == "modbus"

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -99,6 +99,22 @@ def test_power_fraction_gets_gauge_icon():
     assert sensor._attr_icon == "mdi:gauge"
 
 
+def test_sensor_exposes_transport_source_when_present():
+    """A point that went through the Modbus merge exposes its source (#159)."""
+    point = {"code": "total_active_power", "value": "256", "unit": "W", "source": "modbus"}
+    coordinator = _coord_with_devices([], data={"total_active_power": point})
+    sensor = SungrowSensor(coordinator, "total_active_power", "123", "Plant", point)
+    assert sensor.extra_state_attributes == {"source": "modbus"}
+
+
+def test_sensor_no_attributes_without_source():
+    """Cloud-only points carry no source, so no state attributes are emitted (no bloat)."""
+    point = {"code": "total_active_power", "value": "256", "unit": "W"}
+    coordinator = _coord_with_devices([], data={"total_active_power": point})
+    sensor = SungrowSensor(coordinator, "total_active_power", "123", "Plant", point)
+    assert sensor.extra_state_attributes is None
+
+
 def test_temperature_unit_glyph_normalized():
     """The API's ℃ glyph (U+2103) is normalised to HA-valid °C for the temperature class.
 


### PR DESCRIPTION
Wires the phase-1 Modbus client (#213) into the coordinator so local values overlay the cloud data **per-device, with provenance** — the core of the hybrid transport. **Non-breaking and opt-in.**

## What's here
- **Coordinator** builds a `SungrowModbusClient` when a Modbus host is configured (lazy import → cloud-only installs don't load pymodbus). Each successful poll reads it **best-effort** and merges over the cloud data. Any Modbus failure keeps the cloud data, so the local transport can **never take the plant offline** — it only ever supplies fresher values.
- **`merge_realtime()`** — cloud provides structure (`id`/`name` for naming/classification) + points Modbus lacks; where both carry a code, the **live Modbus value wins**; every point is tagged **`source` = `cloud`/`modbus`** so each reading is accountable.
- **Sensor** exposes `source` in `extra_state_attributes` **only** when a point has been merged — cloud-only points stay attribute-free (no recorder bloat; existing `test_no_raw_extra_state_attributes` still holds).
- **Options flow** gains a *"Local Modbus host (WiNet-S IP)"* field (blank = cloud only), whitespace-trimmed. `strings.json` + all five translations updated.
- **manifest** adds `pymodbus>=3.6.0` (a range, so it doesn't clobber HA core's pinned pymodbus).

## Scope
Leaving the host blank is exactly today's behaviour, so nothing changes for existing users. This is the **hybrid (Modbus + cloud)** path. The **breaking config-flow rework** — zeroconf discovery (`WiNet-WebServer` mDNS), per-device Modbus endpoints, the **Modbus-only** mode and the explicit 3-mode selector — is the next phase.

## Tests
merge preference/provenance, coordinator build-client + apply-merge + fallback-on-error + no-op-without-client, sensor source attribute, options-flow store/trim. `ruff` + `format` + `mypy` + full `pytest` (**394 passed**) green.

Part of #159.

🤖 Generated with [Claude Code](https://claude.com/claude-code)