### PR TITLE
docs: local Modbus setup + transport-mode guide (#221)

### DIFF
--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -197,6 +197,54 @@ Non-battery controls — **Export Limitation**, **Export Limit (Power/%)**, and
 
 ---
 
+## Local Modbus (WiNet-S)
+
+These apply to the optional [local Modbus transport](local-modbus.md) (hybrid or Modbus-only
+setups). Cloud-only setups are unaffected.
+
+### The WiNet-S wasn't auto-discovered
+
+Discovery uses **mDNS/zeroconf**, which does **not** cross subnets or VLANs by default.
+
+- Make sure Home Assistant and the WiNet-S are on the **same network segment**. If they're
+  on different VLANs/subnets, the discovery card won't appear.
+- You don't have to wait for discovery: on an existing cloud entry, add the dongle manually
+  via **Configure → Local Modbus host** (hybrid). This talks straight to the dongle's IP and
+  needs no mDNS.
+- If discovery is dismissed, it reappears the next time the dongle is seen; you can also
+  reload the integration or restart Home Assistant to re-trigger it.
+
+### Local reads fail / "Cannot connect" over Modbus
+
+The dongle is reachable for mDNS (port 80) but Modbus reads use **TCP port 502**. If sensors
+are unavailable on a Modbus-only entry, or a hybrid entry keeps falling back to the cloud:
+
+- Confirm the WiNet-S IP is correct and **reachable on port 502** from the Home Assistant
+  host (a firewall/VLAN ACL may block 502 even when the web UI on 80 is reachable).
+- The WiNet-S allows only a **limited number of Modbus TCP clients** — if another tool
+  (another HA integration, a Modbus poller, node-RED) already holds the connection, reads
+  here can fail intermittently. Close the other client.
+- If the dongle's IP changed, a Modbus-only entry updates it automatically on the next
+  discovery; for a hybrid entry, update the **Local Modbus host** field. A **DHCP
+  reservation** for the dongle avoids this.
+
+### `daily_yield` reads higher over Modbus than in the cloud
+
+Known issue on some SG-RS firmware
+([#223](https://github.com/KRoperUK/sungrow-hass/issues/223)) — a scaling/semantics mismatch
+under investigation. **`total_yield` matches the cloud**; only the daily figure diverges. If
+you rely on the daily total, use the cloud value (cloud-only or the cloud sensor on a hybrid
+entry) until it's resolved.
+
+### My inverter model isn't read over Modbus
+
+Local Modbus currently maps only the **SG-RS single-phase string inverters**. Other models
+(SH hybrids, three-phase SG, standalone battery/meter) aren't in the register map yet
+([#219](https://github.com/KRoperUK/sungrow-hass/issues/219)) — use **cloud-only** or
+**hybrid** (the cloud half returns everything) in the meantime.
+
+---
+
 ## Still stuck?
 
 Open a [bug report](https://github.com/KRoperUK/sungrow-hass/issues/new/choose)

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -68,6 +68,15 @@ manufacturer. The Fault sensor exposes an `operating_status` attribute with a hu
 reason for inverter/ESS devices (e.g. *Shut down due to faults*, *Low insulation resistance*),
 and the Connectivity sensor exposes the commissioning date as an attribute.
 
+## Local Modbus host (hybrid)
+
+The options flow has a **Local Modbus host (WiNet-S IP)** field. Leave it blank for the
+default cloud-only behaviour, or enter your WiNet-S dongle's IP address to read the inverter
+**directly over your LAN** — local values are used first and the cloud is a fallback. This is
+faster and doesn't use API quota, while you keep the full cloud sensor set and all
+dispatch/control entities. See [Local Modbus (WiNet-S)](local-modbus.md) for the transport
+modes, auto-discovery, and current limitations.
+
 ## Energy dashboard
 
 Sensors are classified with the correct `device_class` / `state_class`, so energy points (Wh/kWh,

--- a/docs/index.md
+++ b/docs/index.md
@@ -15,7 +15,11 @@ inverters** through the **iSolarCloud** cloud API, using the
 ## Features
 
 - **Cloud polling** — real-time data from the iSolarCloud API (`iot_class: cloud_polling`).
-- **Auto-discovery** — finds every plant linked to your account.
+- **Local Modbus (WiNet-S)** — optionally read the inverter directly over your LAN: as a
+  fast, quota-free overlay on a cloud entry (hybrid), or as a fully cloud-free setup created
+  by auto-discovery. See [Local Modbus](local-modbus.md).
+- **Auto-discovery** — finds every plant linked to your account, and discovers WiNet-S
+  dongles on the network for local Modbus.
 - **Rich sensors** — power, energy, battery SOC, and more, with correct device/state classes so
   they work in the Energy dashboard out of the box.
 - **Device health & diagnostics** — per-device **Fault** and **Connectivity** binary sensors,
@@ -77,7 +81,8 @@ modelled.
   [Installation & Setup](installation.md).
 
 !!! tip "New here?"
-    Start with [Installation & Setup](installation.md). If something goes wrong, the
+    Start with [Installation & Setup](installation.md). Want fast local reads or a cloud-free
+    setup? See [Local Modbus (WiNet-S)](local-modbus.md). If something goes wrong, the
     [Troubleshooting](TROUBLESHOOTING.md) page covers the common auth and "unavailable" issues.
 
 ## Links

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -7,6 +7,12 @@ icon: lucide/download
 Setting up the integration has three parts: create an **iSolarCloud OpenAPI application**,
 install the integration via **HACS**, then **add and authorize** it in Home Assistant.
 
+!!! tip "No cloud account? Use local Modbus"
+    You don't strictly need an iSolarCloud application if you only want **read-only** sensors
+    over your LAN. Install via HACS (step 2 below), and Home Assistant will **auto-discover**
+    your WiNet-S dongle for a cloud-free local setup. See
+    [Local Modbus (WiNet-S)](local-modbus.md) for the transport modes and current limitations.
+
 ## 1. Create an iSolarCloud OpenAPI application
 
 The integration talks to iSolarCloud's OpenAPI, which requires your own application credentials.

--- a/docs/local-modbus.md
+++ b/docs/local-modbus.md
@@ -1,0 +1,174 @@
+---
+icon: lucide/network
+---
+
+# Local Modbus (WiNet-S)
+
+Besides the cloud, the integration can read your inverter **directly over your local
+network** using the **WiNet-S** dongle's Modbus TCP interface. Local reads are fast,
+don't count against any API quota, and keep working even when the internet (or
+iSolarCloud) is down.
+
+You can use local Modbus in two ways: **on its own** (a fully cloud-free setup, created by
+auto-discovery) or **alongside the cloud** (a hybrid entry that reads locally first and
+falls back to the cloud). The [transport modes](#transport-modes) section explains when to
+pick each.
+
+!!! info "What's supported today"
+    Local Modbus currently maps the **SG-RS single-phase string inverters** (e.g. SG3.6RS)
+    and is **read-only**. Wider model coverage and local control are tracked in
+    [#219](https://github.com/KRoperUK/sungrow-hass/issues/219) and
+    [#220](https://github.com/KRoperUK/sungrow-hass/issues/220) — see
+    [Current limitations](#current-limitations).
+
+## What you need
+
+- A **WiNet-S** communication dongle on the **same LAN** as Home Assistant.
+- The dongle reachable on **TCP port 502** (Modbus TCP) from Home Assistant — the default
+  Modbus port and unit ID (`1`) are used automatically.
+- **No iSolarCloud account** for a Modbus-only setup. (The hybrid mode still needs the cloud
+  account for its cloud half.)
+- A supported inverter — **SG-RS** today (see [limitations](#current-limitations)).
+
+!!! tip "mDNS discovery must be able to reach Home Assistant"
+    The dongle is found via **mDNS/zeroconf**, which doesn't cross subnets or VLANs by
+    default. If Home Assistant and the WiNet-S are on different network segments, discovery
+    won't fire — add Modbus manually instead (see
+    [Add local Modbus to a cloud entry](#hybrid-add-local-modbus-to-a-cloud-entry)).
+
+## Transport modes
+
+The integration supports three "transport" modes. They differ in where readings come from
+and whether a cloud account is involved:
+
+| Mode | Data source | Cloud account | Control (dispatch) | Best for |
+| --- | --- | --- | --- | --- |
+| **Cloud-only** *(default)* | iSolarCloud API | Required | ✅ Yes | The standard setup — full sensor set and battery/dispatch controls. |
+| **Cloud + Modbus** *(hybrid)* | Local Modbus **first**, cloud fallback | Required | ✅ Yes (via cloud) | Fast, unmetered local reads **plus** the cloud's full sensor and control set. |
+| **Modbus-only** *(local)* | Local Modbus only | **Not needed** | ❌ Read-only | Offline / privacy-first setups, or where you don't have working cloud credentials. |
+
+```mermaid
+flowchart LR
+    subgraph HA["🏠 Home Assistant"]
+        direction TB
+        CO["Cloud-only entry"]
+        HY["Hybrid entry"]
+        LO["Modbus-only entry"]
+    end
+    CO -->|"poll"| API["☁️ iSolarCloud OpenAPI"]
+    HY -->|"prefer"| WN["🔌 WiNet-S<br/>Modbus TCP :502"]
+    HY -.->|"fall back"| API
+    LO -->|"only"| WN
+    API --> INV["Inverter"]
+    WN --> INV
+```
+
+**Which should I choose?**
+
+- **Just getting started, or you want battery/dispatch control** → **Cloud-only**. Start
+  from [Installation & Setup](installation.md).
+- **You already run cloud and want faster, quota-free local reads** → **Hybrid**. Keep your
+  cloud entry and [add a Modbus host](#hybrid-add-local-modbus-to-a-cloud-entry) to it.
+- **No cloud account (or it isn't working) and you only need read-only sensors** →
+  **Modbus-only**, via [auto-discovery](#modbus-only-set-up-from-auto-discovery).
+
+## Modbus-only: set up from auto-discovery
+
+When a WiNet-S dongle appears on your network, Home Assistant discovers it automatically and
+offers a **cloud-free** local setup.
+
+```mermaid
+sequenceDiagram
+    autonumber
+    participant WN as WiNet-S
+    participant HA as Home Assistant
+    actor You
+    WN-->>HA: mDNS advert (serial + model)
+    HA-->>You: "Discovered: Sungrow <model>"
+    You->>HA: Set up
+    HA->>WN: Read inverter over Modbus TCP :502
+    HA->>HA: Create local entry + sensors
+```
+
+1. Go to **Settings → Devices & Services**. A **Discovered** card reading **Sungrow
+   *&lt;model&gt;*** appears (identified from the dongle's advertised serial and model).
+2. Click **Set up**. A confirmation screen explains it will read the inverter directly over
+   local Modbus — no iSolarCloud account required.
+3. Confirm. Home Assistant creates an entry titled **"Sungrow *&lt;model&gt;* (local)"** and
+   its sensors. Polling defaults to **30 seconds** (there's no cloud quota, so you can poll
+   frequently — the minimum is 10 seconds).
+
+!!! note "Already set up via the cloud?"
+    If this same inverter is **already configured through iSolarCloud**, discovery detects
+    that (by matching the serial number) and instead offers to **add local Modbus to your
+    existing entry** — see below. This avoids creating a duplicate device.
+
+### If the inverter is already on the cloud (attach prompt)
+
+When discovery finds a dongle for an inverter you already monitor via iSolarCloud, it shows
+an **"Add local Modbus to your Sungrow inverter"** prompt naming the discovered model, its
+host, and the matching cloud entry. Confirming enables **hybrid** mode on that existing cloud
+entry — local reads with cloud fallback, **one device, no duplicate**. To keep things
+cloud-only instead, simply ignore the discovery card.
+
+## Hybrid: add local Modbus to a cloud entry
+
+You can also enable Modbus on an existing cloud entry manually, at any time:
+
+**Settings → Devices & Services → Sungrow iSolarCloud → Configure → Local Modbus host.**
+
+Enter the WiNet-S IP address and save. The entry reloads and starts serving **Modbus-preferred**
+values: each reading comes from the local dongle when available and **falls back to the cloud**
+otherwise, so you keep the full cloud sensor set and all dispatch/control entities while the
+common metrics update quickly and without using API quota. **Leave the field blank** to stay
+cloud-only.
+
+!!! tip "Assign the dongle a static IP"
+    A hybrid or Modbus-only entry addresses the dongle by IP. Give the WiNet-S a **DHCP
+    reservation / static lease** on your router so the address doesn't change. If it does
+    change, discovery updates a Modbus-only entry automatically; for a hybrid entry, update
+    the **Local Modbus host** field, or use **Reconfigure** on a Modbus-only entry.
+
+## Options and reconfigure
+
+**Modbus-only entry — options** (**Configure**): only the **polling interval** (default 30 s,
+minimum 10 s). There are no cloud-specific options because no cloud account is involved.
+
+**Modbus-only entry — reconfigure**: updates the **WiNet-S IP address** if it changed on your
+network. It does **not** ask for any iSolarCloud credentials.
+
+**Hybrid (cloud) entry — options**: the usual cloud options (polling interval, custom measure
+points, per-device sensors) **plus** the **Local Modbus host** field. Clear the host to drop
+back to cloud-only.
+
+## What you get over Modbus
+
+The SG-RS register map exposes the inverter's core generation metrics directly, including:
+
+- **Total** and **daily** energy yield
+- **AC** (total active) and **DC** power
+- **MPPT** string voltages and currents
+- **Grid frequency** and AC voltage
+- **Internal temperature**
+
+In **hybrid** mode these overlay the cloud data (Modbus wins where it has a value); in
+**Modbus-only** mode they're the full sensor set for the entry.
+
+## Current limitations
+
+- **SG-RS inverters only.** The bundled register map covers the SG-RS single-phase string
+  inverters. SH hybrids, three-phase SG, and standalone battery/meter maps are tracked in
+  [#219](https://github.com/KRoperUK/sungrow-hass/issues/219). On other models, use
+  **cloud-only** or **hybrid** (the cloud half still returns everything).
+- **Read-only.** Local Modbus reads sensors; it does not yet write. Battery/dispatch control
+  still goes through the cloud, so use **hybrid** if you want both fast local reads and
+  control. Local write support is tracked in
+  [#220](https://github.com/KRoperUK/sungrow-hass/issues/220).
+- **`daily_yield` can read high** versus the cloud on some SG-RS firmware — a scaling/semantics
+  mismatch under investigation in
+  [#223](https://github.com/KRoperUK/sungrow-hass/issues/223). `total_yield` matches the cloud.
+- **One local connection.** The WiNet-S serves a limited number of Modbus TCP clients; if you
+  already poll it from another tool, reads here may fail intermittently.
+
+See [Troubleshooting → Local Modbus](TROUBLESHOOTING.md#local-modbus-winet-s) if discovery
+doesn't appear or local reads fail.

--- a/zensical.toml
+++ b/zensical.toml
@@ -13,6 +13,7 @@ nav = [
   { "Home" = "index.md" },
   { "Installation & Setup" = "installation.md" },
   { "Configuration" = "configuration.md" },
+  { "Local Modbus" = "local-modbus.md" },
   { "Sensors" = "SENSORS.md" },
   { "Troubleshooting" = "TROUBLESHOOTING.md" },
 ]


### PR DESCRIPTION
Closes #221.

Documents the local Modbus transport now that phases 1–3 (#213/#214/#215) and the discovery follow-ups (#218) have shipped.

## What's here
- **New page — `docs/local-modbus.md`** (added to the Zensical nav):
  - How WiNet-S local Modbus works: dongle on the LAN, TCP port 502, unit 1; **no cloud account** for Modbus-only.
  - **The three transport modes** — cloud-only / cloud+Modbus (hybrid) / Modbus-only — as a comparison table + diagram, with a "which should I choose?" guide.
  - **Zeroconf auto-discovery walkthrough**, including the #218 *attach-to-existing-cloud-entry* prompt (no duplicate device) and the manual hybrid path.
  - Options/reconfigure behaviour per mode, what you get over Modbus, and a static-IP tip.
  - **Current limitations**: SG-RS map only (#219), read-only (#220), `daily_yield` discrepancy (#223), single Modbus client.
- **`configuration.md`** — documents the previously-undocumented hybrid **Local Modbus host** option.
- **`index.md`** — feature bullet + pointer; **`installation.md`** — "no cloud account? use local Modbus" note.
- **`TROUBLESHOOTING.md`** — new **Local Modbus (WiNet-S)** section: discovery/mDNS across subnets, port 502 connectivity, `daily_yield`, unsupported models.

## Validation
- `zensical build --clean` → **No issues found** (nav + internal links resolve).
- `ruff check` / `ruff format --check` clean.
- Docs-only: no changes under `custom_components/`, no `strings.json`/translations impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)