### PR TITLE
feat: discovery offers to add local Modbus to an existing cloud entry (#218)

### DIFF
--- a/custom_components/sungrow/config_flow.py
+++ b/custom_components/sungrow/config_flow.py
@@ -10,6 +10,7 @@ from aiohttp import ClientError
 from homeassistant import config_entries, data_entry_flow
 from homeassistant.config_entries import ConfigEntry, ConfigFlowResult
 from homeassistant.core import callback
+from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.network import get_url
 from homeassistant.helpers.service_info.zeroconf import ZeroconfServiceInfo
@@ -90,6 +91,9 @@ class SungrowConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         # Zeroconf-discovered WiNet-S local Modbus host, carried into the confirm step
         # that creates the cloud-free Modbus-only entry (#159).
         self._discovered_modbus_host: str | None = None
+        # Entry id of an existing cloud entry that already monitors the discovered
+        # inverter, when discovery offers to add local Modbus to it (hybrid, #218).
+        self._cloud_entry_id: str | None = None
 
     @staticmethod
     @callback
@@ -189,7 +193,59 @@ class SungrowConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         self._discovered_modbus_host = host
         self.init_info = {CONF_SERIAL: serial, CONF_MODEL: model or "Inverter"}
         self.context["title_placeholders"] = {"name": f"Sungrow {model or 'inverter'}"}
+        # If this inverter is already set up via the cloud, offer to add fast local Modbus
+        # to that entry (hybrid) rather than creating a duplicate device (#218).
+        cloud_entry = self._find_cloud_entry_for_serial(serial)
+        if cloud_entry is not None:
+            self._cloud_entry_id = cloud_entry.entry_id
+            return await self.async_step_attach_modbus()
         return await self.async_step_zeroconf_confirm()
+
+    def _find_cloud_entry_for_serial(self, serial: str) -> ConfigEntry | None:
+        """Return a cloud entry that already monitors this inverter serial, else None (#218).
+
+        Matches on the device-registry ``serial_number`` (set from the cloud ``device_sn``),
+        which equals the WiNet-S-advertised serial for the same physical inverter. Cloud
+        entries that already have a Modbus host are skipped — they are hybrid already.
+        """
+        registry = dr.async_get(self.hass)
+        for entry in self.hass.config_entries.async_entries(DOMAIN):
+            if entry.data.get(CONF_TRANSPORT) == TRANSPORT_MODBUS_ONLY:
+                continue
+            if entry.options.get(CONF_MODBUS_HOST) or entry.data.get(CONF_MODBUS_HOST):
+                continue
+            for device in dr.async_entries_for_config_entry(registry, entry.entry_id):
+                if device.serial_number and device.serial_number == serial:
+                    return entry
+        return None
+
+    async def async_step_attach_modbus(self, user_input: dict[str, Any] | None = None) -> ConfigFlowResult:
+        """Offer to enable local Modbus on the existing cloud entry for this inverter (#218).
+
+        Confirming writes the discovered host into the cloud entry's options and reloads it,
+        so the Phase 2 hybrid overlay serves Modbus-preferred values with cloud fallback —
+        one device, no duplicate.
+        """
+        cloud_entry = self.hass.config_entries.async_get_entry(self._cloud_entry_id or "")
+        if cloud_entry is None:
+            # The cloud entry vanished between steps; fall back to a standalone local entry.
+            return await self.async_step_zeroconf_confirm()
+        if user_input is not None:
+            self.hass.config_entries.async_update_entry(
+                cloud_entry,
+                options={**cloud_entry.options, CONF_MODBUS_HOST: self._discovered_modbus_host},
+            )
+            self.hass.async_create_task(self.hass.config_entries.async_reload(cloud_entry.entry_id))
+            return self.async_abort(reason="modbus_enabled_on_cloud")
+        self._set_confirm_only()
+        return self.async_show_form(
+            step_id="attach_modbus",
+            description_placeholders={
+                "model": self.init_info.get(CONF_MODEL, "Inverter"),
+                "host": self._discovered_modbus_host or "",
+                "cloud": cloud_entry.title,
+            },
+        )
 
     async def async_step_zeroconf_confirm(self, user_input: dict[str, Any] | None = None) -> ConfigFlowResult:
         """Confirm setting up the discovered WiNet-S as a local (Modbus-only) integration."""

--- a/custom_components/sungrow/strings.json
+++ b/custom_components/sungrow/strings.json
@@ -48,6 +48,10 @@
         "data": {
           "modbus_host": "Local Modbus host (WiNet-S IP)"
         }
+      },
+      "attach_modbus": {
+        "title": "Add local Modbus to your Sungrow inverter",
+        "description": "A Sungrow **{model}** was discovered at **{host}** (WiNet-S), and it is already set up via iSolarCloud (**{cloud}**). Add fast local Modbus to that entry — its data will come from the local connection first (Modbus preferred) and fall back to the cloud — without creating a duplicate device."
       }
     },
     "progress": {
@@ -61,6 +65,7 @@
     },
     "abort": {
       "already_configured": "Device is already configured",
+      "modbus_enabled_on_cloud": "Local Modbus was enabled on your existing iSolarCloud entry for this inverter.",
       "not_sungrow_device": "The discovered device is not a supported Sungrow inverter.",
       "library_missing": "The pysolarcloud library is not installed. Restart Home Assistant so the integration's requirements are installed, then try again.",
       "missing_code": "Authorization code was not received. Please try again.",

--- a/custom_components/sungrow/translations/cy.json
+++ b/custom_components/sungrow/translations/cy.json
@@ -48,6 +48,10 @@
         "data": {
           "modbus_host": "Gwesteiwr Modbus lleol (IP WiNet-S)"
         }
+      },
+      "attach_modbus": {
+        "title": "Ychwanegu Modbus lleol at eich gwrthdröydd Sungrow",
+        "description": "Canfuwyd Sungrow **{model}** yn **{host}** (WiNet-S), ac mae eisoes wedi'i sefydlu drwy iSolarCloud (**{cloud}**). Ychwanegwch Modbus lleol cyflym at y cofnod hwnnw — daw ei ddata o'r cysylltiad lleol yn gyntaf (Modbus a ffefrir) gan syrthio'n ôl i'r cwmwl — heb greu dyfais ddyblyg."
       }
     },
     "progress": {
@@ -66,7 +70,8 @@
       "reauth_successful": "Roedd yr ail-ddilysiad yn llwyddiannus",
       "reconfigure_successful": "Roedd yr ailgyflunio'n llwyddiannus",
       "wrong_account": "Nid yw'r cyfrif awdurdodedig yn cyfateb i App ID yr integreiddiad hwn. Defnyddiwch y cymhwysiad datblygwr gwreiddiol.",
-      "not_sungrow_device": "Nid yw'r ddyfais a ddarganfuwyd yn wrthdröydd Sungrow a gefnogir."
+      "not_sungrow_device": "Nid yw'r ddyfais a ddarganfuwyd yn wrthdröydd Sungrow a gefnogir.",
+      "modbus_enabled_on_cloud": "Galluogwyd Modbus lleol ar eich cofnod iSolarCloud presennol ar gyfer y gwrthdröydd hwn."
     }
   },
   "options": {

--- a/custom_components/sungrow/translations/de.json
+++ b/custom_components/sungrow/translations/de.json
@@ -48,6 +48,10 @@
         "data": {
           "modbus_host": "Lokaler Modbus-Host (WiNet-S-IP)"
         }
+      },
+      "attach_modbus": {
+        "title": "Lokales Modbus zu Ihrem Sungrow-Wechselrichter hinzufügen",
+        "description": "Ein Sungrow **{model}** wurde unter **{host}** (WiNet-S) erkannt und ist bereits über iSolarCloud (**{cloud}**) eingerichtet. Fügen Sie diesem Eintrag schnelles lokales Modbus hinzu — die Daten kommen zuerst aus der lokalen Verbindung (Modbus bevorzugt) und fallen auf die Cloud zurück — ohne ein doppeltes Gerät zu erstellen."
       }
     },
     "progress": {
@@ -66,7 +70,8 @@
       "reauth_successful": "Die erneute Authentifizierung war erfolgreich",
       "reconfigure_successful": "Die Neukonfiguration war erfolgreich",
       "wrong_account": "Das autorisierte Konto stimmt nicht mit der App ID dieser Integration überein. Verwenden Sie die ursprüngliche Entwickleranwendung.",
-      "not_sungrow_device": "Das gefundene Gerät ist kein unterstützter Sungrow-Wechselrichter."
+      "not_sungrow_device": "Das gefundene Gerät ist kein unterstützter Sungrow-Wechselrichter.",
+      "modbus_enabled_on_cloud": "Lokales Modbus wurde für diesen Wechselrichter in Ihrem vorhandenen iSolarCloud-Eintrag aktiviert."
     }
   },
   "options": {

--- a/custom_components/sungrow/translations/en.json
+++ b/custom_components/sungrow/translations/en.json
@@ -48,6 +48,10 @@
         "data": {
           "modbus_host": "Local Modbus host (WiNet-S IP)"
         }
+      },
+      "attach_modbus": {
+        "title": "Add local Modbus to your Sungrow inverter",
+        "description": "A Sungrow **{model}** was discovered at **{host}** (WiNet-S), and it is already set up via iSolarCloud (**{cloud}**). Add fast local Modbus to that entry — its data will come from the local connection first (Modbus preferred) and fall back to the cloud — without creating a duplicate device."
       }
     },
     "progress": {
@@ -66,7 +70,8 @@
       "reauth_successful": "Re-authentication was successful",
       "reconfigure_successful": "Reconfiguration was successful",
       "wrong_account": "The authorized account does not match this integration's App ID. Use the original developer application.",
-      "not_sungrow_device": "The discovered device is not a supported Sungrow inverter."
+      "not_sungrow_device": "The discovered device is not a supported Sungrow inverter.",
+      "modbus_enabled_on_cloud": "Local Modbus was enabled on your existing iSolarCloud entry for this inverter."
     }
   },
   "options": {

--- a/custom_components/sungrow/translations/es.json
+++ b/custom_components/sungrow/translations/es.json
@@ -48,6 +48,10 @@
         "data": {
           "modbus_host": "Host Modbus local (IP del WiNet-S)"
         }
+      },
+      "attach_modbus": {
+        "title": "Añadir Modbus local a su inversor Sungrow",
+        "description": "Se detectó un Sungrow **{model}** en **{host}** (WiNet-S), y ya está configurado a través de iSolarCloud (**{cloud}**). Añada Modbus local rápido a esa entrada — sus datos provendrán primero de la conexión local (Modbus preferido) y recurrirán a la nube — sin crear un dispositivo duplicado."
       }
     },
     "progress": {
@@ -66,7 +70,8 @@
       "reauth_successful": "La reautenticación se realizó correctamente",
       "reconfigure_successful": "La reconfiguración se realizó correctamente",
       "wrong_account": "La cuenta autorizada no coincide con el App ID de esta integración. Use la aplicación de desarrollador original.",
-      "not_sungrow_device": "El dispositivo descubierto no es un inversor Sungrow compatible."
+      "not_sungrow_device": "El dispositivo descubierto no es un inversor Sungrow compatible.",
+      "modbus_enabled_on_cloud": "Se habilitó Modbus local en su entrada de iSolarCloud existente para este inversor."
     }
   },
   "options": {

--- a/custom_components/sungrow/translations/fr.json
+++ b/custom_components/sungrow/translations/fr.json
@@ -48,6 +48,10 @@
         "data": {
           "modbus_host": "Hôte Modbus local (IP du WiNet-S)"
         }
+      },
+      "attach_modbus": {
+        "title": "Ajouter Modbus local à votre onduleur Sungrow",
+        "description": "Un Sungrow **{model}** a été découvert à **{host}** (WiNet-S), et il est déjà configuré via iSolarCloud (**{cloud}**). Ajoutez le Modbus local rapide à cette entrée — ses données proviendront d'abord de la connexion locale (Modbus préféré) et basculeront vers le cloud — sans créer de doublon."
       }
     },
     "progress": {
@@ -66,7 +70,8 @@
       "reauth_successful": "La ré-authentification a réussi",
       "reconfigure_successful": "La reconfiguration a réussi",
       "wrong_account": "Le compte autorisé ne correspond pas à l'App ID de cette intégration. Utilisez l'application développeur d'origine.",
-      "not_sungrow_device": "L'appareil découvert n'est pas un onduleur Sungrow pris en charge."
+      "not_sungrow_device": "L'appareil découvert n'est pas un onduleur Sungrow pris en charge.",
+      "modbus_enabled_on_cloud": "Le Modbus local a été activé sur votre entrée iSolarCloud existante pour cet onduleur."
     }
   },
   "options": {

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -14,6 +14,7 @@ import pytest
 from aiohttp import ClientError
 from homeassistant import config_entries, data_entry_flow
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.service_info.zeroconf import ZeroconfServiceInfo
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 
@@ -890,3 +891,65 @@ async def test_zeroconf_aborts_when_already_configured_and_updates_host(hass: Ho
     assert result["reason"] == "already_configured"
     # The WiNet-S moved to a new DHCP lease; the stored host follows it.
     assert entry.data[CONF_MODBUS_HOST] == "192.168.1.99"
+
+
+def _add_cloud_entry_with_inverter(
+    hass: HomeAssistant, serial: str, *, title: str = "My Cloud Plant"
+) -> MockConfigEntry:
+    """A cloud entry whose device registry has an inverter with the given serial (#218)."""
+    cloud = MockConfigEntry(domain=DOMAIN, data=MOCK_CONFIG_DATA.copy(), unique_id="test_app_id", title=title)
+    cloud.add_to_hass(hass)
+    dr.async_get(hass).async_get_or_create(
+        config_entry_id=cloud.entry_id,
+        identifiers={(DOMAIN, f"cloud-{serial}")},
+        serial_number=serial,
+        manufacturer="Sungrow",
+    )
+    return cloud
+
+
+async def test_zeroconf_offers_attach_when_inverter_already_cloud_configured(hass: HomeAssistant):
+    """Discovering an inverter already set up via cloud offers to add local Modbus to it (#218)."""
+    _add_cloud_entry_with_inverter(hass, "A2340512345")
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_ZEROCONF}, data=_winet_discovery(serial="A2340512345")
+    )
+
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
+    assert result["step_id"] == "attach_modbus"
+    assert result["description_placeholders"]["cloud"] == "My Cloud Plant"
+
+
+async def test_zeroconf_attach_enables_hybrid_on_cloud_entry(hass: HomeAssistant):
+    """Confirming the attach step writes the Modbus host onto the cloud entry (hybrid) (#218)."""
+    cloud = _add_cloud_entry_with_inverter(hass, "SNMATCH")
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": config_entries.SOURCE_ZEROCONF},
+        data=_winet_discovery(host="192.168.1.77", serial="SNMATCH"),
+    )
+    assert result["step_id"] == "attach_modbus"
+
+    with patch("custom_components.sungrow.async_setup_entry", return_value=True):
+        result2 = await hass.config_entries.flow.async_configure(result["flow_id"], user_input={})
+        await hass.async_block_till_done()
+
+    assert result2["type"] == data_entry_flow.FlowResultType.ABORT
+    assert result2["reason"] == "modbus_enabled_on_cloud"
+    # The cloud entry became hybrid: the discovered host is now in its options.
+    assert cloud.options[CONF_MODBUS_HOST] == "192.168.1.77"
+
+
+async def test_zeroconf_no_attach_when_cloud_entry_already_hybrid(hass: HomeAssistant):
+    """A cloud entry that already has a Modbus host is skipped — discovery stays standalone (#218)."""
+    cloud = _add_cloud_entry_with_inverter(hass, "A2340512345")
+    hass.config_entries.async_update_entry(cloud, options={CONF_MODBUS_HOST: "10.0.0.1"})
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_ZEROCONF}, data=_winet_discovery(serial="A2340512345")
+    )
+
+    # No hybrid attach offered; falls through to the standalone Modbus-only confirm.
+    assert result["step_id"] == "zeroconf_confirm"


### PR DESCRIPTION
Closes #218.

When zeroconf discovers a WiNet-S for an inverter you **already monitor via iSolarCloud**, discovery now offers to enable **fast local Modbus on that existing entry** (hybrid) instead of creating a second device for the same inverter.

## How it works
- **Match:** on the device-registry `serial_number` (set from the cloud `device_sn`), which equals the WiNet-S-advertised serial for the same physical inverter. Confirmed live: both sources report the same serial.
- **Attach:** confirming writes the discovered host into the cloud entry's **options** and reloads it — the Phase 2 hybrid overlay (#214) then serves Modbus-preferred values with cloud fallback. One device, no duplicate.
- **Fallback:** no matching cloud entry → the standalone Modbus-only confirm as before. A cloud entry that already has a Modbus host is skipped (already hybrid).

This directly resolves the duplicate-device situation observed live (cloud + discovered Modbus-only entry for one SG3.6RS). The chosen behaviour is *attach to the cloud entry* — nothing is auto-applied; the user confirms on the discovery card.

## Testing
- A matching cloud inverter → discovery shows the `attach_modbus` step (with the cloud entry's title).
- Confirming writes `modbus_host` onto the cloud entry's options and aborts `modbus_enabled_on_cloud`.
- A cloud entry already carrying a Modbus host is skipped → standalone `zeroconf_confirm`.
- `attach_modbus` step + `modbus_enabled_on_cloud` abort strings across all five languages; parity green.
- ruff + format + mypy clean; **409 passed**.

## Note
Provenance across a *single merged device* (each entity showing cloud vs Modbus source) is the broader #217 work; this PR reuses the existing hybrid overlay, which merges by measure-point code on the one cloud device.

🤖 Generated with [Claude Code](https://claude.com/claude-code)