### PR TITLE
fix: hybrid local+cloud — derived daily, merge local-first, units & provenance

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,4 @@ htmlcov/
 
 # Local-only AI planning artifacts (specs/plans) — kept off the repo and the docs site
 docs/superpowers/
+uv.lock

--- a/custom_components/sungrow/config_flow.py
+++ b/custom_components/sungrow/config_flow.py
@@ -22,6 +22,7 @@ from .const import (
     CONF_ENABLE_DEVICE_SENSORS,
     CONF_EXTRA_MEASURE_POINTS,
     CONF_GATEWAY,
+    CONF_MODBUS_DEBUG_DAILY_YIELD,
     CONF_MODBUS_HOST,
     CONF_MODEL,
     CONF_REDIRECT_URI,
@@ -94,6 +95,10 @@ class SungrowConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         # Entry id of an existing cloud entry that already monitors the discovered
         # inverter, when discovery offers to add local Modbus to it (hybrid, #218).
         self._cloud_entry_id: str | None = None
+        # After OAuth succeeds, hold the cloud entry data while we offer to adopt an
+        # existing Modbus-only entry (local-first → hybrid reverse of #218).
+        self._pending_cloud_data: dict[str, Any] | None = None
+        self._modbus_only_entry_id: str | None = None
 
     @staticmethod
     @callback
@@ -617,6 +622,13 @@ class SungrowConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
             await self.async_set_unique_id(str(self.init_info[CONF_APP_ID]))
             self._abort_if_unique_id_configured()
+            # Local-first users often already have a Modbus-only entry for the same
+            # inverter. Offer to attach that host and remove the duplicate (#218 reverse).
+            local = self._find_modbus_only_entry()
+            if local is not None:
+                self._pending_cloud_data = data
+                self._modbus_only_entry_id = local.entry_id
+                return await self.async_step_merge_local_modbus()
             return self.async_create_entry(title=f"Sungrow {self.init_info[CONF_APP_ID]}", data=data)
 
         except data_entry_flow.AbortFlow:
@@ -627,6 +639,54 @@ class SungrowConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         except Exception as e:  # pylint: disable=broad-except
             _LOGGER.exception("Unexpected exception in async_step_finish: %s", e)
             return self._finish_error_result("unknown")
+
+    def _find_modbus_only_entry(self) -> ConfigEntry | None:
+        """Return the first Modbus-only entry that still has a host, if any."""
+        for entry in self.hass.config_entries.async_entries(DOMAIN):
+            if entry.data.get(CONF_TRANSPORT) != TRANSPORT_MODBUS_ONLY:
+                continue
+            if entry.data.get(CONF_MODBUS_HOST) or entry.options.get(CONF_MODBUS_HOST):
+                return entry
+        return None
+
+    async def async_step_merge_local_modbus(self, user_input: dict[str, Any] | None = None) -> ConfigFlowResult:
+        """Offer to adopt an existing Modbus-only entry when finishing cloud OAuth.
+
+        Confirming creates the cloud entry with that host in options (hybrid) and removes
+        the standalone local entry so the user is not left with duplicate devices.
+        Declining creates a cloud-only entry and leaves the local entry alone.
+        """
+        local = self.hass.config_entries.async_get_entry(self._modbus_only_entry_id or "")
+        data = self._pending_cloud_data
+        if data is None:
+            return self.async_abort(reason="missing_code")
+        if local is None:
+            return self.async_create_entry(title=f"Sungrow {self.init_info[CONF_APP_ID]}", data=data)
+
+        host = str(local.data.get(CONF_MODBUS_HOST) or local.options.get(CONF_MODBUS_HOST) or "")
+        if user_input is not None:
+            options: dict[str, Any] = {}
+            if user_input.get("merge_local", True) and host:
+                options[CONF_MODBUS_HOST] = host
+                # Keep the snappy local poll interval the user already chose.
+                if CONF_SCAN_INTERVAL in local.options:
+                    options[CONF_SCAN_INTERVAL] = local.options[CONF_SCAN_INTERVAL]
+                self.hass.async_create_task(self.hass.config_entries.async_remove(local.entry_id))
+            return self.async_create_entry(
+                title=f"Sungrow {self.init_info[CONF_APP_ID]}",
+                data=data,
+                options=options,
+            )
+
+        return self.async_show_form(
+            step_id="merge_local_modbus",
+            data_schema=vol.Schema({vol.Required("merge_local", default=True): bool}),
+            description_placeholders={
+                "host": host,
+                "local_title": local.title,
+                "model": str(local.data.get(CONF_MODEL) or "inverter"),
+            },
+        )
 
 
 def _parse_extra_measure_points(raw: str | None) -> dict[str, str]:
@@ -682,12 +742,14 @@ class SungrowOptionsFlow(config_entries.OptionsFlowWithReload):
                 data = {**user_input, CONF_EXTRA_MEASURE_POINTS: extras}
                 # Normalise the Modbus host; blank/whitespace means "cloud only".
                 data[CONF_MODBUS_HOST] = (user_input.get(CONF_MODBUS_HOST) or "").strip()
+                data[CONF_MODBUS_DEBUG_DAILY_YIELD] = bool(user_input.get(CONF_MODBUS_DEBUG_DAILY_YIELD, False))
                 return self.async_create_entry(title="", data=data)
 
         current_interval = self.config_entry.options.get(CONF_SCAN_INTERVAL, DEFAULT_SCAN_INTERVAL)
         current_extras = self.config_entry.options.get(CONF_EXTRA_MEASURE_POINTS, {})
         current_device_sensors = self.config_entry.options.get(CONF_ENABLE_DEVICE_SENSORS, False)
         current_modbus_host = self.config_entry.options.get(CONF_MODBUS_HOST, "")
+        current_debug_daily = bool(self.config_entry.options.get(CONF_MODBUS_DEBUG_DAILY_YIELD, False))
         extras_str = ",".join(f"{pid}={code}" for pid, code in current_extras.items())
         return self.async_show_form(
             step_id="init",
@@ -709,6 +771,7 @@ class SungrowOptionsFlow(config_entries.OptionsFlowWithReload):
                         default=current_modbus_host,
                         description={"suggested_value": current_modbus_host},
                     ): str,
+                    vol.Optional(CONF_MODBUS_DEBUG_DAILY_YIELD, default=current_debug_daily): bool,
                 }
             ),
             errors=errors,
@@ -722,8 +785,15 @@ class SungrowOptionsFlow(config_entries.OptionsFlowWithReload):
         WiNet-S host is managed by discovery, not the options flow.
         """
         if user_input is not None:
-            return self.async_create_entry(title="", data={CONF_SCAN_INTERVAL: user_input[CONF_SCAN_INTERVAL]})
+            return self.async_create_entry(
+                title="",
+                data={
+                    CONF_SCAN_INTERVAL: user_input[CONF_SCAN_INTERVAL],
+                    CONF_MODBUS_DEBUG_DAILY_YIELD: bool(user_input.get(CONF_MODBUS_DEBUG_DAILY_YIELD, False)),
+                },
+            )
         current_interval = self.config_entry.options.get(CONF_SCAN_INTERVAL, DEFAULT_MODBUS_SCAN_INTERVAL)
+        current_debug_daily = bool(self.config_entry.options.get(CONF_MODBUS_DEBUG_DAILY_YIELD, False))
         return self.async_show_form(
             step_id="modbus_options",
             data_schema=vol.Schema(
@@ -732,6 +802,7 @@ class SungrowOptionsFlow(config_entries.OptionsFlowWithReload):
                         vol.Coerce(int),
                         vol.Range(min=MIN_SCAN_INTERVAL, max=MAX_SCAN_INTERVAL),
                     ),
+                    vol.Optional(CONF_MODBUS_DEBUG_DAILY_YIELD, default=current_debug_daily): bool,
                 }
             ),
         )

--- a/custom_components/sungrow/const.py
+++ b/custom_components/sungrow/const.py
@@ -22,6 +22,9 @@ CONF_ENABLE_DEVICE_SENSORS = "enable_device_sensors"
 CONF_MODBUS_HOST = "modbus_host"
 CONF_MODBUS_PORT = "modbus_port"
 CONF_MODBUS_UNIT = "modbus_unit"
+# Opt-in: expose the raw Modbus register window on the daily_yield sensor as
+# ``daily_yield_diagnostic`` (large attribute; off by default to protect the recorder).
+CONF_MODBUS_DEBUG_DAILY_YIELD = "modbus_debug_daily_yield"
 DEFAULT_MODBUS_PORT = 502
 DEFAULT_MODBUS_UNIT = 1
 # Entry-data marker for a fully local, cloud-free entry created from zeroconf

--- a/custom_components/sungrow/coordinator.py
+++ b/custom_components/sungrow/coordinator.py
@@ -11,7 +11,9 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryAuthFailed
 from homeassistant.helpers import issue_registry as ir
+from homeassistant.helpers.storage import Store
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
+from homeassistant.util import dt as dt_util
 from pysolarcloud import AuthError, PySolarCloudException
 from pysolarcloud.plants import DeviceType, Plants
 
@@ -204,11 +206,20 @@ class SungrowPlantCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         # (Modbus preferred). None -> cloud only. Built lazily to avoid importing
         # pymodbus for cloud-only installs.
         self._modbus_client = self._build_modbus_client(config_entry)
-        # Raw-wire diagnostic for #223 (daily_yield cloud vs. Modbus discrepancy). Populated
-        # on each successful Modbus poll and surfaced on the daily_yield sensor's
-        # ``daily_yield_diagnostic`` attribute, so a daytime re-capture can pick the
-        # right (address, scale) without guessing. None until the first successful read.
+        # Raw-wire diagnostic for #223 (daily_yield register window). Populated on each
+        # successful Modbus poll and surfaced on the daily_yield sensor for inspection.
+        # The *entity value* is no longer taken from that register — see
+        # ``_async_apply_derived_daily_yield`` (SG-RS firmware never resets wire 5002).
         self.daily_yield_diagnostic: dict[str, Any] | None = None
+        # Persisted baseline for deriving daily_yield from total_yield when Modbus is used.
+        self._daily_yield_store: Store[dict[str, Any]] | None = (
+            Store(hass, 1, f"{DOMAIN}.daily_yield_baseline_{self.plant_id}")
+            if self._modbus_client is not None
+            else None
+        )
+        self._daily_yield_baseline_loaded = False
+        # Imported lazily-typed to avoid a circular import at module load; set on first use.
+        self._daily_yield_state: Any = None
 
     @staticmethod
     def _build_modbus_client(config_entry: ConfigEntry) -> Any:
@@ -304,7 +315,8 @@ class SungrowPlantCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             _LOGGER.debug("Local Modbus read failed for %s; using cloud data: %s", self.plant_name, err)
             return cloud_data
         await self._async_capture_daily_yield_diagnostic()
-        return merge_realtime(cloud_data, local)
+        merged = merge_realtime(cloud_data, local)
+        return await self._async_apply_derived_daily_yield(merged)
 
     async def _async_modbus_only_update(self) -> dict[str, Any]:
         """Read realtime data from the local Modbus client only (cloud-free entry, #159)."""
@@ -321,7 +333,36 @@ class SungrowPlantCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             raise UpdateFailed(f"Local Modbus read failed: {err}") from err
         self._last_successful_update = self.hass.loop.time()
         await self._async_capture_daily_yield_diagnostic()
-        return cast("dict[str, Any]", data)
+        return await self._async_apply_derived_daily_yield(cast("dict[str, Any]", data))
+
+    async def _async_apply_derived_daily_yield(self, data: dict[str, Any]) -> dict[str, Any]:
+        """Replace Modbus ``daily_yield`` with total_yield − start-of-local-day baseline.
+
+        SG-RS wire 5002 does not reset at midnight on observed firmware; lifetime
+        ``total_yield`` is trustworthy. Baseline is persisted so a restart mid-day
+        keeps counting from the same day start.
+        """
+        from .daily_yield import DailyYieldBaseline, apply_derived_daily_yield
+
+        if self._daily_yield_store is None:
+            return data
+        if not self._daily_yield_baseline_loaded:
+            stored = await self._daily_yield_store.async_load()
+            self._daily_yield_state = DailyYieldBaseline.from_store(stored)
+            self._daily_yield_baseline_loaded = True
+        if self._daily_yield_state is None:
+            self._daily_yield_state = DailyYieldBaseline()
+
+        local_date = dt_util.now().date()
+        data, new_state, daily = apply_derived_daily_yield(data, local_date=local_date, state=self._daily_yield_state)
+        if daily is None:
+            return data
+        if new_state.to_store() != self._daily_yield_state.to_store():
+            self._daily_yield_state = new_state
+            await self._daily_yield_store.async_save(new_state.to_store())
+        else:
+            self._daily_yield_state = new_state
+        return data
 
     async def _async_capture_daily_yield_diagnostic(self) -> None:
         """Best-effort capture of the #223 daily_yield register window for inspection.

--- a/custom_components/sungrow/coordinator.py
+++ b/custom_components/sungrow/coordinator.py
@@ -23,6 +23,7 @@ from .const import (
     COMM_MODULE_POINTS,
     CONF_ENABLE_DEVICE_SENSORS,
     CONF_EXTRA_MEASURE_POINTS,
+    CONF_MODBUS_DEBUG_DAILY_YIELD,
     CONF_MODBUS_HOST,
     CONF_MODBUS_PORT,
     CONF_MODBUS_UNIT,
@@ -37,6 +38,7 @@ from .const import (
     INVERTER_OPERATING_STATUS_POINT,
     METER_DEVICE_POINTS,
 )
+from .energy_units import normalize_energy_units, tag_source
 
 # Upper bound on a single poll's cloud calls, so a hung request can neither stall
 # the coordinator indefinitely nor let successive polls pile up.
@@ -291,10 +293,14 @@ class SungrowPlantCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         # each inverter/ESS device's operating status so the Fault binary sensor can
         # show a human-readable reason (#182). The heavy diagnostic sets are still gated
         # on the option inside the fetch.
-        self.device_data = await self._async_fetch_device_data()
+        raw_devices = await self._async_fetch_device_data()
+        self.device_data = {
+            uuid: normalize_energy_units(tag_source(points, "cloud")) for uuid, points in raw_devices.items()
+        }
 
         # pysolarcloud is untyped, so the realtime payload is Any.
         cloud_data = cast("dict[str, Any]", all_plants_data.get(self.plant_id, {}))
+        cloud_data = normalize_energy_units(tag_source(cloud_data, "cloud"))
         # Overlay fast local Modbus values (Modbus preferred) when configured (#159).
         return await self._async_apply_modbus(cloud_data)
 
@@ -315,6 +321,7 @@ class SungrowPlantCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             _LOGGER.debug("Local Modbus read failed for %s; using cloud data: %s", self.plant_name, err)
             return cloud_data
         await self._async_capture_daily_yield_diagnostic()
+        local = normalize_energy_units(local)
         merged = merge_realtime(cloud_data, local)
         return await self._async_apply_derived_daily_yield(merged)
 
@@ -333,7 +340,8 @@ class SungrowPlantCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             raise UpdateFailed(f"Local Modbus read failed: {err}") from err
         self._last_successful_update = self.hass.loop.time()
         await self._async_capture_daily_yield_diagnostic()
-        return await self._async_apply_derived_daily_yield(cast("dict[str, Any]", data))
+        data = normalize_energy_units(cast("dict[str, Any]", data))
+        return await self._async_apply_derived_daily_yield(data)
 
     async def _async_apply_derived_daily_yield(self, data: dict[str, Any]) -> dict[str, Any]:
         """Replace Modbus ``daily_yield`` with total_yield − start-of-local-day baseline.
@@ -365,14 +373,15 @@ class SungrowPlantCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         return data
 
     async def _async_capture_daily_yield_diagnostic(self) -> None:
-        """Best-effort capture of the #223 daily_yield register window for inspection.
+        """Best-effort capture of the raw daily_yield register window (opt-in).
 
-        Runs an extra short Modbus read on the existing persistent connection after each
-        successful realtime poll. Failure is non-fatal: we keep the previous diagnostic
-        in place, so a transient blip never clears evidence the user is collecting for
-        the bug report.
+        Off by default: the dump is ~2 KB per state write and would bloat the recorder.
+        Enable via options → ``modbus_debug_daily_yield`` when investigating register maps.
         """
         if self._modbus_client is None:
+            return
+        if not self.config_entry.options.get(CONF_MODBUS_DEBUG_DAILY_YIELD, False):
+            self.daily_yield_diagnostic = None
             return
         try:
             async with asyncio.timeout(self._poll_timeout):

--- a/custom_components/sungrow/coordinator.py
+++ b/custom_components/sungrow/coordinator.py
@@ -380,7 +380,8 @@ class SungrowPlantCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         """
         if self._modbus_client is None:
             return
-        if not self.config_entry.options.get(CONF_MODBUS_DEBUG_DAILY_YIELD, False):
+        entry = self.config_entry
+        if entry is None or not entry.options.get(CONF_MODBUS_DEBUG_DAILY_YIELD, False):
             self.daily_yield_diagnostic = None
             return
         try:

--- a/custom_components/sungrow/daily_yield.py
+++ b/custom_components/sungrow/daily_yield.py
@@ -1,0 +1,135 @@
+"""Derive calendar-day yield from lifetime ``total_yield`` (#223 / Modbus SG-RS).
+
+On several SG-RS + WiNet-S firmwares the documented "Daily power yields" register
+(wire 5002) never resets at midnight — it climbs in lockstep with lifetime energy
+and reports a multi-day cumulative value. Lifetime ``total_yield`` (wire 5003/5004)
+matches the cloud, so "energy today" is computed as:
+
+    daily = total_yield − total_yield_at_start_of_local_day
+
+The baseline is the last ``total_yield`` observed on the previous local calendar
+day (approximately end-of-yesterday / start-of-today). State is meant to be
+persisted across restarts by the coordinator.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import date
+from typing import Any
+
+
+@dataclass
+class DailyYieldBaseline:
+    """Mutable baseline used to derive today's yield from lifetime total."""
+
+    # total_yield at the start of ``baseline_date`` (local calendar day).
+    baseline: float | None = None
+    baseline_date: date | None = None
+    # Most recent total_yield sample (used as the next day's baseline on rollover).
+    last_total: float | None = None
+
+    def to_store(self) -> dict[str, Any]:
+        """Serialize for HA Store."""
+        return {
+            "baseline": self.baseline,
+            "baseline_date": self.baseline_date.isoformat() if self.baseline_date else None,
+            "last_total": self.last_total,
+        }
+
+    @classmethod
+    def from_store(cls, data: dict[str, Any] | None) -> DailyYieldBaseline:
+        """Restore from HA Store (tolerant of missing/partial payloads)."""
+        if not data:
+            return cls()
+        raw_date = data.get("baseline_date")
+        try:
+            baseline_date = date.fromisoformat(str(raw_date)) if raw_date else None
+        except ValueError:
+            baseline_date = None
+        baseline = _as_float(data.get("baseline"))
+        last_total = _as_float(data.get("last_total"))
+        return cls(baseline=baseline, baseline_date=baseline_date, last_total=last_total)
+
+
+def _as_float(value: Any) -> float | None:
+    if value is None or value == "":
+        return None
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def step_daily_yield(
+    total_yield: float,
+    local_date: date,
+    state: DailyYieldBaseline,
+) -> tuple[float, DailyYieldBaseline]:
+    """Advance baseline state for one ``total_yield`` sample; return (daily, new_state).
+
+    * On the first sample of a new local calendar day, the baseline becomes the
+      previous sample's total (``last_total``), which is the best available estimate
+      of energy at local midnight when polls run through the night.
+    * On the first sample ever (no history), baseline is set to the current total so
+      daily starts at 0 until the next midnight (midday install / empty store).
+    * If total drops below the baseline (meter reset / firmware glitch), the baseline
+      resets to the new total and daily is 0.
+    """
+    if state.baseline_date != local_date:
+        # Prefer yesterday's last sample as start-of-today; else anchor at current total
+        # (fresh install / empty store — daily stays 0 until more production today).
+        new_baseline = state.last_total if state.last_total is not None else total_yield
+        new_date = local_date
+    else:
+        new_baseline = state.baseline if state.baseline is not None else total_yield
+        new_date = local_date
+
+    if total_yield < new_baseline:
+        # Lifetime counter went backwards — re-anchor rather than report negative day.
+        new_baseline = total_yield
+        daily = 0.0
+    else:
+        daily = total_yield - new_baseline
+
+    new_state = DailyYieldBaseline(
+        baseline=new_baseline,
+        baseline_date=new_date,
+        last_total=total_yield,
+    )
+    return round(daily, 3), new_state
+
+
+def apply_derived_daily_yield(
+    data: dict[str, Any],
+    *,
+    local_date: date,
+    state: DailyYieldBaseline,
+) -> tuple[dict[str, Any], DailyYieldBaseline, float | None]:
+    """Overwrite ``daily_yield`` from ``total_yield`` when lifetime total is present.
+
+    Returns ``(data, new_state, daily_or_None)``. Leaves ``data`` unchanged when
+    ``total_yield`` is missing or not numeric.
+    """
+    total_point = data.get("total_yield")
+    if not isinstance(total_point, dict):
+        return data, state, None
+    total = _as_float(total_point.get("value"))
+    if total is None:
+        return data, state, None
+
+    daily, new_state = step_daily_yield(total, local_date, state)
+    unit = total_point.get("unit") or "kWh"
+    existing = data.get("daily_yield") if isinstance(data.get("daily_yield"), dict) else {}
+    data = {
+        **data,
+        "daily_yield": {
+            **existing,
+            "code": "daily_yield",
+            "value": daily,
+            "unit": unit,
+            # Distinct from the raw broken register so provenance stays honest.
+            "source": "modbus_derived",
+        },
+    }
+    return data, new_state, daily

--- a/custom_components/sungrow/daily_yield.py
+++ b/custom_components/sungrow/daily_yield.py
@@ -120,7 +120,8 @@ def apply_derived_daily_yield(
 
     daily, new_state = step_daily_yield(total, local_date, state)
     unit = total_point.get("unit") or "kWh"
-    existing = data.get("daily_yield") if isinstance(data.get("daily_yield"), dict) else {}
+    existing_raw = data.get("daily_yield")
+    existing: dict[str, Any] = existing_raw if isinstance(existing_raw, dict) else {}
     data = {
         **data,
         "daily_yield": {

--- a/custom_components/sungrow/energy_units.py
+++ b/custom_components/sungrow/energy_units.py
@@ -1,0 +1,49 @@
+"""Normalize iSolarCloud energy units for consistent HA Energy dashboard use.
+
+Plant-level points often arrive in Wh while inverter points arrive in kWh for the
+same physical quantity (e.g. total_yield 6_467_800 Wh vs 6467.8 kWh). Converting
+Wh → kWh keeps related entities comparable and avoids mixed-unit Energy config.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+_WH_UNITS = frozenset({"wh", "w·h", "w.h", "watt-hour", "watt hour", "watthour"})
+
+
+def normalize_energy_point(point: dict[str, Any]) -> dict[str, Any]:
+    """Return a copy of *point* with Wh values scaled to kWh when applicable."""
+    unit = str(point.get("unit") or "").strip()
+    if unit.lower() not in _WH_UNITS:
+        return point
+    raw = point.get("value")
+    if raw is None or raw == "":
+        return {**point, "unit": "kWh"}
+    try:
+        num = float(raw)
+    except (TypeError, ValueError):
+        return {**point, "unit": "kWh"}
+    return {**point, "value": round(num / 1000.0, 3), "unit": "kWh"}
+
+
+def normalize_energy_units(data: dict[str, Any]) -> dict[str, Any]:
+    """Normalize every point dict in a realtime payload (plant or per-device)."""
+    out: dict[str, Any] = {}
+    for code, point in data.items():
+        if isinstance(point, dict):
+            out[code] = normalize_energy_point(point)
+        else:
+            out[code] = point
+    return out
+
+
+def tag_source(data: dict[str, Any], source: str) -> dict[str, Any]:
+    """Ensure every point dict carries a ``source`` provenance tag."""
+    out: dict[str, Any] = {}
+    for code, point in data.items():
+        if isinstance(point, dict) and point.get("source") is None:
+            out[code] = {**point, "source": source}
+        else:
+            out[code] = point
+    return out

--- a/custom_components/sungrow/sensor.py
+++ b/custom_components/sungrow/sensor.py
@@ -321,6 +321,10 @@ class SungrowSensor(CoordinatorEntity, SensorEntity):
         if point_code in _INTEGER_COUNT_CODES:
             self._attr_suggested_display_precision = 0
 
+        # Local Modbus device-type register is useful for map selection, not the main UI.
+        if point_code == "device_type_code":
+            self._attr_entity_category = EntityCategory.DIAGNOSTIC
+
     def _current_point(self) -> dict[str, Any] | None:
         """Return the current point payload for this sensor (plant-level source)."""
         data = self.coordinator.data
@@ -359,17 +363,11 @@ class SungrowSensor(CoordinatorEntity, SensorEntity):
 
     @property
     def extra_state_attributes(self) -> dict[str, Any] | None:
-        """Expose which transport (``cloud``/``modbus``) provided the current value (#159).
+        """Expose transport provenance (``cloud`` / ``modbus`` / ``modbus_derived``).
 
-        Only present once a point has been through the Modbus merge — i.e. when local
-        Modbus is configured. Cloud-only points carry no source, so this stays ``None``
-        and the entities keep their attribute-free payload (no recorder bloat).
-
-        The ``daily_yield`` point additionally carries a ``daily_yield_diagnostic`` field
-        when a Modbus transport is configured (#223): the raw 16-bit register values
-        around the candidate daily_yield positions and every plausible
-        ``(address, scale)`` decoding, so a daytime re-capture can pick the right mapping
-        without guessing.
+        Cloud and Modbus paths both tag ``source`` on the point payload so hybrid setups
+        are debuggable without reading logs. Optional ``daily_yield_diagnostic`` is only
+        present when the Modbus debug option is enabled (gated in the coordinator).
         """
         point = self._current_point()
         source = point.get("source") if point else None
@@ -409,8 +407,8 @@ class SungrowDeviceSensor(SungrowSensor):
         # Enrich the device card with the model/serial the cloud reports.
         self._attr_device_info = build_device_info(device, self.plant_id, fallback_name=coordinator.plant_name)
         self._apply_point_metadata(point_code, init_data, device_name)
-        # Inverter internals (operating status, MPPT, DC power, ...) are diagnostics.
-        if point_code in _DIAGNOSTIC_CODES:
+        # Inverter internals (operating status, MPPT, DC power, device type, ...) are diagnostics.
+        if point_code in _DIAGNOSTIC_CODES or point_code == "device_type_code":
             self._attr_entity_category = EntityCategory.DIAGNOSTIC
 
     def _current_point(self) -> dict[str, Any] | None:

--- a/custom_components/sungrow/strings.json
+++ b/custom_components/sungrow/strings.json
@@ -52,6 +52,13 @@
       "attach_modbus": {
         "title": "Add local Modbus to your Sungrow inverter",
         "description": "A Sungrow **{model}** was discovered at **{host}** (WiNet-S), and it is already set up via iSolarCloud (**{cloud}**). Add fast local Modbus to that entry — its data will come from the local connection first (Modbus preferred) and fall back to the cloud — without creating a duplicate device."
+      },
+      "merge_local_modbus": {
+        "title": "Use your existing local Modbus connection?",
+        "description": "You already have a local Modbus entry (**{local_title}**, host **{host}**) for a **{model}**. Enable hybrid mode on this iSolarCloud entry so plant/grid data comes from the cloud and live inverter metrics from local Modbus (preferred), then remove the standalone local entry to avoid duplicates.",
+        "data": {
+          "merge_local": "Attach local Modbus and remove the standalone local entry"
+        }
       }
     },
     "progress": {
@@ -83,14 +90,16 @@
           "scan_interval": "Polling interval (seconds)",
           "extra_measure_points": "Extra measure points (point_id=code, comma separated)",
           "enable_device_sensors": "Create per-device sensors (EV chargers, meters, extra batteries)",
-          "modbus_host": "Local Modbus host (WiNet-S IP) — optional; leave blank for cloud only"
+          "modbus_host": "Local Modbus host (WiNet-S IP) — optional; leave blank for cloud only",
+          "modbus_debug_daily_yield": "Expose raw Modbus daily_yield register dump on the sensor (debug only)"
         }
       },
       "modbus_options": {
         "title": "Local Modbus Options",
         "description": "Adjust how often Home Assistant reads the inverter directly over local Modbus. There is no cloud API quota, so you can poll frequently; the minimum is 10 seconds.",
         "data": {
-          "scan_interval": "Polling interval (seconds)"
+          "scan_interval": "Polling interval (seconds)",
+          "modbus_debug_daily_yield": "Expose raw Modbus daily_yield register dump on the sensor (debug only)"
         }
       }
     }

--- a/custom_components/sungrow/translations/cy.json
+++ b/custom_components/sungrow/translations/cy.json
@@ -52,6 +52,13 @@
       "attach_modbus": {
         "title": "Ychwanegu Modbus lleol at eich gwrthdröydd Sungrow",
         "description": "Canfuwyd Sungrow **{model}** yn **{host}** (WiNet-S), ac mae eisoes wedi'i sefydlu drwy iSolarCloud (**{cloud}**). Ychwanegwch Modbus lleol cyflym at y cofnod hwnnw — daw ei ddata o'r cysylltiad lleol yn gyntaf (Modbus a ffefrir) gan syrthio'n ôl i'r cwmwl — heb greu dyfais ddyblyg."
+      },
+      "merge_local_modbus": {
+        "title": "Use your existing local Modbus connection?",
+        "description": "You already have a local Modbus entry (**{local_title}**, host **{host}**) for a **{model}**. Enable hybrid mode on this iSolarCloud entry so plant/grid data comes from the cloud and live inverter metrics from local Modbus (preferred), then remove the standalone local entry to avoid duplicates.",
+        "data": {
+          "merge_local": "Attach local Modbus and remove the standalone local entry"
+        }
       }
     },
     "progress": {
@@ -83,14 +90,16 @@
           "scan_interval": "Cyfwng holi (eiliadau)",
           "extra_measure_points": "Pwyntiau mesur ychwanegol (point_id=code, wedi'u gwahanu gan atalnodau)",
           "enable_device_sensors": "Creu synwyryddion fesul dyfais (gwefrwyr EV, mesuryddion, batris ychwanegol)",
-          "modbus_host": "Gwesteiwr Modbus lleol (IP y WiNet-S) — dewisol; gadewch yn wag ar gyfer cwmwl yn unig"
+          "modbus_host": "Gwesteiwr Modbus lleol (IP y WiNet-S) — dewisol; gadewch yn wag ar gyfer cwmwl yn unig",
+          "modbus_debug_daily_yield": "Expose raw Modbus daily_yield register dump on the sensor (debug only)"
         }
       },
       "modbus_options": {
         "title": "Opsiynau Modbus Lleol",
         "description": "Addaswch pa mor aml y mae Home Assistant yn darllen y gwrthdröydd yn uniongyrchol dros Modbus lleol. Nid oes cwota API cwmwl, felly gallwch holi'n aml; yr isafswm yw 10 eiliad.",
         "data": {
-          "scan_interval": "Cyfwng holi (eiliadau)"
+          "scan_interval": "Cyfwng holi (eiliadau)",
+          "modbus_debug_daily_yield": "Expose raw Modbus daily_yield register dump on the sensor (debug only)"
         }
       }
     }

--- a/custom_components/sungrow/translations/de.json
+++ b/custom_components/sungrow/translations/de.json
@@ -52,6 +52,13 @@
       "attach_modbus": {
         "title": "Lokales Modbus zu Ihrem Sungrow-Wechselrichter hinzufügen",
         "description": "Ein Sungrow **{model}** wurde unter **{host}** (WiNet-S) erkannt und ist bereits über iSolarCloud (**{cloud}**) eingerichtet. Fügen Sie diesem Eintrag schnelles lokales Modbus hinzu — die Daten kommen zuerst aus der lokalen Verbindung (Modbus bevorzugt) und fallen auf die Cloud zurück — ohne ein doppeltes Gerät zu erstellen."
+      },
+      "merge_local_modbus": {
+        "title": "Use your existing local Modbus connection?",
+        "description": "You already have a local Modbus entry (**{local_title}**, host **{host}**) for a **{model}**. Enable hybrid mode on this iSolarCloud entry so plant/grid data comes from the cloud and live inverter metrics from local Modbus (preferred), then remove the standalone local entry to avoid duplicates.",
+        "data": {
+          "merge_local": "Attach local Modbus and remove the standalone local entry"
+        }
       }
     },
     "progress": {
@@ -83,14 +90,16 @@
           "scan_interval": "Abfrageintervall (Sekunden)",
           "extra_measure_points": "Zusätzliche Messpunkte (point_id=code, durch Kommata getrennt)",
           "enable_device_sensors": "Sensoren pro Gerät erstellen (EV-Ladegeräte, Zähler, zusätzliche Batterien)",
-          "modbus_host": "Lokaler Modbus-Host (WiNet-S-IP) — optional; für reinen Cloud-Betrieb leer lassen"
+          "modbus_host": "Lokaler Modbus-Host (WiNet-S-IP) — optional; für reinen Cloud-Betrieb leer lassen",
+          "modbus_debug_daily_yield": "Expose raw Modbus daily_yield register dump on the sensor (debug only)"
         }
       },
       "modbus_options": {
         "title": "Lokale Modbus-Optionen",
         "description": "Legen Sie fest, wie oft Home Assistant den Wechselrichter direkt über lokales Modbus ausliest. Es gibt kein Cloud-API-Kontingent, sodass Sie häufig abfragen können; das Minimum beträgt 10 Sekunden.",
         "data": {
-          "scan_interval": "Abfrageintervall (Sekunden)"
+          "scan_interval": "Abfrageintervall (Sekunden)",
+          "modbus_debug_daily_yield": "Expose raw Modbus daily_yield register dump on the sensor (debug only)"
         }
       }
     }

--- a/custom_components/sungrow/translations/en.json
+++ b/custom_components/sungrow/translations/en.json
@@ -52,6 +52,13 @@
       "attach_modbus": {
         "title": "Add local Modbus to your Sungrow inverter",
         "description": "A Sungrow **{model}** was discovered at **{host}** (WiNet-S), and it is already set up via iSolarCloud (**{cloud}**). Add fast local Modbus to that entry — its data will come from the local connection first (Modbus preferred) and fall back to the cloud — without creating a duplicate device."
+      },
+      "merge_local_modbus": {
+        "title": "Use your existing local Modbus connection?",
+        "description": "You already have a local Modbus entry (**{local_title}**, host **{host}**) for a **{model}**. Enable hybrid mode on this iSolarCloud entry so plant/grid data comes from the cloud and live inverter metrics from local Modbus (preferred), then remove the standalone local entry to avoid duplicates.",
+        "data": {
+          "merge_local": "Attach local Modbus and remove the standalone local entry"
+        }
       }
     },
     "progress": {
@@ -83,14 +90,16 @@
           "scan_interval": "Polling interval (seconds)",
           "extra_measure_points": "Extra measure points (point_id=code, comma separated)",
           "enable_device_sensors": "Create per-device sensors (EV chargers, meters, extra batteries)",
-          "modbus_host": "Local Modbus host (WiNet-S IP) — optional; leave blank for cloud only"
+          "modbus_host": "Local Modbus host (WiNet-S IP) — optional; leave blank for cloud only",
+          "modbus_debug_daily_yield": "Expose raw Modbus daily_yield register dump on the sensor (debug only)"
         }
       },
       "modbus_options": {
         "title": "Local Modbus Options",
         "description": "Adjust how often Home Assistant reads the inverter directly over local Modbus. There is no cloud API quota, so you can poll frequently; the minimum is 10 seconds.",
         "data": {
-          "scan_interval": "Polling interval (seconds)"
+          "scan_interval": "Polling interval (seconds)",
+          "modbus_debug_daily_yield": "Expose raw Modbus daily_yield register dump on the sensor (debug only)"
         }
       }
     }

--- a/custom_components/sungrow/translations/es.json
+++ b/custom_components/sungrow/translations/es.json
@@ -52,6 +52,13 @@
       "attach_modbus": {
         "title": "Añadir Modbus local a su inversor Sungrow",
         "description": "Se detectó un Sungrow **{model}** en **{host}** (WiNet-S), y ya está configurado a través de iSolarCloud (**{cloud}**). Añada Modbus local rápido a esa entrada — sus datos provendrán primero de la conexión local (Modbus preferido) y recurrirán a la nube — sin crear un dispositivo duplicado."
+      },
+      "merge_local_modbus": {
+        "title": "Use your existing local Modbus connection?",
+        "description": "You already have a local Modbus entry (**{local_title}**, host **{host}**) for a **{model}**. Enable hybrid mode on this iSolarCloud entry so plant/grid data comes from the cloud and live inverter metrics from local Modbus (preferred), then remove the standalone local entry to avoid duplicates.",
+        "data": {
+          "merge_local": "Attach local Modbus and remove the standalone local entry"
+        }
       }
     },
     "progress": {
@@ -83,14 +90,16 @@
           "scan_interval": "Intervalo de sondeo (segundos)",
           "extra_measure_points": "Puntos de medición adicionales (point_id=code, separados por comas)",
           "enable_device_sensors": "Crear sensores por dispositivo (cargadores de VE, contadores, baterías adicionales)",
-          "modbus_host": "Host Modbus local (IP del WiNet-S) — opcional; déjelo en blanco para usar solo la nube"
+          "modbus_host": "Host Modbus local (IP del WiNet-S) — opcional; déjelo en blanco para usar solo la nube",
+          "modbus_debug_daily_yield": "Expose raw Modbus daily_yield register dump on the sensor (debug only)"
         }
       },
       "modbus_options": {
         "title": "Opciones de Modbus local",
         "description": "Ajuste la frecuencia con la que Home Assistant lee el inversor directamente a través de Modbus local. No hay cuota de API en la nube, por lo que puede sondear con frecuencia; el mínimo es de 10 segundos.",
         "data": {
-          "scan_interval": "Intervalo de sondeo (segundos)"
+          "scan_interval": "Intervalo de sondeo (segundos)",
+          "modbus_debug_daily_yield": "Expose raw Modbus daily_yield register dump on the sensor (debug only)"
         }
       }
     }

--- a/custom_components/sungrow/translations/fr.json
+++ b/custom_components/sungrow/translations/fr.json
@@ -52,6 +52,13 @@
       "attach_modbus": {
         "title": "Ajouter Modbus local à votre onduleur Sungrow",
         "description": "Un Sungrow **{model}** a été découvert à **{host}** (WiNet-S), et il est déjà configuré via iSolarCloud (**{cloud}**). Ajoutez le Modbus local rapide à cette entrée — ses données proviendront d'abord de la connexion locale (Modbus préféré) et basculeront vers le cloud — sans créer de doublon."
+      },
+      "merge_local_modbus": {
+        "title": "Use your existing local Modbus connection?",
+        "description": "You already have a local Modbus entry (**{local_title}**, host **{host}**) for a **{model}**. Enable hybrid mode on this iSolarCloud entry so plant/grid data comes from the cloud and live inverter metrics from local Modbus (preferred), then remove the standalone local entry to avoid duplicates.",
+        "data": {
+          "merge_local": "Attach local Modbus and remove the standalone local entry"
+        }
       }
     },
     "progress": {
@@ -83,14 +90,16 @@
           "scan_interval": "Intervalle d'interrogation (secondes)",
           "extra_measure_points": "Points de mesure supplémentaires (point_id=code, séparés par des virgules)",
           "enable_device_sensors": "Créer des capteurs par appareil (bornes de recharge EV, compteurs, batteries supplémentaires)",
-          "modbus_host": "Hôte Modbus local (IP du WiNet-S) — optionnel ; laisser vide pour le cloud uniquement"
+          "modbus_host": "Hôte Modbus local (IP du WiNet-S) — optionnel ; laisser vide pour le cloud uniquement",
+          "modbus_debug_daily_yield": "Expose raw Modbus daily_yield register dump on the sensor (debug only)"
         }
       },
       "modbus_options": {
         "title": "Options Modbus locales",
         "description": "Ajustez la fréquence à laquelle Home Assistant lit l'onduleur directement via Modbus local. Il n'y a pas de quota d'API cloud, vous pouvez donc interroger fréquemment ; le minimum est de 10 secondes.",
         "data": {
-          "scan_interval": "Intervalle d'interrogation (secondes)"
+          "scan_interval": "Intervalle d'interrogation (secondes)",
+          "modbus_debug_daily_yield": "Expose raw Modbus daily_yield register dump on the sensor (debug only)"
         }
       }
     }

--- a/docs/local-modbus.md
+++ b/docs/local-modbus.md
@@ -164,12 +164,13 @@ In **hybrid** mode these overlay the cloud data (Modbus wins where it has a valu
   still goes through the cloud, so use **hybrid** if you want both fast local reads and
   control. Local write support is tracked in
   [#220](https://github.com/KRoperUK/sungrow-hass/issues/220).
-- **`daily_yield` can read high** versus the cloud on some SG-RS firmware — a scaling/semantics
-  mismatch under investigation in
-  [#223](https://github.com/KRoperUK/sungrow-hass/issues/223). `total_yield` matches the cloud.
-  The `sensor.sungrow_*_daily_yield` entity carries a `daily_yield_diagnostic` attribute
-  (raw register frame + candidate `(address, scale)` decodings) — attach it to a comment
-  on #223 to help pin the cause down.
+- **`daily_yield` is derived from `total_yield`.** On observed SG-RS + WiNet-S firmware the
+  documented "Daily power yields" register (wire 5002) **never resets at midnight** — it
+  climbs with lifetime energy (see [#223](https://github.com/KRoperUK/sungrow-hass/issues/223)).
+  Lifetime `total_yield` matches the cloud, so the integration computes
+  `daily_yield = total_yield − total_at_start_of_local_day` and persists the baseline across
+  restarts. The sensor `source` is `modbus_derived`. A `daily_yield_diagnostic` attribute on
+  the entity still exposes the raw register window for inspection.
 - **One local connection.** The WiNet-S serves a limited number of Modbus TCP clients; if you
   already poll it from another tool, reads here may fail intermittently.
 

--- a/docs/local-modbus.md
+++ b/docs/local-modbus.md
@@ -169,8 +169,24 @@ In **hybrid** mode these overlay the cloud data (Modbus wins where it has a valu
   climbs with lifetime energy (see [#223](https://github.com/KRoperUK/sungrow-hass/issues/223)).
   Lifetime `total_yield` matches the cloud, so the integration computes
   `daily_yield = total_yield − total_at_start_of_local_day` and persists the baseline across
-  restarts. The sensor `source` is `modbus_derived`. A `daily_yield_diagnostic` attribute on
-  the entity still exposes the raw register window for inspection.
+  restarts. The sensor `source` is `modbus_derived`. An optional
+  **Expose raw Modbus daily_yield register dump** option attaches a
+  `daily_yield_diagnostic` attribute for register debugging (off by default — it is large).
+
+## Local-first, then add cloud (hybrid)
+
+If you started with **Modbus-only** (zeroconf) and later add iSolarCloud:
+
+1. Start **Add integration → Sungrow iSolarCloud** and complete OAuth as usual.
+2. When a standalone local entry already exists, the flow offers **Use your existing local
+   Modbus connection?** — confirm to attach that WiNet-S host to the new cloud entry and
+   remove the duplicate local entry.
+3. Or, after cloud is set up: **Configure** the cloud entry → set **Local Modbus host** to the
+   WiNet-S IP, then remove the old Modbus-only entry manually.
+
+Hybrid behaviour: plant/grid/tariff points from the cloud; overlapping inverter metrics from
+Modbus when available (`source` attribute: `cloud` / `modbus` / `modbus_derived`). Energy
+points reported in Wh are normalised to **kWh** so plant and inverter totals stay comparable.
 - **One local connection.** The WiNet-S serves a limited number of Modbus TCP clients; if you
   already poll it from another tool, reads here may fail intermittently.
 

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -296,6 +296,46 @@ async def test_finish_step_missing_code(hass: HomeAssistant, mock_auth):
     assert result["reason"] == "missing_code"
 
 
+async def test_finish_offers_merge_when_modbus_only_exists(hass: HomeAssistant, mock_auth):
+    """Cloud OAuth finish offers to adopt an existing Modbus-only entry (local-first hybrid)."""
+    from custom_components.sungrow.const import CONF_MODBUS_HOST, CONF_MODEL, CONF_TRANSPORT, TRANSPORT_MODBUS_ONLY
+
+    local = MockConfigEntry(
+        domain=DOMAIN,
+        unique_id="modbus_SN1",
+        title="Sungrow SG3.6RS (local)",
+        data={
+            CONF_TRANSPORT: TRANSPORT_MODBUS_ONLY,
+            CONF_MODBUS_HOST: "192.168.1.93",
+            CONF_MODEL: "SG3.6RS",
+            "serial": "SN1",
+        },
+        options={CONF_SCAN_INTERVAL: 30},
+    )
+    local.add_to_hass(hass)
+
+    flow = _flow_at_finish(hass)
+    flow._code = "auth-code"
+    mock_auth.tokens = {"access_token": "tok", "refresh_token": "ref"}
+    flow.auth_client = mock_auth
+    flow.auth_client.async_authorize = AsyncMock()
+
+    result = await flow.async_step_finish()
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
+    assert result["step_id"] == "merge_local_modbus"
+    assert result["description_placeholders"]["host"] == "192.168.1.93"
+
+    with patch("custom_components.sungrow.async_setup_entry", return_value=True):
+        result2 = await flow.async_step_merge_local_modbus({"merge_local": True})
+        await hass.async_block_till_done()
+
+    assert result2["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
+    assert result2["options"][CONF_MODBUS_HOST] == "192.168.1.93"
+    assert result2["options"][CONF_SCAN_INTERVAL] == 30
+    # Standalone local entry removed so devices are not duplicated.
+    assert hass.config_entries.async_entry_for_domain_unique_id(DOMAIN, "modbus_SN1") is None
+
+
 # ---------------------------------------------------------------------------
 # Phase 2: the automatic OAuth-callback wait
 # ---------------------------------------------------------------------------
@@ -728,11 +768,16 @@ async def test_options_flow_stores_and_trims_modbus_host(hass: HomeAssistant, mo
     await hass.async_block_till_done()
 
     result = await hass.config_entries.options.async_init(entry.entry_id)
-    result2 = await hass.config_entries.options.async_configure(
-        result["flow_id"],
-        user_input={CONF_SCAN_INTERVAL: 30, CONF_MODBUS_HOST: "  192.168.1.93  "},
-    )
-    await hass.async_block_till_done()
+    # OptionsFlowWithReload reloads the entry; stub Modbus so the hybrid setup does not open sockets.
+    client = MagicMock()
+    client.async_read_realtime = AsyncMock(return_value={})
+    client.async_read_daily_yield_diagnostic = AsyncMock(return_value=None)
+    with patch("custom_components.sungrow.modbus.SungrowModbusClient", return_value=client):
+        result2 = await hass.config_entries.options.async_configure(
+            result["flow_id"],
+            user_input={CONF_SCAN_INTERVAL: 30, CONF_MODBUS_HOST: "  192.168.1.93  "},
+        )
+        await hass.async_block_till_done()
 
     assert result2["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
     assert entry.options[CONF_MODBUS_HOST] == "192.168.1.93"
@@ -766,17 +811,20 @@ async def test_options_flow_modbus_only_hides_cloud_settings(hass: HomeAssistant
         result = await hass.config_entries.options.async_init(entry.entry_id)
         assert result["type"] == data_entry_flow.FlowResultType.FORM
         assert result["step_id"] == "modbus_options"
-        # Only the poll interval — none of the cloud-only settings.
+        # Local poll + optional debug dump — none of the cloud-only settings.
+        from custom_components.sungrow.const import CONF_MODBUS_DEBUG_DAILY_YIELD
+
         keys = {str(m.schema) for m in result["data_schema"].schema}
-        assert keys == {CONF_SCAN_INTERVAL}
+        assert keys == {CONF_SCAN_INTERVAL, CONF_MODBUS_DEBUG_DAILY_YIELD}
 
         result2 = await hass.config_entries.options.async_configure(
-            result["flow_id"], user_input={CONF_SCAN_INTERVAL: 15}
+            result["flow_id"],
+            user_input={CONF_SCAN_INTERVAL: 15, CONF_MODBUS_DEBUG_DAILY_YIELD: False},
         )
         await hass.async_block_till_done()
 
     assert result2["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
-    assert result2["data"] == {CONF_SCAN_INTERVAL: 15}
+    assert result2["data"][CONF_SCAN_INTERVAL] == 15
     assert entry.options[CONF_SCAN_INTERVAL] == 15
 
 

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -803,7 +803,44 @@ async def test_apply_modbus_merges_over_cloud(hass: HomeAssistant):
     merged = await coordinator._async_apply_modbus(cloud)
     assert merged["total_active_power"]["value"] == 256
     assert merged["total_active_power"]["source"] == "modbus"
+    # No total_yield in this payload → derived daily is not applied; cloud daily kept.
     assert merged["daily_yield"]["source"] == "cloud"
+
+
+async def test_modbus_derives_daily_yield_from_total(hass: HomeAssistant):
+    """When Modbus supplies total_yield, daily_yield is total − start-of-day baseline (#223)."""
+    from datetime import date
+    from unittest.mock import patch
+
+    from custom_components.sungrow.daily_yield import DailyYieldBaseline
+
+    entry = _make_entry(data={CONF_MODBUS_HOST: "10.0.0.9"})
+    coordinator = SungrowPlantCoordinator(hass, entry, None, "SN-DY", "SG")
+    coordinator._modbus_client = MagicMock()
+    coordinator._modbus_client.async_read_realtime = AsyncMock(
+        return_value={
+            "total_yield": {"code": "total_yield", "value": 6467.0, "unit": "kWh", "source": "modbus"},
+            "daily_yield": {"code": "daily_yield", "value": 201.6, "unit": "kWh", "source": "modbus"},
+        }
+    )
+    # Pretend we already saw 6462 earlier today.
+    coordinator._daily_yield_baseline_loaded = True
+    coordinator._daily_yield_state = DailyYieldBaseline(
+        baseline=6462.0, baseline_date=date(2026, 7, 13), last_total=6462.0
+    )
+    # Avoid Store I/O in the unit test.
+    coordinator._daily_yield_store = MagicMock()
+    coordinator._daily_yield_store.async_save = AsyncMock()
+    coordinator._modbus_client.async_read_daily_yield_diagnostic = AsyncMock(return_value=None)
+
+    with patch("custom_components.sungrow.coordinator.dt_util") as mock_dt:
+        mock_dt.now.return_value.date.return_value = date(2026, 7, 13)
+        data = await coordinator._async_modbus_only_update()
+
+    assert data["daily_yield"]["value"] == 5.0
+    assert data["daily_yield"]["source"] == "modbus_derived"
+    assert data["total_yield"]["value"] == 6467.0
+    coordinator._daily_yield_store.async_save.assert_awaited()
 
 
 async def test_apply_modbus_falls_back_to_cloud_on_error(hass: HomeAssistant):

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -14,6 +14,7 @@ from pysolarcloud.plants import DeviceType
 from custom_components.sungrow.const import (
     CONF_ENABLE_DEVICE_SENSORS,
     CONF_EXTRA_MEASURE_POINTS,
+    CONF_MODBUS_DEBUG_DAILY_YIELD,
     CONF_MODBUS_HOST,
     CONF_MODBUS_PORT,
     CONF_MODBUS_UNIT,
@@ -797,14 +798,32 @@ async def test_apply_modbus_merges_over_cloud(hass: HomeAssistant):
         }
     )
     cloud = {
-        "total_active_power": {"code": "total_active_power", "value": "250", "unit": "W"},
-        "daily_yield": {"code": "daily_yield", "value": "38"},
+        "total_active_power": {"code": "total_active_power", "value": "250", "unit": "W", "source": "cloud"},
+        "daily_yield": {"code": "daily_yield", "value": "38", "source": "cloud"},
     }
     merged = await coordinator._async_apply_modbus(cloud)
     assert merged["total_active_power"]["value"] == 256
     assert merged["total_active_power"]["source"] == "modbus"
     # No total_yield in this payload → derived daily is not applied; cloud daily kept.
     assert merged["daily_yield"]["source"] == "cloud"
+
+
+async def test_modbus_debug_daily_yield_gated(hass: HomeAssistant):
+    """Raw daily_yield register dump is only captured when the debug option is on."""
+    entry = _make_entry(data={CONF_MODBUS_HOST: "10.0.0.9"})
+    coordinator = SungrowPlantCoordinator(hass, entry, None, "SN", "SG")
+    coordinator._modbus_client = MagicMock()
+    coordinator._modbus_client.async_read_daily_yield_diagnostic = AsyncMock(return_value={"raw": {"5002": 1}})
+
+    # Default: off → clear / skip capture.
+    await coordinator._async_capture_daily_yield_diagnostic()
+    assert coordinator.daily_yield_diagnostic is None
+    coordinator._modbus_client.async_read_daily_yield_diagnostic.assert_not_awaited()
+
+    # Opt-in.
+    entry.options = {CONF_MODBUS_DEBUG_DAILY_YIELD: True}
+    await coordinator._async_capture_daily_yield_diagnostic()
+    assert coordinator.daily_yield_diagnostic == {"raw": {"5002": 1}}
 
 
 async def test_modbus_derives_daily_yield_from_total(hass: HomeAssistant):
@@ -941,6 +960,8 @@ async def test_apply_modbus_captures_daily_yield_diagnostic(hass: HomeAssistant)
         }
     )
     cloud = {"daily_yield": {"code": "daily_yield", "value": "60.0", "unit": "kWh"}}
+    # Diagnostic capture is opt-in (recorder bloat when off).
+    coordinator.config_entry.options = {CONF_MODBUS_DEBUG_DAILY_YIELD: True}
     await coordinator._async_apply_modbus(cloud)
     assert coordinator.daily_yield_diagnostic is not None
     assert coordinator.daily_yield_diagnostic["raw"]["5002"] == 640
@@ -962,6 +983,7 @@ async def test_apply_modbus_keeps_previous_diagnostic_on_capture_failure(hass: H
         "current_mapping": {"address": 5002, "raw": 640, "scale": 0.1, "unit": "kWh"},
     }
     coordinator.daily_yield_diagnostic = previous
+    coordinator.config_entry.options = {CONF_MODBUS_DEBUG_DAILY_YIELD: True}
     from custom_components.sungrow.modbus import SungrowModbusError
 
     coordinator._modbus_client.async_read_daily_yield_diagnostic = AsyncMock(side_effect=SungrowModbusError("boom"))
@@ -970,8 +992,9 @@ async def test_apply_modbus_keeps_previous_diagnostic_on_capture_failure(hass: H
 
 
 async def test_modbus_only_update_captures_daily_yield_diagnostic(hass: HomeAssistant):
-    """The Modbus-only path also refreshes the diagnostic on every successful poll (#223)."""
+    """The Modbus-only path refreshes the diagnostic when the debug option is on."""
     coordinator = _modbus_only_coordinator(hass)
+    coordinator.config_entry.options = {CONF_MODBUS_DEBUG_DAILY_YIELD: True}
     coordinator._modbus_client.async_read_realtime = AsyncMock(
         return_value={"daily_yield": {"code": "daily_yield", "value": 64.0, "unit": "kWh", "source": "modbus"}}
     )

--- a/tests/test_daily_yield.py
+++ b/tests/test_daily_yield.py
@@ -1,0 +1,82 @@
+"""Tests for software-derived daily yield from total_yield (#223)."""
+
+from datetime import date
+
+from custom_components.sungrow.daily_yield import (
+    DailyYieldBaseline,
+    apply_derived_daily_yield,
+    step_daily_yield,
+)
+
+
+def test_first_sample_starts_day_at_zero():
+    """With no history, baseline anchors at current total so daily starts at 0."""
+    state = DailyYieldBaseline()
+    daily, new = step_daily_yield(6462.0, date(2026, 7, 13), state)
+    assert daily == 0.0
+    assert new.baseline == 6462.0
+    assert new.baseline_date == date(2026, 7, 13)
+    assert new.last_total == 6462.0
+
+
+def test_same_day_growth():
+    """Within a day, daily tracks total − baseline."""
+    state = DailyYieldBaseline(baseline=6462.0, baseline_date=date(2026, 7, 13), last_total=6462.0)
+    daily, new = step_daily_yield(6467.0, date(2026, 7, 13), state)
+    assert daily == 5.0
+    assert new.baseline == 6462.0
+    assert new.last_total == 6467.0
+
+
+def test_midnight_rollover_uses_yesterdays_last_total():
+    """On a new local date, baseline becomes the previous sample's total."""
+    state = DailyYieldBaseline(baseline=6400.0, baseline_date=date(2026, 7, 12), last_total=6462.0)
+    daily, new = step_daily_yield(6465.0, date(2026, 7, 13), state)
+    assert new.baseline == 6462.0
+    assert new.baseline_date == date(2026, 7, 13)
+    assert daily == 3.0
+
+
+def test_meter_reset_reanchors():
+    """If total drops below baseline, re-anchor rather than go negative."""
+    state = DailyYieldBaseline(baseline=100.0, baseline_date=date(2026, 7, 13), last_total=150.0)
+    daily, new = step_daily_yield(10.0, date(2026, 7, 13), state)
+    assert daily == 0.0
+    assert new.baseline == 10.0
+    assert new.last_total == 10.0
+
+
+def test_store_roundtrip():
+    """Baseline survives serialize → deserialize."""
+    state = DailyYieldBaseline(baseline=1.5, baseline_date=date(2026, 7, 13), last_total=2.0)
+    restored = DailyYieldBaseline.from_store(state.to_store())
+    assert restored == state
+    assert DailyYieldBaseline.from_store(None).baseline is None
+    assert DailyYieldBaseline.from_store({"baseline_date": "nope"}).baseline_date is None
+
+
+def test_apply_overwrites_daily_from_total():
+    """apply_derived_daily_yield replaces a bogus register daily with the delta."""
+    data = {
+        "total_yield": {"code": "total_yield", "value": 6467.0, "unit": "kWh", "source": "modbus"},
+        "daily_yield": {"code": "daily_yield", "value": 201.6, "unit": "kWh", "source": "modbus"},
+    }
+    state = DailyYieldBaseline(baseline=6462.0, baseline_date=date(2026, 7, 13), last_total=6462.0)
+    out, new_state, daily = apply_derived_daily_yield(data, local_date=date(2026, 7, 13), state=state)
+    assert daily == 5.0
+    assert out["daily_yield"]["value"] == 5.0
+    assert out["daily_yield"]["source"] == "modbus_derived"
+    assert out["daily_yield"]["unit"] == "kWh"
+    assert new_state.last_total == 6467.0
+    # Original total untouched.
+    assert out["total_yield"]["value"] == 6467.0
+
+
+def test_apply_noop_without_total():
+    """No total_yield → leave data alone."""
+    data = {"daily_yield": {"code": "daily_yield", "value": 1.0, "unit": "kWh", "source": "modbus"}}
+    state = DailyYieldBaseline()
+    out, new_state, daily = apply_derived_daily_yield(data, local_date=date(2026, 7, 13), state=state)
+    assert daily is None
+    assert out is data
+    assert new_state is state

--- a/tests/test_energy_units.py
+++ b/tests/test_energy_units.py
@@ -1,0 +1,35 @@
+"""Tests for energy unit normalisation and source tagging."""
+
+from custom_components.sungrow.energy_units import (
+    normalize_energy_point,
+    normalize_energy_units,
+    tag_source,
+)
+
+
+def test_wh_to_kwh():
+    point = {"code": "total_yield", "value": 6467800.0, "unit": "Wh"}
+    out = normalize_energy_point(point)
+    assert out["value"] == 6467.8
+    assert out["unit"] == "kWh"
+
+
+def test_kwh_unchanged():
+    point = {"code": "total_yield", "value": 6467.8, "unit": "kWh"}
+    assert normalize_energy_point(point) is point
+
+
+def test_payload_and_source_tag():
+    data = {
+        "total_yield": {"code": "total_yield", "value": 5000, "unit": "Wh"},
+        "power": {"code": "power", "value": 100, "unit": "W"},
+    }
+    norm = normalize_energy_units(data)
+    tagged = tag_source(norm, "cloud")
+    assert tagged["total_yield"]["value"] == 5.0
+    assert tagged["total_yield"]["unit"] == "kWh"
+    assert tagged["total_yield"]["source"] == "cloud"
+    assert tagged["power"]["source"] == "cloud"
+    # Does not overwrite an existing source.
+    already = tag_source({"x": {"value": 1, "source": "modbus"}}, "cloud")
+    assert already["x"]["source"] == "modbus"

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -149,8 +149,16 @@ def test_sensor_no_attributes_without_source():
     assert sensor.extra_state_attributes is None
 
 
+def test_device_type_code_is_diagnostic():
+    """device_type_code is a Modbus map selector — keep it out of the main entity list."""
+    point = {"code": "device_type_code", "value": "9732", "unit": None, "source": "modbus"}
+    coordinator = _coord_with_devices([], data={"device_type_code": point})
+    sensor = SungrowSensor(coordinator, "device_type_code", "123", "Plant", point)
+    assert sensor._attr_entity_category == EntityCategory.DIAGNOSTIC
+
+
 def test_daily_yield_sensor_surfaces_modbus_diagnostic_when_captured():
-    """#223: daily_yield's diagnostic dump rides along on the sensor as an extra attribute."""
+    """Opt-in daily_yield diagnostic dump rides along on the sensor as an extra attribute."""
     point = {"code": "daily_yield", "value": "64.0", "unit": "kWh", "source": "modbus"}
     coordinator = _coord_with_devices([], data={"daily_yield": point})
     coordinator.daily_yield_diagnostic = {

--- a/uv.lock
+++ b/uv.lock
@@ -1,8 +1,0 @@
-version = 1
-revision = 3
-requires-python = ">=3.13"
-
-[[package]]
-name = "sungrow-hass"
-version = "3.4.1"
-source = { virtual = "." }

--- a/uv.lock
+++ b/uv.lock
@@ -1,0 +1,8 @@
+version = 1
+revision = 3
+requires-python = ">=3.13"
+
+[[package]]
+name = "sungrow-hass"
+version = "3.4.1"
+source = { virtual = "." }


### PR DESCRIPTION
## Summary

Single PR for pre-release testing of local + cloud on real hardware (e.g. dell-serve SG3.6RS).

### 1. Derived `daily_yield` (#223)
SG-RS wire 5002 never resets at midnight. Compute:

```text
daily_yield = total_yield − total_at_start_of_local_day
```

Baseline persisted across restarts. Sensor `source` = `modbus_derived`.

### 2. Local-first → hybrid (reverse of #218)
When finishing **cloud OAuth** and a **Modbus-only** entry already exists, offer:

> Use your existing local Modbus connection?

Confirm → cloud entry options get that host + scan interval; standalone local entry is **removed**.

### 3. Provenance
Cloud plant/device realtime points are tagged `source=cloud`. Merge still prefers Modbus (`modbus` / `modbus_derived`).

### 4. Energy units
Wh plant points (e.g. `total_yield` 6_467_800 Wh) are normalised to **kWh** so they match inverter totals.

### 5. Diagnostic dump gated
`daily_yield_diagnostic` attribute only when option **Expose raw Modbus daily_yield register dump** is enabled (cloud hybrid + Modbus-only options). Off by default (recorder bloat).

### 6. Docs + UI polish
- `docs/local-modbus.md` migration path
- `device_type_code` → diagnostic entity category

## Type of change

- [x] Bug fix
- [x] New feature (merge-local step / options)
- [ ] Breaking change
- [x] Documentation

## Checklist

- [x] ruff
- [x] pytest (energy_units, daily_yield, coordinator, sensor, config_flow modbus/merge paths)
- [x] docs

## Test plan (PR dev release on dell-serve)

1. Install this PR’s HACS/dev build; restart HA.
2. **Derived daily (local or hybrid):** `sensor.*_daily_yield` should be ~today’s kWh (not ~200); `source=modbus_derived` when Modbus supplies total.
3. **Hybrid merge:** with Modbus-only + cloud both present, either:
   - re-run cloud setup / remove cloud and re-add to hit **merge_local_modbus**, or
   - set **Local Modbus host** on cloud options and remove Modbus-only entry.
4. After hybrid: one device tree; overlapping codes show `source=modbus` (or derived); plant load/grid remain cloud.
5. **Units:** plant `total_yield` / daily feed-in style points in **kWh**, not multi-million Wh.
6. **Debug dump off by default:** no huge `daily_yield_diagnostic` attr until option enabled.
