### PR TITLE
fix: correct Modbus-only entry options + unload (#159)

### DIFF
--- a/custom_components/sungrow/__init__.py
+++ b/custom_components/sungrow/__init__.py
@@ -43,6 +43,19 @@ from .const import (
 from .coordinator import SungrowPlantCoordinator, describe_api_error, is_auth_error
 
 PLATFORMS: list[Platform] = [Platform.BINARY_SENSOR, Platform.NUMBER, Platform.SELECT, Platform.SENSOR]
+# A cloud-free Modbus-only entry has no device status or dispatch, so it sets up only
+# the sensor platform (#159). Setup and unload MUST use the same list — unloading a
+# platform that was never set up fails the unload, which breaks the options-change
+# reload and takes every entity unavailable.
+MODBUS_ONLY_PLATFORMS: list[Platform] = [Platform.SENSOR]
+
+
+def _entry_platforms(entry: SungrowConfigEntry) -> list[Platform]:
+    """Return the platforms this entry sets up (fewer for a Modbus-only entry, #159)."""
+    if entry.data.get(CONF_TRANSPORT) == TRANSPORT_MODBUS_ONLY:
+        return MODBUS_ONLY_PLATFORMS
+    return PLATFORMS
+
 
 # How long to wait for a heartbeat loop to observe its stop event and exit
 # before force-cancelling it.
@@ -280,7 +293,7 @@ async def _async_setup_modbus_only(hass: HomeAssistant, entry: SungrowConfigEntr
         **build_plant_device_info(serial, plant_name, f"http://{host}" if host else DEFAULT_CONSOLE_URL),
     )
     # Only the sensor platform: a Modbus-only entry has no cloud device status or dispatch.
-    await hass.config_entries.async_forward_entry_setups(entry, [Platform.SENSOR])
+    await hass.config_entries.async_forward_entry_setups(entry, _entry_platforms(entry))
     return True
 
 
@@ -382,7 +395,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: SungrowConfigEntry) -> b
             **build_plant_device_info(coordinator.plant_id, coordinator.plant_name, console_url),
         )
 
-    await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
+    await hass.config_entries.async_forward_entry_setups(entry, _entry_platforms(entry))
 
     # Prune devices that drop out of the API after each refresh (stale-devices).
     @callback
@@ -406,7 +419,7 @@ async def async_unload_entry(hass: HomeAssistant, entry: SungrowConfigEntry) -> 
     # them up front would strand an active Charge/Discharge dispatch without its keepalive
     # (the inverter times out of External-EMS mode) while the entry stays LOADED on a
     # failed unload.
-    unloaded = await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
+    unloaded = await hass.config_entries.async_unload_platforms(entry, _entry_platforms(entry))
     if unloaded:
         heartbeats = entry.runtime_data.heartbeats
         for heartbeat in list(heartbeats.values()):

--- a/custom_components/sungrow/config_flow.py
+++ b/custom_components/sungrow/config_flow.py
@@ -581,6 +581,10 @@ class SungrowOptionsFlow(config_entries.OptionsFlowWithReload):
 
     async def async_step_init(self, user_input: dict[str, Any] | None = None) -> ConfigFlowResult:
         """Manage the integration options."""
+        # A cloud-free Modbus-only entry has none of the cloud settings (API quota,
+        # extra measure points, per-device fetch); show only the local poll interval (#159).
+        if self.config_entry.data.get(CONF_TRANSPORT) == TRANSPORT_MODBUS_ONLY:
+            return await self.async_step_modbus_options(user_input)
         errors: dict[str, str] = {}
         if user_input is not None:
             # Normalise the free-text mapping into a dict before storing.
@@ -623,4 +627,26 @@ class SungrowOptionsFlow(config_entries.OptionsFlowWithReload):
                 }
             ),
             errors=errors,
+        )
+
+    async def async_step_modbus_options(self, user_input: dict[str, Any] | None = None) -> ConfigFlowResult:
+        """Options for a cloud-free Modbus-only entry: just the local poll interval (#159).
+
+        The cloud settings (API quota, extra measure points, per-device fetch, the
+        optional-Modbus-host toggle) are all meaningless here, so none are shown. The
+        WiNet-S host is managed by discovery, not the options flow.
+        """
+        if user_input is not None:
+            return self.async_create_entry(title="", data={CONF_SCAN_INTERVAL: user_input[CONF_SCAN_INTERVAL]})
+        current_interval = self.config_entry.options.get(CONF_SCAN_INTERVAL, DEFAULT_MODBUS_SCAN_INTERVAL)
+        return self.async_show_form(
+            step_id="modbus_options",
+            data_schema=vol.Schema(
+                {
+                    vol.Required(CONF_SCAN_INTERVAL, default=current_interval): vol.All(
+                        vol.Coerce(int),
+                        vol.Range(min=MIN_SCAN_INTERVAL, max=MAX_SCAN_INTERVAL),
+                    ),
+                }
+            ),
         )

--- a/custom_components/sungrow/strings.json
+++ b/custom_components/sungrow/strings.json
@@ -73,6 +73,13 @@
           "enable_device_sensors": "Create per-device sensors (EV chargers, meters, extra batteries)",
           "modbus_host": "Local Modbus host (WiNet-S IP) — optional; leave blank for cloud only"
         }
+      },
+      "modbus_options": {
+        "title": "Local Modbus Options",
+        "description": "Adjust how often Home Assistant reads the inverter directly over local Modbus. There is no cloud API quota, so you can poll frequently; the minimum is 10 seconds.",
+        "data": {
+          "scan_interval": "Polling interval (seconds)"
+        }
       }
     }
   },

--- a/custom_components/sungrow/translations/cy.json
+++ b/custom_components/sungrow/translations/cy.json
@@ -73,6 +73,13 @@
           "enable_device_sensors": "Creu synwyryddion fesul dyfais (gwefrwyr EV, mesuryddion, batris ychwanegol)",
           "modbus_host": "Gwesteiwr Modbus lleol (IP y WiNet-S) — dewisol; gadewch yn wag ar gyfer cwmwl yn unig"
         }
+      },
+      "modbus_options": {
+        "title": "Opsiynau Modbus Lleol",
+        "description": "Addaswch pa mor aml y mae Home Assistant yn darllen y gwrthdröydd yn uniongyrchol dros Modbus lleol. Nid oes cwota API cwmwl, felly gallwch holi'n aml; yr isafswm yw 10 eiliad.",
+        "data": {
+          "scan_interval": "Cyfwng holi (eiliadau)"
+        }
       }
     }
   },

--- a/custom_components/sungrow/translations/de.json
+++ b/custom_components/sungrow/translations/de.json
@@ -73,6 +73,13 @@
           "enable_device_sensors": "Sensoren pro Gerät erstellen (EV-Ladegeräte, Zähler, zusätzliche Batterien)",
           "modbus_host": "Lokaler Modbus-Host (WiNet-S-IP) — optional; für reinen Cloud-Betrieb leer lassen"
         }
+      },
+      "modbus_options": {
+        "title": "Lokale Modbus-Optionen",
+        "description": "Legen Sie fest, wie oft Home Assistant den Wechselrichter direkt über lokales Modbus ausliest. Es gibt kein Cloud-API-Kontingent, sodass Sie häufig abfragen können; das Minimum beträgt 10 Sekunden.",
+        "data": {
+          "scan_interval": "Abfrageintervall (Sekunden)"
+        }
       }
     }
   },

--- a/custom_components/sungrow/translations/en.json
+++ b/custom_components/sungrow/translations/en.json
@@ -73,6 +73,13 @@
           "enable_device_sensors": "Create per-device sensors (EV chargers, meters, extra batteries)",
           "modbus_host": "Local Modbus host (WiNet-S IP) — optional; leave blank for cloud only"
         }
+      },
+      "modbus_options": {
+        "title": "Local Modbus Options",
+        "description": "Adjust how often Home Assistant reads the inverter directly over local Modbus. There is no cloud API quota, so you can poll frequently; the minimum is 10 seconds.",
+        "data": {
+          "scan_interval": "Polling interval (seconds)"
+        }
       }
     }
   },

--- a/custom_components/sungrow/translations/es.json
+++ b/custom_components/sungrow/translations/es.json
@@ -73,6 +73,13 @@
           "enable_device_sensors": "Crear sensores por dispositivo (cargadores de VE, contadores, baterías adicionales)",
           "modbus_host": "Host Modbus local (IP del WiNet-S) — opcional; déjelo en blanco para usar solo la nube"
         }
+      },
+      "modbus_options": {
+        "title": "Opciones de Modbus local",
+        "description": "Ajuste la frecuencia con la que Home Assistant lee el inversor directamente a través de Modbus local. No hay cuota de API en la nube, por lo que puede sondear con frecuencia; el mínimo es de 10 segundos.",
+        "data": {
+          "scan_interval": "Intervalo de sondeo (segundos)"
+        }
       }
     }
   },

--- a/custom_components/sungrow/translations/fr.json
+++ b/custom_components/sungrow/translations/fr.json
@@ -73,6 +73,13 @@
           "enable_device_sensors": "Créer des capteurs par appareil (bornes de recharge EV, compteurs, batteries supplémentaires)",
           "modbus_host": "Hôte Modbus local (IP du WiNet-S) — optionnel ; laisser vide pour le cloud uniquement"
         }
+      },
+      "modbus_options": {
+        "title": "Options Modbus locales",
+        "description": "Ajustez la fréquence à laquelle Home Assistant lit l'onduleur directement via Modbus local. Il n'y a pas de quota d'API cloud, vous pouvez donc interroger fréquemment ; le minimum est de 10 secondes.",
+        "data": {
+          "scan_interval": "Intervalle d'interrogation (secondes)"
+        }
       }
     }
   },

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -665,6 +665,48 @@ async def test_options_flow_stores_and_trims_modbus_host(hass: HomeAssistant, mo
     assert entry.options[CONF_MODBUS_HOST] == "192.168.1.93"
 
 
+async def test_options_flow_modbus_only_hides_cloud_settings(hass: HomeAssistant):
+    """A Modbus-only entry's options show only the local poll interval — no cloud fields (#159).
+
+    Regression: the cloud iSolarCloud-quota description, extra measure points, per-device
+    sensors and the "leave blank for cloud only" host field must not appear on a local entry.
+    """
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={
+            CONF_TRANSPORT: TRANSPORT_MODBUS_ONLY,
+            CONF_SERIAL: "SN123",
+            CONF_MODEL: "SG3.6RS",
+            CONF_MODBUS_HOST: "10.0.0.9",
+        },
+        options={CONF_SCAN_INTERVAL: 30},
+        unique_id="modbus_SN123",
+    )
+    entry.add_to_hass(hass)
+
+    client = MagicMock()
+    client.async_read_realtime = AsyncMock(return_value={"grid_frequency": {"value": 49.9}})
+    with patch("custom_components.sungrow.modbus.SungrowModbusClient", return_value=client):
+        await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+
+        result = await hass.config_entries.options.async_init(entry.entry_id)
+        assert result["type"] == data_entry_flow.FlowResultType.FORM
+        assert result["step_id"] == "modbus_options"
+        # Only the poll interval — none of the cloud-only settings.
+        keys = {str(m.schema) for m in result["data_schema"].schema}
+        assert keys == {CONF_SCAN_INTERVAL}
+
+        result2 = await hass.config_entries.options.async_configure(
+            result["flow_id"], user_input={CONF_SCAN_INTERVAL: 15}
+        )
+        await hass.async_block_till_done()
+
+    assert result2["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
+    assert result2["data"] == {CONF_SCAN_INTERVAL: 15}
+    assert entry.options[CONF_SCAN_INTERVAL] == 15
+
+
 async def test_options_flow_rejects_invalid_extra_measure_points(
     hass: HomeAssistant, mock_setup_auth, mock_plants_service
 ):

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -7,6 +7,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pysolarcloud
 from aiohttp.test_utils import make_mocked_request
 from homeassistant.config_entries import ConfigEntryState
+from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
 from pysolarcloud.plants import DeviceType
 from pytest_homeassistant_custom_component.common import MockConfigEntry
@@ -168,9 +169,20 @@ async def test_setup_modbus_only_entry(hass: HomeAssistant):
     # The local client supplied the realtime data.
     assert data.coordinators[0].data["grid_frequency"]["value"] == 49.9
 
-    # A Modbus-only entry (no dispatch, no heartbeat) unloads cleanly.
-    assert await hass.config_entries.async_unload(entry.entry_id)
-    await hass.async_block_till_done()
+    # A Modbus-only entry must unload ONLY the platform it set up (sensor). Unloading
+    # number/select/binary_sensor — never forwarded — fails the unload in production,
+    # which breaks the options-change reload and takes every entity unavailable.
+    orig = hass.config_entries.async_unload_platforms
+    seen: dict[str, list[Platform]] = {}
+
+    async def _spy(e, platforms):
+        seen["platforms"] = list(platforms)
+        return await orig(e, platforms)
+
+    with patch.object(hass.config_entries, "async_unload_platforms", side_effect=_spy):
+        assert await hass.config_entries.async_unload(entry.entry_id)
+        await hass.async_block_till_done()
+    assert seen["platforms"] == [Platform.SENSOR]
     assert entry.state is ConfigEntryState.NOT_LOADED
 
 


### PR DESCRIPTION
Two defects found while live-testing a **discovered Modbus-only entry alongside a cloud entry** on real hardware (SG3.6RS + WiNet-S). Follow-up to #215.

## 1. Options flow showed cloud settings on a local entry
Opening the options (cog) on a cloud-free Modbus-only entry showed the **cloud** settings — the iSolarCloud API-quota description, extra measure points, per-device sensors, and a nonsensical *"Local Modbus host (WiNet-S IP) — leave blank for cloud only"* field. Saving that form wrote a blank `modbus_host` and the other cloud keys into the entry's options.

**Fix:** a dedicated `modbus_options` step for Modbus-only entries that shows **only the local poll interval** and writes only `scan_interval`. Cloud entries are unchanged.

## 2. Options change took every entity unavailable
A Modbus-only entry sets up **only** the `sensor` platform, but `async_unload_entry` unloaded **all four** platforms. Unloading `number`/`select`/`binary_sensor` — never forwarded — **fails the unload**, so the options-change reload (`OptionsFlowWithReload`) could not re-setup, and every entity went unavailable. Confirmed in the live log:

```
ERROR Error unloading entry Sungrow SG3.6RS (local) for binary_sensor / number / select
```

(The host was a red herring — the `options.get() or data.get()` fallback kept the real IP; the failed unload was the actual cause.)

**Fix:** route setup **and** unload through one `_entry_platforms()` helper so they always agree (`[SENSOR]` for Modbus-only, all four for cloud).

## Testing
- Options flow on a Modbus-only entry now shows only `scan_interval` (asserts the cloud fields are gone).
- The setup/unload test spies `async_unload_platforms` and asserts it is called with `[SENSOR]` only — this is what my original Phase 3 test missed (the test harness tolerated unloading never-loaded platforms where production does not).
- `modbus_options` strings added across all five languages.
- ruff + format + mypy clean; **404 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)