### PR TITLE
feat: zeroconf discovery of WiNet-S for cloud-free local Modbus setup (#159 phase 3)

### DIFF
--- a/custom_components/sungrow/__init__.py
+++ b/custom_components/sungrow/__init__.py
@@ -27,13 +27,18 @@ from .const import (
     CONF_APP_KEY,
     CONF_APP_SECRET,
     CONF_GATEWAY,
+    CONF_MODBUS_HOST,
+    CONF_MODEL,
     CONF_SCAN_INTERVAL,
+    CONF_SERIAL,
+    CONF_TRANSPORT,
     DEFAULT_CONSOLE_URL,
     DEFAULT_HOST,
     DOMAIN,
     GATEWAY_CONSOLE_URLS,
     GATEWAYS,
     POINT_DEVICE_TYPE,
+    TRANSPORT_MODBUS_ONLY,
 )
 from .coordinator import SungrowPlantCoordinator, describe_api_error, is_auth_error
 
@@ -56,7 +61,8 @@ class SungrowData:
     """Runtime data stored on the config entry (``entry.runtime_data``)."""
 
     coordinators: list[SungrowPlantCoordinator]
-    control: Control
+    # None for a Modbus-only (cloud-free) entry, which has no dispatch/control (#159).
+    control: Control | None
     devices: dict[str, list[dict[str, Any]]]
     # plant_id -> (stop_event, task) for the running EMS heartbeat loops.
     heartbeats: dict[str, tuple[asyncio.Event, asyncio.Task[None]]] = field(default_factory=dict)
@@ -242,8 +248,46 @@ async def async_migrate_entry(hass: HomeAssistant, config_entry: ConfigEntry) ->
     return True
 
 
+async def _async_setup_modbus_only(hass: HomeAssistant, entry: SungrowConfigEntry) -> bool:
+    """Set up a cloud-free entry that reads a single inverter over local Modbus (#159).
+
+    Created by zeroconf discovery of a WiNet-S: no credentials, no cloud calls. One
+    coordinator reads the inverter's registers and the sensor platform builds entities
+    from the same measure-point codes the cloud path uses.
+    """
+    serial = str(entry.data.get(CONF_SERIAL) or entry.unique_id or "inverter")
+    model = str(entry.data.get(CONF_MODEL) or "Inverter")
+    plant_name = f"Sungrow {model}"
+    host = str(entry.options.get(CONF_MODBUS_HOST) or entry.data.get(CONF_MODBUS_HOST) or "")
+    # One inverter device nested under a service "plant" anchor (mirrors the cloud
+    # topology); distinct identifiers so the plant and inverter don't collide.
+    inverter = {
+        "uuid": f"{serial}_inv",
+        "device_name": plant_name,
+        "device_type": DeviceType.INVERTER,
+        "device_model_code": model,
+        "device_sn": serial,
+        "factory_name": "SUNGROW",
+    }
+    coordinator = SungrowPlantCoordinator(hass, entry, None, serial, plant_name, [inverter])
+    await coordinator.async_config_entry_first_refresh()
+
+    entry.runtime_data = SungrowData(coordinators=[coordinator], control=None, devices={serial: [inverter]})
+    # Pre-create the plant service device (via_device parent) with the WiNet-S web UI
+    # as its configuration URL.
+    dr.async_get(hass).async_get_or_create(
+        config_entry_id=entry.entry_id,
+        **build_plant_device_info(serial, plant_name, f"http://{host}" if host else DEFAULT_CONSOLE_URL),
+    )
+    # Only the sensor platform: a Modbus-only entry has no cloud device status or dispatch.
+    await hass.config_entries.async_forward_entry_setups(entry, [Platform.SENSOR])
+    return True
+
+
 async def async_setup_entry(hass: HomeAssistant, entry: SungrowConfigEntry) -> bool:
     """Set up Sungrow iSolarCloud from a config entry."""
+    if entry.data.get(CONF_TRANSPORT) == TRANSPORT_MODBUS_ONLY:
+        return await _async_setup_modbus_only(hass, entry)
     if "tokens" not in entry.data:
         # Nothing to authenticate with — ask the user to re-authorize.
         raise ConfigEntryAuthFailed("No stored tokens; re-authorization required")
@@ -441,7 +485,8 @@ async def async_start_heartbeat(
     heartbeats = data.heartbeats
 
     stop_event = asyncio.Event()
-    control: Control = data.control
+    control = data.control
+    assert control is not None  # the heartbeat is only ever started on a cloud dispatch entry
     # Tracked by the config entry so HA cancels it automatically on unload.
     task = entry.async_create_background_task(
         hass,

--- a/custom_components/sungrow/config_flow.py
+++ b/custom_components/sungrow/config_flow.py
@@ -12,6 +12,7 @@ from homeassistant.config_entries import ConfigEntry, ConfigFlowResult
 from homeassistant.core import callback
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.network import get_url
+from homeassistant.helpers.service_info.zeroconf import ZeroconfServiceInfo
 
 from .const import (
     CONF_APP_ID,
@@ -21,13 +22,18 @@ from .const import (
     CONF_EXTRA_MEASURE_POINTS,
     CONF_GATEWAY,
     CONF_MODBUS_HOST,
+    CONF_MODEL,
     CONF_REDIRECT_URI,
     CONF_SCAN_INTERVAL,
+    CONF_SERIAL,
+    CONF_TRANSPORT,
+    DEFAULT_MODBUS_SCAN_INTERVAL,
     DEFAULT_SCAN_INTERVAL,
     DOMAIN,
     GATEWAYS,
     MAX_SCAN_INTERVAL,
     MIN_SCAN_INTERVAL,
+    TRANSPORT_MODBUS_ONLY,
 )
 
 # Try to import pysolarcloud, handle if missing gracefully for development
@@ -44,6 +50,23 @@ _LOGGER = logging.getLogger(__name__)
 # can be slow — a redirect that lands within this window completes the flow
 # automatically even if the user has already reached the manual-entry form.
 CALLBACK_WAIT_TIMEOUT = 300
+
+
+def _parse_winet_properties(props: dict[str, Any]) -> tuple[str | None, str | None]:
+    """Extract ``(inverter_serial, model)`` from a WiNet-S mDNS TXT-record dict.
+
+    The dongle advertises ``inverter=1;<type_code>;<serial>;1;<x>;<model>;...``. TXT
+    values may arrive as ``bytes``; a missing/short field yields ``None``.
+    """
+    raw: Any = props.get("inverter")
+    if isinstance(raw, bytes):
+        raw = raw.decode(errors="replace")
+    if not raw:
+        return None, None
+    parts = str(raw).split(";")
+    serial = parts[2].strip() if len(parts) > 2 and parts[2].strip() else None
+    model = parts[5].strip() if len(parts) > 5 and parts[5].strip() else None
+    return serial, model
 
 
 class SungrowConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
@@ -64,6 +87,9 @@ class SungrowConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         # OAuth ``state`` token that correlates the callback redirect back to this
         # exact flow (registered in hass.data so the callback view can look it up).
         self._state: str | None = None
+        # Zeroconf-discovered WiNet-S local Modbus host, carried into the confirm step
+        # that creates the cloud-free Modbus-only entry (#159).
+        self._discovered_modbus_host: str | None = None
 
     @staticmethod
     @callback
@@ -115,6 +141,45 @@ class SungrowConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                     vol.Required(CONF_REDIRECT_URI, default=current.get(CONF_REDIRECT_URI, "")): str,
                 }
             ),
+        )
+
+    async def async_step_zeroconf(self, discovery_info: ZeroconfServiceInfo) -> ConfigFlowResult:
+        """Discover a WiNet-S dongle via mDNS and offer a cloud-free local Modbus setup (#159).
+
+        The dongle advertises ``WiNet-WebServer`` (``_http._tcp``) with TXT records that
+        carry the inverter's serial and model, so we can identify it and pick the register
+        map without connecting or needing any cloud credentials.
+        """
+        host = str(discovery_info.ip_address)
+        serial, model = _parse_winet_properties(discovery_info.properties)
+        if not serial:
+            return self.async_abort(reason="not_sungrow_device")
+        await self.async_set_unique_id(f"modbus_{serial}")
+        # Already set up? Update the host in case the WiNet-S's IP changed, then stop.
+        self._abort_if_unique_id_configured(updates={CONF_MODBUS_HOST: host})
+        self._discovered_modbus_host = host
+        self.init_info = {CONF_SERIAL: serial, CONF_MODEL: model or "Inverter"}
+        self.context["title_placeholders"] = {"name": f"Sungrow {model or 'inverter'}"}
+        return await self.async_step_zeroconf_confirm()
+
+    async def async_step_zeroconf_confirm(self, user_input: dict[str, Any] | None = None) -> ConfigFlowResult:
+        """Confirm setting up the discovered WiNet-S as a local (Modbus-only) integration."""
+        model = self.init_info.get(CONF_MODEL, "Inverter")
+        if user_input is not None:
+            return self.async_create_entry(
+                title=f"Sungrow {model} (local)",
+                data={
+                    CONF_TRANSPORT: TRANSPORT_MODBUS_ONLY,
+                    CONF_SERIAL: self.init_info[CONF_SERIAL],
+                    CONF_MODEL: model,
+                    CONF_MODBUS_HOST: self._discovered_modbus_host,
+                },
+                options={CONF_SCAN_INTERVAL: DEFAULT_MODBUS_SCAN_INTERVAL},
+            )
+        self._set_confirm_only()
+        return self.async_show_form(
+            step_id="zeroconf_confirm",
+            description_placeholders={"model": model, "host": self._discovered_modbus_host or ""},
         )
 
     async def async_step_user(self, user_input: dict[str, Any] | None = None) -> ConfigFlowResult:

--- a/custom_components/sungrow/const.py
+++ b/custom_components/sungrow/const.py
@@ -24,6 +24,15 @@ CONF_MODBUS_PORT = "modbus_port"
 CONF_MODBUS_UNIT = "modbus_unit"
 DEFAULT_MODBUS_PORT = 502
 DEFAULT_MODBUS_UNIT = 1
+# Entry-data marker for a fully local, cloud-free entry created from zeroconf
+# discovery of a WiNet-S (#159). Such an entry carries no cloud credentials; its
+# realtime data comes entirely from local Modbus.
+CONF_TRANSPORT = "transport"
+TRANSPORT_MODBUS_ONLY = "modbus_only"
+# Discovered WiNet-S identity stored on a Modbus-only entry.
+CONF_MODEL = "model"
+CONF_SERIAL = "serial"
+DEFAULT_MODBUS_SCAN_INTERVAL = 30
 
 GATEWAYS = {
     "Europe": "https://gateway.isolarcloud.eu",

--- a/custom_components/sungrow/coordinator.py
+++ b/custom_components/sungrow/coordinator.py
@@ -142,12 +142,16 @@ class SungrowPlantCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         self,
         hass: HomeAssistant,
         config_entry: ConfigEntry,
-        plants_service: Plants,
+        plants_service: Plants | None,
         plant_id: str,
         plant_name: str,
         devices: list[dict[str, Any]] | None = None,
     ) -> None:
-        """Initialize the coordinator."""
+        """Initialize the coordinator.
+
+        ``plants_service`` is ``None`` for a Modbus-only (cloud-free) entry, in which
+        case the realtime data comes entirely from the local Modbus client (#159).
+        """
         scan_seconds = config_entry.options.get(CONF_SCAN_INTERVAL, DEFAULT_SCAN_INTERVAL)
         super().__init__(
             hass,
@@ -203,8 +207,12 @@ class SungrowPlantCoordinator(DataUpdateCoordinator[dict[str, Any]]):
 
     @staticmethod
     def _build_modbus_client(config_entry: ConfigEntry) -> Any:
-        """Return a SungrowModbusClient if a Modbus host is configured, else None."""
-        host = config_entry.options.get(CONF_MODBUS_HOST)
+        """Return a SungrowModbusClient if a Modbus host is configured, else None.
+
+        The host lives in options for a cloud entry (opt-in hybrid) or in data for a
+        discovery-created Modbus-only entry (#159).
+        """
+        host = config_entry.options.get(CONF_MODBUS_HOST) or config_entry.data.get(CONF_MODBUS_HOST)
         if not host:
             return None
         from .modbus import SungrowModbusClient
@@ -217,6 +225,9 @@ class SungrowPlantCoordinator(DataUpdateCoordinator[dict[str, Any]]):
 
     async def _async_update_data(self) -> dict[str, Any]:
         """Fetch data from the API for this plant."""
+        # Cloud-free (Modbus-only) entry: everything comes from the local inverter.
+        if self.plants_service is None:
+            return await self._async_modbus_only_update()
         try:
             # async_get_realtime_data returns a dict of plants keyed by plant_id:
             # { "123": { "code1": {...}, "code2": {...} } }
@@ -289,6 +300,22 @@ class SungrowPlantCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             return cloud_data
         return merge_realtime(cloud_data, local)
 
+    async def _async_modbus_only_update(self) -> dict[str, Any]:
+        """Read realtime data from the local Modbus client only (cloud-free entry, #159)."""
+        if self._modbus_client is None:
+            raise UpdateFailed("Modbus-only entry has no Modbus client configured")
+        try:
+            async with asyncio.timeout(self._poll_timeout):
+                data = await self._modbus_client.async_read_realtime()
+        except Exception as err:  # pylint: disable=broad-except
+            # Ride out a brief local blip the same way the cloud path does (#152).
+            if self.data is not None and self._within_availability_grace():
+                _LOGGER.debug("Transient Modbus read failure for %s; keeping last-good data: %s", self.plant_name, err)
+                return self.data
+            raise UpdateFailed(f"Local Modbus read failed: {err}") from err
+        self._last_successful_update = self.hass.loop.time()
+        return cast("dict[str, Any]", data)
+
     def _within_availability_grace(self) -> bool:
         """True while the last successful poll is recent enough to keep serving stale data."""
         if self._last_successful_update is None:
@@ -360,6 +387,7 @@ class SungrowPlantCoordinator(DataUpdateCoordinator[dict[str, Any]]):
 
     async def _async_refresh_devices(self) -> None:
         """Re-fetch the plant's device list (best effort, non-fatal)."""
+        assert self.plants_service is not None  # only reached on the cloud path
         try:
             async with asyncio.timeout(self._poll_timeout):
                 devices = await self.plants_service.async_get_plant_devices(self.plant_id)
@@ -386,6 +414,7 @@ class SungrowPlantCoordinator(DataUpdateCoordinator[dict[str, Any]]):
 
     async def _async_refresh_plant_detail(self) -> None:
         """Re-fetch the plant-detail fields (best effort, non-fatal)."""
+        assert self.plants_service is not None  # only reached on the cloud path
         try:
             async with asyncio.timeout(self._poll_timeout):
                 details = await self.plants_service.async_get_plant_details(self.plant_id)
@@ -406,6 +435,7 @@ class SungrowPlantCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         extra measure points are requested here too, so newly identified charger/meter
         point IDs surface without a code change.
         """
+        assert self.plants_service is not None  # only reached on the cloud path
         merged: dict[str, dict[str, Any]] = {}
         seen_types: set[Any] = set()
         for device in self.devices:

--- a/custom_components/sungrow/manifest.json
+++ b/custom_components/sungrow/manifest.json
@@ -21,5 +21,11 @@
     "sungrow-isolarcloud==0.10.3",
     "pymodbus>=3.6.0"
   ],
-  "version": "3.4.1"
+  "version": "3.4.1",
+  "zeroconf": [
+    {
+      "type": "_http._tcp.local.",
+      "name": "winet-webserver*"
+    }
+  ]
 }

--- a/custom_components/sungrow/strings.json
+++ b/custom_components/sungrow/strings.json
@@ -37,6 +37,10 @@
           "gateway": "Gateway Region",
           "redirect_uri": "Redirect URI"
         }
+      },
+      "zeroconf_confirm": {
+        "title": "Set up local Sungrow inverter",
+        "description": "A Sungrow **{model}** was discovered on your network at **{host}** (WiNet-S). Set it up to read data directly over local Modbus — fast, unmetered and offline-capable, with no iSolarCloud account required."
       }
     },
     "progress": {
@@ -50,6 +54,7 @@
     },
     "abort": {
       "already_configured": "Device is already configured",
+      "not_sungrow_device": "The discovered device is not a supported Sungrow inverter.",
       "library_missing": "The pysolarcloud library is not installed. Restart Home Assistant so the integration's requirements are installed, then try again.",
       "missing_code": "Authorization code was not received. Please try again.",
       "reauth_successful": "Re-authentication was successful",

--- a/custom_components/sungrow/translations/cy.json
+++ b/custom_components/sungrow/translations/cy.json
@@ -37,6 +37,10 @@
           "gateway": "Rhanbarth y Porth",
           "redirect_uri": "URI Ailgyfeirio"
         }
+      },
+      "zeroconf_confirm": {
+        "title": "Gosod gwrthdröydd Sungrow lleol",
+        "description": "Darganfuwyd Sungrow **{model}** ar eich rhwydwaith yn **{host}** (WiNet-S). Gosodwch ef i ddarllen data'n uniongyrchol dros Modbus lleol — cyflym, heb derfyn ac all-lein, heb angen cyfrif iSolarCloud."
       }
     },
     "progress": {
@@ -54,7 +58,8 @@
       "missing_code": "Ni dderbyniwyd y cod awdurdodi. Rhowch gynnig arall arni.",
       "reauth_successful": "Roedd yr ail-ddilysiad yn llwyddiannus",
       "reconfigure_successful": "Roedd yr ailgyflunio'n llwyddiannus",
-      "wrong_account": "Nid yw'r cyfrif awdurdodedig yn cyfateb i App ID yr integreiddiad hwn. Defnyddiwch y cymhwysiad datblygwr gwreiddiol."
+      "wrong_account": "Nid yw'r cyfrif awdurdodedig yn cyfateb i App ID yr integreiddiad hwn. Defnyddiwch y cymhwysiad datblygwr gwreiddiol.",
+      "not_sungrow_device": "Nid yw'r ddyfais a ddarganfuwyd yn wrthdröydd Sungrow a gefnogir."
     }
   },
   "options": {

--- a/custom_components/sungrow/translations/de.json
+++ b/custom_components/sungrow/translations/de.json
@@ -37,6 +37,10 @@
           "gateway": "Gateway-Region",
           "redirect_uri": "Weiterleitungs-URI"
         }
+      },
+      "zeroconf_confirm": {
+        "title": "Lokalen Sungrow-Wechselrichter einrichten",
+        "description": "Ein Sungrow **{model}** wurde in Ihrem Netzwerk unter **{host}** (WiNet-S) gefunden. Richten Sie ihn ein, um Daten direkt über lokales Modbus zu lesen — schnell, ohne Limit und offline-fähig, ohne iSolarCloud-Konto."
       }
     },
     "progress": {
@@ -54,7 +58,8 @@
       "missing_code": "Der Autorisierungscode wurde nicht empfangen. Bitte versuchen Sie es erneut.",
       "reauth_successful": "Die erneute Authentifizierung war erfolgreich",
       "reconfigure_successful": "Die Neukonfiguration war erfolgreich",
-      "wrong_account": "Das autorisierte Konto stimmt nicht mit der App ID dieser Integration überein. Verwenden Sie die ursprüngliche Entwickleranwendung."
+      "wrong_account": "Das autorisierte Konto stimmt nicht mit der App ID dieser Integration überein. Verwenden Sie die ursprüngliche Entwickleranwendung.",
+      "not_sungrow_device": "Das gefundene Gerät ist kein unterstützter Sungrow-Wechselrichter."
     }
   },
   "options": {

--- a/custom_components/sungrow/translations/en.json
+++ b/custom_components/sungrow/translations/en.json
@@ -37,6 +37,10 @@
           "gateway": "Gateway Region",
           "redirect_uri": "Redirect URI"
         }
+      },
+      "zeroconf_confirm": {
+        "title": "Set up local Sungrow inverter",
+        "description": "A Sungrow **{model}** was discovered on your network at **{host}** (WiNet-S). Set it up to read data directly over local Modbus — fast, unmetered and offline-capable, with no iSolarCloud account required."
       }
     },
     "progress": {
@@ -54,7 +58,8 @@
       "missing_code": "Authorization code was not received. Please try again.",
       "reauth_successful": "Re-authentication was successful",
       "reconfigure_successful": "Reconfiguration was successful",
-      "wrong_account": "The authorized account does not match this integration's App ID. Use the original developer application."
+      "wrong_account": "The authorized account does not match this integration's App ID. Use the original developer application.",
+      "not_sungrow_device": "The discovered device is not a supported Sungrow inverter."
     }
   },
   "options": {

--- a/custom_components/sungrow/translations/es.json
+++ b/custom_components/sungrow/translations/es.json
@@ -37,6 +37,10 @@
           "gateway": "Región de la pasarela",
           "redirect_uri": "URI de redirección"
         }
+      },
+      "zeroconf_confirm": {
+        "title": "Configurar inversor Sungrow local",
+        "description": "Se descubrió un Sungrow **{model}** en su red en **{host}** (WiNet-S). Configúrelo para leer datos directamente por Modbus local — rápido, sin límites y sin conexión, sin necesidad de una cuenta de iSolarCloud."
       }
     },
     "progress": {
@@ -54,7 +58,8 @@
       "missing_code": "No se recibió el código de autorización. Vuelva a intentarlo.",
       "reauth_successful": "La reautenticación se realizó correctamente",
       "reconfigure_successful": "La reconfiguración se realizó correctamente",
-      "wrong_account": "La cuenta autorizada no coincide con el App ID de esta integración. Use la aplicación de desarrollador original."
+      "wrong_account": "La cuenta autorizada no coincide con el App ID de esta integración. Use la aplicación de desarrollador original.",
+      "not_sungrow_device": "El dispositivo descubierto no es un inversor Sungrow compatible."
     }
   },
   "options": {

--- a/custom_components/sungrow/translations/fr.json
+++ b/custom_components/sungrow/translations/fr.json
@@ -37,6 +37,10 @@
           "gateway": "Région de la passerelle",
           "redirect_uri": "URI de redirection"
         }
+      },
+      "zeroconf_confirm": {
+        "title": "Configurer l'onduleur Sungrow local",
+        "description": "Un Sungrow **{model}** a été découvert sur votre réseau à **{host}** (WiNet-S). Configurez-le pour lire les données directement via Modbus local — rapide, sans quota et hors ligne, sans compte iSolarCloud."
       }
     },
     "progress": {
@@ -54,7 +58,8 @@
       "missing_code": "Le code d'autorisation n'a pas été reçu. Veuillez réessayer.",
       "reauth_successful": "La ré-authentification a réussi",
       "reconfigure_successful": "La reconfiguration a réussi",
-      "wrong_account": "Le compte autorisé ne correspond pas à l'App ID de cette intégration. Utilisez l'application développeur d'origine."
+      "wrong_account": "Le compte autorisé ne correspond pas à l'App ID de cette intégration. Utilisez l'application développeur d'origine.",
+      "not_sungrow_device": "L'appareil découvert n'est pas un onduleur Sungrow pris en charge."
     }
   },
   "options": {

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -7,14 +7,17 @@ before any redirect, which is what fixes the first-install 404.
 """
 
 import asyncio
+from ipaddress import ip_address
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from aiohttp import ClientError
 from homeassistant import config_entries, data_entry_flow
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers.service_info.zeroconf import ZeroconfServiceInfo
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 
+from custom_components.sungrow.config_flow import _parse_winet_properties
 from custom_components.sungrow.const import (
     CONF_APP_ID,
     CONF_APP_KEY,
@@ -22,9 +25,14 @@ from custom_components.sungrow.const import (
     CONF_EXTRA_MEASURE_POINTS,
     CONF_GATEWAY,
     CONF_MODBUS_HOST,
+    CONF_MODEL,
     CONF_REDIRECT_URI,
     CONF_SCAN_INTERVAL,
+    CONF_SERIAL,
+    CONF_TRANSPORT,
+    DEFAULT_MODBUS_SCAN_INTERVAL,
     DOMAIN,
+    TRANSPORT_MODBUS_ONLY,
 )
 
 from .conftest import MOCK_CONFIG_DATA, MOCK_USER_INPUT
@@ -674,3 +682,97 @@ async def test_options_flow_rejects_invalid_extra_measure_points(
 
     assert result2["type"] == data_entry_flow.FlowResultType.FORM
     assert result2["errors"] is not None
+
+
+# ---------------------------------------------------------------------------
+# Zeroconf discovery -> standalone Modbus-only entry (#159)
+# ---------------------------------------------------------------------------
+
+
+def _winet_discovery(host: str = "192.168.1.93", serial: str = "A2340512345", model: str = "SG3.6RS"):
+    """A WiNet-S mDNS discovery advertising one inverter's serial and model."""
+    return ZeroconfServiceInfo(
+        ip_address=ip_address(host),
+        ip_addresses=[ip_address(host)],
+        port=80,
+        hostname=f"SUNGROW{serial}.local.",
+        type="_http._tcp.local.",
+        name="WiNet-WebServer._http._tcp.local.",
+        properties={
+            "board": f"SUNGROW;1;WiNet-S;{serial};1;",
+            "inverter": f"1;9732;{serial};1;516;{model};1;1;",
+        },
+    )
+
+
+def test_parse_winet_properties():
+    """The TXT-record parser extracts the inverter serial and model, or (None, None)."""
+    assert _parse_winet_properties({"inverter": "1;9732;A2340512345;1;516;SG3.6RS;1;1;"}) == (
+        "A2340512345",
+        "SG3.6RS",
+    )
+    # bytes-valued TXT records are decoded.
+    assert _parse_winet_properties({"inverter": b"1;9732;SN9;1;516;SG5.0RS;1;1;"}) == ("SN9", "SG5.0RS")
+    # No inverter record -> nothing to identify.
+    assert _parse_winet_properties({"board": "SUNGROW;1;WiNet-S;SN;1;"}) == (None, None)
+    # Too few fields -> no crash, just None.
+    assert _parse_winet_properties({"inverter": "1;9732"}) == (None, None)
+
+
+async def test_zeroconf_discovery_creates_modbus_entry(hass: HomeAssistant):
+    """Discovering a WiNet-S offers a confirm form, then creates a cloud-free Modbus entry."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_ZEROCONF}, data=_winet_discovery()
+    )
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
+    assert result["step_id"] == "zeroconf_confirm"
+    assert result["description_placeholders"] == {"model": "SG3.6RS", "host": "192.168.1.93"}
+
+    with patch("custom_components.sungrow.async_setup_entry", return_value=True):
+        result2 = await hass.config_entries.flow.async_configure(result["flow_id"], user_input={})
+        await hass.async_block_till_done()
+
+    assert result2["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
+    assert result2["title"] == "Sungrow SG3.6RS (local)"
+    assert result2["data"] == {
+        CONF_TRANSPORT: TRANSPORT_MODBUS_ONLY,
+        CONF_SERIAL: "A2340512345",
+        CONF_MODEL: "SG3.6RS",
+        CONF_MODBUS_HOST: "192.168.1.93",
+    }
+    assert result2["options"] == {CONF_SCAN_INTERVAL: DEFAULT_MODBUS_SCAN_INTERVAL}
+    assert result2["result"].unique_id == "modbus_A2340512345"
+
+
+async def test_zeroconf_aborts_non_sungrow_device(hass: HomeAssistant):
+    """A discovery with no inverter serial is not a device we can set up."""
+    info = _winet_discovery()
+    info.properties.pop("inverter")
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_ZEROCONF}, data=info
+    )
+    assert result["type"] == data_entry_flow.FlowResultType.ABORT
+    assert result["reason"] == "not_sungrow_device"
+
+
+async def test_zeroconf_aborts_when_already_configured_and_updates_host(hass: HomeAssistant):
+    """A re-discovered WiNet-S aborts as already configured and refreshes its stored host."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={
+            CONF_TRANSPORT: TRANSPORT_MODBUS_ONLY,
+            CONF_SERIAL: "A2340512345",
+            CONF_MODEL: "SG3.6RS",
+            CONF_MODBUS_HOST: "192.168.1.50",  # old IP
+        },
+        unique_id="modbus_A2340512345",
+    )
+    entry.add_to_hass(hass)
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_ZEROCONF}, data=_winet_discovery(host="192.168.1.99")
+    )
+    assert result["type"] == data_entry_flow.FlowResultType.ABORT
+    assert result["reason"] == "already_configured"
+    # The WiNet-S moved to a new DHCP lease; the stored host follows it.
+    assert entry.data[CONF_MODBUS_HOST] == "192.168.1.99"

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -31,9 +31,10 @@ from custom_components.sungrow.coordinator import (
 from .conftest import MOCK_REALTIME_DATA
 
 
-def _make_entry(options=None):
+def _make_entry(options=None, data=None):
     entry = MagicMock()
     entry.options = options or {}
+    entry.data = data or {}
     return entry
 
 
@@ -823,3 +824,61 @@ async def test_apply_modbus_noop_without_client(hass: HomeAssistant):
     assert coordinator._modbus_client is None
     cloud = {"x": {"value": "1"}}
     assert await coordinator._async_apply_modbus(cloud) is cloud
+
+
+# ---------------------------------------------------------------------------
+# Modbus-only transport (cloud-free entry, #159)
+# ---------------------------------------------------------------------------
+
+
+def _modbus_only_coordinator(hass: HomeAssistant) -> SungrowPlantCoordinator:
+    """A coordinator with no cloud service and a stubbed Modbus client."""
+    entry = _make_entry(data={CONF_MODBUS_HOST: "10.0.0.9"})
+    coordinator = SungrowPlantCoordinator(hass, entry, None, "SN123", "Sungrow SG3.6RS")
+    assert coordinator.plants_service is None
+    coordinator._modbus_client = MagicMock()
+    return coordinator
+
+
+async def test_modbus_only_update_reads_from_modbus(hass: HomeAssistant):
+    """A Modbus-only entry sources all realtime data from the local client."""
+    coordinator = _modbus_only_coordinator(hass)
+    local = {"grid_frequency": {"code": "grid_frequency", "value": 49.9, "unit": "Hz", "source": "modbus"}}
+    coordinator._modbus_client.async_read_realtime = AsyncMock(return_value=local)
+
+    data = await coordinator._async_update_data()
+
+    assert data == local
+    assert coordinator._last_successful_update is not None
+
+
+async def test_modbus_only_update_no_client_raises(hass: HomeAssistant):
+    """A Modbus-only entry with no client configured fails the update (defensive)."""
+    entry = _make_entry()  # no host anywhere -> no client is built
+    coordinator = SungrowPlantCoordinator(hass, entry, None, "SN123", "Sungrow SG3.6RS")
+    assert coordinator._modbus_client is None
+    with pytest.raises(UpdateFailed):
+        await coordinator._async_update_data()
+
+
+async def test_modbus_only_update_keeps_last_good_within_grace(hass: HomeAssistant):
+    """A transient Modbus blip keeps serving the last-good data (availability grace)."""
+    coordinator = _modbus_only_coordinator(hass)
+    coordinator.data = {"grid_frequency": {"value": 50.0}}
+    coordinator._last_successful_update = hass.loop.time()  # fresh success
+    coordinator._modbus_client.async_read_realtime = AsyncMock(side_effect=OSError("connection reset"))
+
+    data = await coordinator._async_update_data()
+
+    assert data == {"grid_frequency": {"value": 50.0}}
+
+
+async def test_modbus_only_update_raises_outside_grace(hass: HomeAssistant):
+    """Once the last-good data is stale, a Modbus failure takes the entry unavailable."""
+    coordinator = _modbus_only_coordinator(hass)
+    coordinator.data = {"grid_frequency": {"value": 50.0}}
+    coordinator._last_successful_update = None  # no recent success -> outside grace
+    coordinator._modbus_client.async_read_realtime = AsyncMock(side_effect=OSError("connection reset"))
+
+    with pytest.raises(UpdateFailed):
+        await coordinator._async_update_data()

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -21,7 +21,15 @@ from custom_components.sungrow import (
     async_unload_entry,
     resolve_point_device,
 )
-from custom_components.sungrow.const import CONF_SCAN_INTERVAL, DOMAIN
+from custom_components.sungrow.const import (
+    CONF_MODBUS_HOST,
+    CONF_MODEL,
+    CONF_SCAN_INTERVAL,
+    CONF_SERIAL,
+    CONF_TRANSPORT,
+    DOMAIN,
+    TRANSPORT_MODBUS_ONLY,
+)
 
 from .conftest import MOCK_CONFIG_DATA, MOCK_PLANT_LIST, MOCK_REALTIME_DATA
 
@@ -120,6 +128,49 @@ async def test_async_unload_entry(hass: HomeAssistant, mock_setup_auth, mock_pla
     assert await hass.config_entries.async_unload(entry.entry_id)
     await hass.async_block_till_done()
 
+    assert entry.state is ConfigEntryState.NOT_LOADED
+
+
+# ---------------------------------------------------------------------------
+# Modbus-only (cloud-free) setup (#159)
+# ---------------------------------------------------------------------------
+
+
+async def test_setup_modbus_only_entry(hass: HomeAssistant):
+    """A Modbus-only entry sets up cloud-free: one coordinator, no cloud/dispatch, sensors only."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={
+            CONF_TRANSPORT: TRANSPORT_MODBUS_ONLY,
+            CONF_SERIAL: "SN123",
+            CONF_MODEL: "SG3.6RS",
+            CONF_MODBUS_HOST: "10.0.0.9",
+        },
+        options={CONF_SCAN_INTERVAL: 30},
+        unique_id="modbus_SN123",
+    )
+    entry.add_to_hass(hass)
+
+    client = MagicMock()
+    client.async_read_realtime = AsyncMock(
+        return_value={"grid_frequency": {"code": "grid_frequency", "value": 49.9, "unit": "Hz", "source": "modbus"}}
+    )
+    with patch("custom_components.sungrow.modbus.SungrowModbusClient", return_value=client):
+        assert await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+
+    assert entry.state is ConfigEntryState.LOADED
+    data = entry.runtime_data
+    assert len(data.coordinators) == 1
+    # No cloud service and no dispatch controller on a Modbus-only entry.
+    assert data.coordinators[0].plants_service is None
+    assert data.control is None
+    # The local client supplied the realtime data.
+    assert data.coordinators[0].data["grid_frequency"]["value"] == 49.9
+
+    # A Modbus-only entry (no dispatch, no heartbeat) unloads cleanly.
+    assert await hass.config_entries.async_unload(entry.entry_id)
+    await hass.async_block_till_done()
     assert entry.state is ConfigEntryState.NOT_LOADED
 
 


### PR DESCRIPTION
## What & why

Phase 3 of local Modbus (#159). Home Assistant now **auto-discovers** a Sungrow WiNet-S dongle on the network and offers a **fully local, cloud-free** setup — read the inverter directly over Modbus with **no iSolarCloud account required**.

The WiNet-S advertises itself over mDNS as `WiNet-WebServer` (`_http._tcp`), and its TXT records self-describe the inverter's serial and model — so we identify the device and pick the right register map **without connecting or needing any credentials**.

This is the discovery-first path the quality-scale [`discovery` rule](https://developers.home-assistant.io/docs/core/integration-quality-scale/rules/discovery/) calls for: the dongle shows up in Settings → Devices as "discovered", and one confirmation click sets it up.

## Changes

- **config_flow**: `async_step_zeroconf` / `async_step_zeroconf_confirm` create a standalone `transport=modbus_only` entry. `_parse_winet_properties` extracts serial/model from the mDNS TXT records. Re-discovering an already-configured dongle aborts and **refreshes the stored host** (the WiNet-S's DHCP lease can change).
- **coordinator**: `plants_service` is now optional. A Modbus-only entry sources all realtime data from the local client via `_async_modbus_only_update`, reusing the same availability grace window as the cloud path. `_build_modbus_client` reads the host from entry **data** (discovery) as well as **options** (the opt-in hybrid from phase 2).
- **__init__**: `_async_setup_modbus_only` builds one coordinator with no cloud service and no dispatch controller, forwarding **only** the sensor platform. `SungrowData.control` is now optional.
- **manifest**: register the `zeroconf` discovery matcher (`winet-webserver*`).
- **strings/translations**: `zeroconf_confirm` step + `not_sungrow_device` abort, in sync across all five languages.

## Transport modes so far

| Mode | Source | Entry created by |
| --- | --- | --- |
| Cloud only | iSolarCloud | existing user flow |
| Cloud + Modbus (hybrid) | Modbus preferred, cloud fallback | options (phase 2) |
| **Modbus only** | local Modbus, no cloud | **zeroconf discovery (this PR)** |

## Testing

`ruff` + `ruff format` + `mypy` clean; **403 passed**. New tests:
- Modbus-only coordinator update: success, availability-grace ride-through, hard failure, and no-client guard.
- Cloud-free setup loads one coordinator with `control=None`, sensor-only, and **unloads cleanly**.
- Zeroconf flow: discover → confirm → standalone entry; non-Sungrow discovery aborts; re-discovery refreshes the host; TXT-record parser.

## Notes

- Validated live against a real SG3.6RS + WiNet-S.
- Stacked on #214 (phase 2), which is now merged; this branch is rebased onto `main` so the diff is phase-3-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)