### PR TITLE
fix: default unitless battery SOC sensors to %

### DIFF
--- a/custom_components/sungrow/sensor.py
+++ b/custom_components/sungrow/sensor.py
@@ -297,6 +297,10 @@ class SungrowSensor(CoordinatorEntity, SensorEntity):
             self._attr_native_unit_of_measurement = None
         elif self._scale_to_percent:
             self._attr_native_unit_of_measurement = PERCENTAGE
+        elif device_class == SensorDeviceClass.BATTERY:
+            # SOC points often arrive with no unit (or "") but HA requires "%" for
+            # device_class battery — otherwise it logs and refuses the entity (#228).
+            self._attr_native_unit_of_measurement = unit or PERCENTAGE
         elif device_class == SensorDeviceClass.SIGNAL_STRENGTH:
             # WLAN/wireless signal strength comes back with no unit; it's decibels.
             self._attr_native_unit_of_measurement = unit or "dB"

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -91,6 +91,40 @@ def test_signal_strength_sensor_gets_db_unit_and_signal_icon():
     assert sensor.native_value == -62.0
 
 
+@pytest.mark.parametrize(
+    "code",
+    [
+        "battery_soc",
+        "battery_level_soc",
+        "battery_level",
+        "battery_state_of_charge",
+        "total_field_soc",
+        "energy_storage_soc_ems",
+    ],
+)
+def test_battery_soc_unitless_gets_percent_unit(code):
+    """Unitless SOC points still get device_class battery with unit % (#228).
+
+    The API often omits the unit for charge-level points; classification still
+    marks them BATTERY from the code, but HA rejects battery without '%'.
+    """
+    point = {"code": code, "value": "72", "unit": None}
+    coordinator = _coord_with_devices([], data={code: point})
+    sensor = SungrowSensor(coordinator, code, "123", "Plant", point)
+    assert sensor._attr_device_class == SensorDeviceClass.BATTERY
+    assert sensor._attr_native_unit_of_measurement == "%"
+    assert sensor.native_value == 72.0
+
+
+def test_battery_soc_empty_string_unit_gets_percent():
+    """An empty-string unit from the API is treated like missing (#228)."""
+    point = {"code": "battery_soc", "value": "55", "unit": ""}
+    coordinator = _coord_with_devices([], data={"battery_soc": point})
+    sensor = SungrowSensor(coordinator, "battery_soc", "123", "Plant", point)
+    assert sensor._attr_device_class == SensorDeviceClass.BATTERY
+    assert sensor._attr_native_unit_of_measurement == "%"
+
+
 def test_power_fraction_gets_gauge_icon():
     """A per-code override gives power_fraction a gauge icon, not the solar fallback."""
     point = {"code": "power_fraction", "value": "0.83", "unit": ""}


### PR DESCRIPTION
## Summary

Fixes #228.

On restart, HA logs that battery SOC entities use `native_unit_of_measurement=None` with `device_class=battery` (expected `%`), e.g.:

- `sensor.*_battery_soc`
- `sensor.*_battery_state_of_charge`
- `sensor.*_battery_level`

**Root cause:** Measure-point classification already marks SOC codes as `SensorDeviceClass.BATTERY` even when the API omits the unit (`#105` / code heuristics). `_apply_point_metadata` only special-cased signal strength (`dB`) and percent-fraction scaling for missing units — battery fell through to `unit if unit else None`.

**Fix:** When `device_class` is `battery`, default the native unit to `%` if the API unit is missing/empty (same pattern as signal strength → `dB`).

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change
- [ ] Documentation / chore

## Checklist

- [x] `ruff check custom_components/` passes
- [x] `ruff format --check custom_components/` passes
- [x] `pytest` passes and new/changed behaviour is covered by tests (`tests/test_sensor.py` — 93 passed)
- [ ] I have updated documentation where relevant *(N/A — behaviour already documented as battery %)*

## Test plan

- [x] Unit: unitless `battery_soc` / `battery_level` / `total_field_soc` / etc. → `device_class=battery`, unit `%`
- [x] Unit: empty-string unit treated as missing
- [x] Full `tests/test_sensor.py` green
- [ ] Live: after upgrade, restart HA and confirm the three log lines no longer appear
