### PR TITLE
fix: Modbus-only entry reconfigure edits host, not cloud credentials (#159)

### DIFF
--- a/custom_components/sungrow/config_flow.py
+++ b/custom_components/sungrow/config_flow.py
@@ -117,6 +117,10 @@ class SungrowConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         authorization and updates the entry in place (no delete & re-add).
         """
         entry = self._get_reconfigure_entry()
+        # A cloud-free Modbus-only entry has no credentials to change; reconfigure just
+        # updates the WiNet-S host (#159), not the cloud app key/secret/gateway.
+        if entry.data.get(CONF_TRANSPORT) == TRANSPORT_MODBUS_ONLY:
+            return await self.async_step_reconfigure_modbus(user_input)
         self._reauth_entry = entry
         self._is_reconfigure = True
 
@@ -139,6 +143,31 @@ class SungrowConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                         list(GATEWAYS.keys())
                     ),
                     vol.Required(CONF_REDIRECT_URI, default=current.get(CONF_REDIRECT_URI, "")): str,
+                }
+            ),
+        )
+
+    async def async_step_reconfigure_modbus(self, user_input: dict[str, Any] | None = None) -> ConfigFlowResult:
+        """Reconfigure a cloud-free Modbus-only entry: update the WiNet-S host (#159).
+
+        No credentials are involved — the only thing worth changing is the local IP, in
+        case the WiNet-S moved to a new DHCP lease and discovery did not re-announce.
+        """
+        entry = self._get_reconfigure_entry()
+        if user_input is not None:
+            # Blank means "leave unchanged" so reconfigure can never accidentally clear
+            # the host (which would take the entry offline).
+            host = (user_input.get(CONF_MODBUS_HOST) or "").strip() or entry.data.get(CONF_MODBUS_HOST)
+            return self.async_update_reload_and_abort(
+                entry,
+                data={**entry.data, CONF_MODBUS_HOST: host},
+                reason="reconfigure_successful",
+            )
+        return self.async_show_form(
+            step_id="reconfigure_modbus",
+            data_schema=vol.Schema(
+                {
+                    vol.Required(CONF_MODBUS_HOST, default=entry.data.get(CONF_MODBUS_HOST, "")): str,
                 }
             ),
         )

--- a/custom_components/sungrow/strings.json
+++ b/custom_components/sungrow/strings.json
@@ -41,6 +41,13 @@
       "zeroconf_confirm": {
         "title": "Set up local Sungrow inverter",
         "description": "A Sungrow **{model}** was discovered on your network at **{host}** (WiNet-S). Set it up to read data directly over local Modbus — fast, unmetered and offline-capable, with no iSolarCloud account required."
+      },
+      "reconfigure_modbus": {
+        "title": "Reconfigure local Sungrow inverter",
+        "description": "Update the WiNet-S IP address if it changed on your network. This is a local Modbus connection — no iSolarCloud account is involved.",
+        "data": {
+          "modbus_host": "Local Modbus host (WiNet-S IP)"
+        }
       }
     },
     "progress": {

--- a/custom_components/sungrow/translations/cy.json
+++ b/custom_components/sungrow/translations/cy.json
@@ -41,6 +41,13 @@
       "zeroconf_confirm": {
         "title": "Gosod gwrthdröydd Sungrow lleol",
         "description": "Darganfuwyd Sungrow **{model}** ar eich rhwydwaith yn **{host}** (WiNet-S). Gosodwch ef i ddarllen data'n uniongyrchol dros Modbus lleol — cyflym, heb derfyn ac all-lein, heb angen cyfrif iSolarCloud."
+      },
+      "reconfigure_modbus": {
+        "title": "Ailgyflunio gwrthdröydd Sungrow lleol",
+        "description": "Diweddarwch gyfeiriad IP y WiNet-S os yw wedi newid ar eich rhwydwaith. Cysylltiad Modbus lleol yw hwn — nid oes cyfrif iSolarCloud yn gysylltiedig.",
+        "data": {
+          "modbus_host": "Gwesteiwr Modbus lleol (IP WiNet-S)"
+        }
       }
     },
     "progress": {

--- a/custom_components/sungrow/translations/de.json
+++ b/custom_components/sungrow/translations/de.json
@@ -41,6 +41,13 @@
       "zeroconf_confirm": {
         "title": "Lokalen Sungrow-Wechselrichter einrichten",
         "description": "Ein Sungrow **{model}** wurde in Ihrem Netzwerk unter **{host}** (WiNet-S) gefunden. Richten Sie ihn ein, um Daten direkt über lokales Modbus zu lesen — schnell, ohne Limit und offline-fähig, ohne iSolarCloud-Konto."
+      },
+      "reconfigure_modbus": {
+        "title": "Lokalen Sungrow-Wechselrichter neu konfigurieren",
+        "description": "Aktualisieren Sie die WiNet-S-IP-Adresse, falls sie sich in Ihrem Netzwerk geändert hat. Dies ist eine lokale Modbus-Verbindung — es ist kein iSolarCloud-Konto beteiligt.",
+        "data": {
+          "modbus_host": "Lokaler Modbus-Host (WiNet-S-IP)"
+        }
       }
     },
     "progress": {

--- a/custom_components/sungrow/translations/en.json
+++ b/custom_components/sungrow/translations/en.json
@@ -41,6 +41,13 @@
       "zeroconf_confirm": {
         "title": "Set up local Sungrow inverter",
         "description": "A Sungrow **{model}** was discovered on your network at **{host}** (WiNet-S). Set it up to read data directly over local Modbus — fast, unmetered and offline-capable, with no iSolarCloud account required."
+      },
+      "reconfigure_modbus": {
+        "title": "Reconfigure local Sungrow inverter",
+        "description": "Update the WiNet-S IP address if it changed on your network. This is a local Modbus connection — no iSolarCloud account is involved.",
+        "data": {
+          "modbus_host": "Local Modbus host (WiNet-S IP)"
+        }
       }
     },
     "progress": {

--- a/custom_components/sungrow/translations/es.json
+++ b/custom_components/sungrow/translations/es.json
@@ -41,6 +41,13 @@
       "zeroconf_confirm": {
         "title": "Configurar inversor Sungrow local",
         "description": "Se descubrió un Sungrow **{model}** en su red en **{host}** (WiNet-S). Configúrelo para leer datos directamente por Modbus local — rápido, sin límites y sin conexión, sin necesidad de una cuenta de iSolarCloud."
+      },
+      "reconfigure_modbus": {
+        "title": "Reconfigurar inversor Sungrow local",
+        "description": "Actualice la dirección IP del WiNet-S si ha cambiado en su red. Esta es una conexión Modbus local — no interviene ninguna cuenta de iSolarCloud.",
+        "data": {
+          "modbus_host": "Host Modbus local (IP del WiNet-S)"
+        }
       }
     },
     "progress": {

--- a/custom_components/sungrow/translations/fr.json
+++ b/custom_components/sungrow/translations/fr.json
@@ -41,6 +41,13 @@
       "zeroconf_confirm": {
         "title": "Configurer l'onduleur Sungrow local",
         "description": "Un Sungrow **{model}** a été découvert sur votre réseau à **{host}** (WiNet-S). Configurez-le pour lire les données directement via Modbus local — rapide, sans quota et hors ligne, sans compte iSolarCloud."
+      },
+      "reconfigure_modbus": {
+        "title": "Reconfigurer l'onduleur Sungrow local",
+        "description": "Mettez à jour l'adresse IP du WiNet-S si elle a changé sur votre réseau. Il s'agit d'une connexion Modbus locale — aucun compte iSolarCloud n'est impliqué.",
+        "data": {
+          "modbus_host": "Hôte Modbus local (IP du WiNet-S)"
+        }
       }
     },
     "progress": {

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -556,6 +556,78 @@ async def test_reconfigure_shows_form(hass: HomeAssistant, mock_auth):
     assert result["step_id"] == "reconfigure"
 
 
+async def test_reconfigure_modbus_only_edits_host_not_credentials(hass: HomeAssistant):
+    """Reconfiguring a Modbus-only entry edits the WiNet-S host — never cloud credentials (#159).
+
+    Regression: a cloud-free local hub must not present the app key/secret/gateway form.
+    """
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={
+            CONF_TRANSPORT: TRANSPORT_MODBUS_ONLY,
+            CONF_SERIAL: "SN123",
+            CONF_MODEL: "SG3.6RS",
+            CONF_MODBUS_HOST: "10.0.0.9",
+        },
+        options={CONF_SCAN_INTERVAL: 30},
+        unique_id="modbus_SN123",
+    )
+    entry.add_to_hass(hass)
+
+    client = MagicMock()
+    client.async_read_realtime = AsyncMock(return_value={"grid_frequency": {"value": 49.9}})
+    with patch("custom_components.sungrow.modbus.SungrowModbusClient", return_value=client):
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN,
+            context={"source": config_entries.SOURCE_RECONFIGURE, "entry_id": entry.entry_id},
+        )
+        assert result["type"] == data_entry_flow.FlowResultType.FORM
+        assert result["step_id"] == "reconfigure_modbus"
+        # Only the local host — none of the cloud credential fields.
+        keys = {str(m.schema) for m in result["data_schema"].schema}
+        assert keys == {CONF_MODBUS_HOST}
+
+        result2 = await hass.config_entries.flow.async_configure(
+            result["flow_id"], user_input={CONF_MODBUS_HOST: "192.168.1.55"}
+        )
+        await hass.async_block_till_done()
+
+    assert result2["type"] == data_entry_flow.FlowResultType.ABORT
+    assert result2["reason"] == "reconfigure_successful"
+    assert entry.data[CONF_MODBUS_HOST] == "192.168.1.55"
+
+
+async def test_reconfigure_modbus_only_blank_keeps_current_host(hass: HomeAssistant):
+    """Submitting a blank host on reconfigure leaves the existing WiNet-S host intact (#159)."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={
+            CONF_TRANSPORT: TRANSPORT_MODBUS_ONLY,
+            CONF_SERIAL: "SN123",
+            CONF_MODEL: "SG3.6RS",
+            CONF_MODBUS_HOST: "10.0.0.9",
+        },
+        options={CONF_SCAN_INTERVAL: 30},
+        unique_id="modbus_SN123",
+    )
+    entry.add_to_hass(hass)
+
+    client = MagicMock()
+    client.async_read_realtime = AsyncMock(return_value={"grid_frequency": {"value": 49.9}})
+    with patch("custom_components.sungrow.modbus.SungrowModbusClient", return_value=client):
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN,
+            context={"source": config_entries.SOURCE_RECONFIGURE, "entry_id": entry.entry_id},
+        )
+        result2 = await hass.config_entries.flow.async_configure(
+            result["flow_id"], user_input={CONF_MODBUS_HOST: "   "}
+        )
+        await hass.async_block_till_done()
+
+    assert result2["type"] == data_entry_flow.FlowResultType.ABORT
+    assert entry.data[CONF_MODBUS_HOST] == "10.0.0.9"
+
+
 async def test_reconfigure_updates_settings_and_reauthorizes(hass: HomeAssistant, mock_auth):
     """Reconfigure changes region/credentials (App ID fixed) and re-authorizes in place (#80)."""
     entry = _hub_entry(hass)  # gateway=Europe, app_id=test_app_id


### PR DESCRIPTION
Found while running a Modbus-only (discovered) entry and a cloud entry side by side. Follow-up to #222 — same family: a cloud-free local hub must never surface cloud-only UI.

## Problem
**Reconfigure** on a Modbus-only hub showed the **cloud credential form** — app key, app secret, gateway, redirect URI — none of which exist for a local entry. `async_step_reconfigure` never branched on transport.

## Fix
Branch `async_step_reconfigure`: a Modbus-only entry gets a dedicated `reconfigure_modbus` step that edits **only the WiNet-S host** (useful if the dongle's IP changed and discovery didn't re-announce). A blank submission leaves the current host intact, so reconfigure can never accidentally clear it and take the entry offline. Cloud entries are unchanged.

## Testing
- Reconfigure on a Modbus-only entry shows only the host field (asserts no `app_secret` etc.) and updates `modbus_host`.
- A blank host submission keeps the existing host.
- `reconfigure_modbus` strings added across all five languages; parity test green.
- ruff + format + mypy clean; **406 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)