### PR TITLE
refactor: separate cloud and local Modbus (no hybrid merge)

### DIFF
--- a/custom_components/sungrow/__init__.py
+++ b/custom_components/sungrow/__init__.py
@@ -195,17 +195,17 @@ def build_device_info(
     ``via_plant_id`` overrides the parent plant identifier (used by a local Modbus
     inverter that nests under a matching cloud plant without merging data).
     """
-    kwargs: dict[str, Any] = {
-        "identifiers": {(DOMAIN, str(device["uuid"]))},
-        "name": device.get("device_name") or device.get("device_model_name") or fallback_name,
-        "manufacturer": device.get("factory_name") or "Sungrow",
-        "model": device.get("device_model_code") or device.get("device_model_name"),
-        "serial_number": device.get("device_sn"),
-        "via_device": (DOMAIN, via_plant_id or plant_id),
-    }
+    info = DeviceInfo(
+        identifiers={(DOMAIN, str(device["uuid"]))},
+        name=device.get("device_name") or device.get("device_model_name") or fallback_name,
+        manufacturer=device.get("factory_name") or "Sungrow",
+        model=device.get("device_model_code") or device.get("device_model_name"),
+        serial_number=device.get("device_sn"),
+        via_device=(DOMAIN, via_plant_id or plant_id),
+    )
     if configuration_url:
-        kwargs["configuration_url"] = configuration_url
-    return DeviceInfo(**kwargs)
+        info["configuration_url"] = configuration_url
+    return info
 
 
 def find_related_cloud_plant_id(hass: HomeAssistant, serial: str) -> str | None:
@@ -436,9 +436,7 @@ async def _async_setup_modbus_only(hass: HomeAssistant, entry: SungrowConfigEntr
     if cloud_plant_id is None:
         dr.async_get(hass).async_get_or_create(
             config_entry_id=entry.entry_id,
-            **build_plant_device_info(
-                serial, f"Sungrow {model} (local)", winet_url or DEFAULT_CONSOLE_URL
-            ),
+            **build_plant_device_info(serial, f"Sungrow {model} (local)", winet_url or DEFAULT_CONSOLE_URL),
         )
     # Only the sensor platform: a Modbus-only entry has no cloud device status or dispatch.
     await hass.config_entries.async_forward_entry_setups(entry, _entry_platforms(entry))

--- a/custom_components/sungrow/__init__.py
+++ b/custom_components/sungrow/__init__.py
@@ -176,7 +176,14 @@ async def _async_has_battery(plants_service: Plants, plant_id: str, devices: lis
     return _has_battery_device(devices)
 
 
-def build_device_info(device: dict[str, Any], plant_id: str, *, fallback_name: str | None = None) -> DeviceInfo:
+def build_device_info(
+    device: dict[str, Any],
+    plant_id: str,
+    *,
+    fallback_name: str | None = None,
+    via_plant_id: str | None = None,
+    configuration_url: str | None = None,
+) -> DeviceInfo:
     """Build a device-registry entry for a physical device, nested under its plant.
 
     Enriches the HA device card with the model, serial number and manufacturer the
@@ -184,15 +191,143 @@ def build_device_info(device: dict[str, Any], plant_id: str, *, fallback_name: s
     ``getDeviceListByPsId``) instead of a bare name, and links it to the plant device
     via ``via_device``. The uuid is stringified so the identifier matches
     ``_known_device_ids`` (which keys on ``str(uuid)``) and the device isn't pruned.
+
+    ``via_plant_id`` overrides the parent plant identifier (used by a local Modbus
+    inverter that nests under a matching cloud plant without merging data).
     """
-    return DeviceInfo(
-        identifiers={(DOMAIN, str(device["uuid"]))},
-        name=device.get("device_name") or device.get("device_model_name") or fallback_name,
-        manufacturer=device.get("factory_name") or "Sungrow",
-        model=device.get("device_model_code") or device.get("device_model_name"),
-        serial_number=device.get("device_sn"),
-        via_device=(DOMAIN, plant_id),
-    )
+    kwargs: dict[str, Any] = {
+        "identifiers": {(DOMAIN, str(device["uuid"]))},
+        "name": device.get("device_name") or device.get("device_model_name") or fallback_name,
+        "manufacturer": device.get("factory_name") or "Sungrow",
+        "model": device.get("device_model_code") or device.get("device_model_name"),
+        "serial_number": device.get("device_sn"),
+        "via_device": (DOMAIN, via_plant_id or plant_id),
+    }
+    if configuration_url:
+        kwargs["configuration_url"] = configuration_url
+    return DeviceInfo(**kwargs)
+
+
+def find_related_cloud_plant_id(hass: HomeAssistant, serial: str) -> str | None:
+    """Return the cloud plant identifier that already owns this inverter serial, if any.
+
+    Used so a separate Modbus-only entry can nest its local inverter under the cloud
+    plant device without merging sensor values.
+    """
+    registry = dr.async_get(hass)
+    for entry in hass.config_entries.async_entries(DOMAIN):
+        if entry.data.get(CONF_TRANSPORT) == TRANSPORT_MODBUS_ONLY:
+            continue
+        inv = None
+        for device in dr.async_entries_for_config_entry(registry, entry.entry_id):
+            if device.serial_number and device.serial_number == serial:
+                inv = device
+                break
+        if inv is None:
+            continue
+        if inv.via_device_id:
+            parent = registry.async_get(inv.via_device_id)
+            if parent is not None:
+                for domain_key, ident in parent.identifiers:
+                    if domain_key == DOMAIN:
+                        return str(ident)
+        for device in dr.async_entries_for_config_entry(registry, entry.entry_id):
+            if device.entry_type == dr.DeviceEntryType.SERVICE:
+                for domain_key, ident in device.identifiers:
+                    if domain_key == DOMAIN:
+                        return str(ident)
+    return None
+
+
+_HYBRID_OPTION_KEYS = frozenset(
+    {
+        CONF_MODBUS_HOST,
+        "modbus_port",
+        "modbus_unit",
+        "modbus_debug_daily_yield",
+    }
+)
+
+
+def _async_split_legacy_hybrid(hass: HomeAssistant, entry: ConfigEntry) -> None:
+    """Strip hybrid Modbus settings from a cloud entry and spawn local entries.
+
+    Older builds stored ``modbus_host`` on the cloud entry and merged values. That
+    mashup is gone: cloud stays pure, and a separate Modbus-only entry is created
+    per known inverter serial when possible.
+    """
+    if entry.data.get(CONF_TRANSPORT) == TRANSPORT_MODBUS_ONLY:
+        return
+    host = str(entry.options.get(CONF_MODBUS_HOST) or entry.data.get(CONF_MODBUS_HOST) or "").strip()
+    has_hybrid_keys = any(k in entry.options or k in entry.data for k in _HYBRID_OPTION_KEYS)
+    if not host and not has_hybrid_keys:
+        return
+
+    debug = bool(entry.options.get("modbus_debug_daily_yield", False))
+    new_options = {k: v for k, v in entry.options.items() if k not in _HYBRID_OPTION_KEYS}
+    new_data = {k: v for k, v in entry.data.items() if k not in _HYBRID_OPTION_KEYS}
+    if new_options != dict(entry.options) or new_data != dict(entry.data):
+        hass.config_entries.async_update_entry(entry, data=new_data, options=new_options)
+        _LOGGER.info(
+            "Removed hybrid Modbus settings from cloud entry %s; use a separate local entry instead",
+            entry.title,
+        )
+
+    if not host:
+        return
+
+    registry = dr.async_get(hass)
+    serials: list[tuple[str, str]] = []
+    for device in dr.async_entries_for_config_entry(registry, entry.entry_id):
+        sn = device.serial_number
+        if not sn:
+            continue
+        model = device.model or "Inverter"
+        serials.append((sn, str(model)))
+    # de-dupe by serial, keep first model
+    seen: set[str] = set()
+    unique_serials: list[tuple[str, str]] = []
+    for sn, model in serials:
+        if sn in seen:
+            continue
+        seen.add(sn)
+        unique_serials.append((sn, model))
+
+    if not unique_serials:
+        _LOGGER.warning(
+            "Cloud entry %s had modbus_host=%s but no inverter serial in the device registry; "
+            "set up local Modbus via discovery (or Add Integration) for a separate local entry",
+            entry.title,
+            host,
+        )
+        return
+
+    from homeassistant.config_entries import SOURCE_IMPORT
+
+    for serial, model in unique_serials:
+        unique_id = f"modbus_{serial}"
+        if hass.config_entries.async_entry_for_domain_unique_id(DOMAIN, unique_id) is not None:
+            continue
+        hass.async_create_task(
+            hass.config_entries.flow.async_init(
+                DOMAIN,
+                context={"source": SOURCE_IMPORT},
+                data={
+                    CONF_TRANSPORT: TRANSPORT_MODBUS_ONLY,
+                    CONF_SERIAL: serial,
+                    CONF_MODEL: model,
+                    CONF_MODBUS_HOST: host,
+                    CONF_SCAN_INTERVAL: 30,
+                    "modbus_debug_daily_yield": debug,
+                },
+            )
+        )
+        _LOGGER.info(
+            "Created separate local Modbus entry for serial %s (host %s) split from cloud entry %s",
+            serial,
+            host,
+            entry.title,
+        )
 
 
 def build_plant_device_info(plant_id: str, plant_name: str, console_url: str) -> DeviceInfo:
@@ -264,34 +399,47 @@ async def async_migrate_entry(hass: HomeAssistant, config_entry: ConfigEntry) ->
 async def _async_setup_modbus_only(hass: HomeAssistant, entry: SungrowConfigEntry) -> bool:
     """Set up a cloud-free entry that reads a single inverter over local Modbus (#159).
 
-    Created by zeroconf discovery of a WiNet-S: no credentials, no cloud calls. One
-    coordinator reads the inverter's registers and the sensor platform builds entities
-    from the same measure-point codes the cloud path uses.
+    Created by zeroconf discovery or import from a legacy hybrid split: no credentials,
+    no cloud calls. One coordinator reads the inverter's registers and the sensor
+    platform builds entities from the same measure-point codes the cloud path uses.
+
+    When a cloud entry already owns this serial, the local inverter is nested under
+    that cloud plant (``via_device``) without merging any sensor values.
     """
     serial = str(entry.data.get(CONF_SERIAL) or entry.unique_id or "inverter")
+    # unique_id is modbus_{serial}; strip prefix if present for a clean serial key
+    if serial.startswith("modbus_"):
+        serial = serial.removeprefix("modbus_")
     model = str(entry.data.get(CONF_MODEL) or "Inverter")
-    plant_name = f"Sungrow {model}"
+    local_name = f"{model} (local)"
     host = str(entry.options.get(CONF_MODBUS_HOST) or entry.data.get(CONF_MODBUS_HOST) or "")
-    # One inverter device nested under a service "plant" anchor (mirrors the cloud
-    # topology); distinct identifiers so the plant and inverter don't collide.
+    winet_url = f"http://{host}" if host else None
+    cloud_plant_id = find_related_cloud_plant_id(hass, serial)
+    via_plant_id = cloud_plant_id or serial
+
+    # One inverter device. Distinct identifiers so the plant and inverter don't collide.
     inverter = {
         "uuid": f"{serial}_inv",
-        "device_name": plant_name,
+        "device_name": local_name,
         "device_type": DeviceType.INVERTER,
         "device_model_code": model,
         "device_sn": serial,
         "factory_name": "SUNGROW",
     }
-    coordinator = SungrowPlantCoordinator(hass, entry, None, serial, plant_name, [inverter])
+    coordinator = SungrowPlantCoordinator(hass, entry, None, serial, local_name, [inverter])
+    coordinator.via_plant_id = via_plant_id
+    coordinator.local_configuration_url = winet_url
     await coordinator.async_config_entry_first_refresh()
 
     entry.runtime_data = SungrowData(coordinators=[coordinator], control=None, devices={serial: [inverter]})
-    # Pre-create the plant service device (via_device parent) with the WiNet-S web UI
-    # as its configuration URL.
-    dr.async_get(hass).async_get_or_create(
-        config_entry_id=entry.entry_id,
-        **build_plant_device_info(serial, plant_name, f"http://{host}" if host else DEFAULT_CONSOLE_URL),
-    )
+    # Only create a synthetic local plant anchor when there is no cloud plant to nest under.
+    if cloud_plant_id is None:
+        dr.async_get(hass).async_get_or_create(
+            config_entry_id=entry.entry_id,
+            **build_plant_device_info(
+                serial, f"Sungrow {model} (local)", winet_url or DEFAULT_CONSOLE_URL
+            ),
+        )
     # Only the sensor platform: a Modbus-only entry has no cloud device status or dispatch.
     await hass.config_entries.async_forward_entry_setups(entry, _entry_platforms(entry))
     return True
@@ -301,6 +449,8 @@ async def async_setup_entry(hass: HomeAssistant, entry: SungrowConfigEntry) -> b
     """Set up Sungrow iSolarCloud from a config entry."""
     if entry.data.get(CONF_TRANSPORT) == TRANSPORT_MODBUS_ONLY:
         return await _async_setup_modbus_only(hass, entry)
+    # Split legacy hybrid cloud+Modbus entries into pure cloud + separate local.
+    _async_split_legacy_hybrid(hass, entry)
     if "tokens" not in entry.data:
         # Nothing to authenticate with — ask the user to re-authorize.
         raise ConfigEntryAuthFailed("No stored tokens; re-authorization required")

--- a/custom_components/sungrow/config_flow.py
+++ b/custom_components/sungrow/config_flow.py
@@ -10,7 +10,6 @@ from aiohttp import ClientError
 from homeassistant import config_entries, data_entry_flow
 from homeassistant.config_entries import ConfigEntry, ConfigFlowResult
 from homeassistant.core import callback
-from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.network import get_url
 from homeassistant.helpers.service_info.zeroconf import ZeroconfServiceInfo
@@ -92,13 +91,6 @@ class SungrowConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         # Zeroconf-discovered WiNet-S local Modbus host, carried into the confirm step
         # that creates the cloud-free Modbus-only entry (#159).
         self._discovered_modbus_host: str | None = None
-        # Entry id of an existing cloud entry that already monitors the discovered
-        # inverter, when discovery offers to add local Modbus to it (hybrid, #218).
-        self._cloud_entry_id: str | None = None
-        # After OAuth succeeds, hold the cloud entry data while we offer to adopt an
-        # existing Modbus-only entry (local-first → hybrid reverse of #218).
-        self._pending_cloud_data: dict[str, Any] | None = None
-        self._modbus_only_entry_id: str | None = None
 
     @staticmethod
     @callback
@@ -198,58 +190,34 @@ class SungrowConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         self._discovered_modbus_host = host
         self.init_info = {CONF_SERIAL: serial, CONF_MODEL: model or "Inverter"}
         self.context["title_placeholders"] = {"name": f"Sungrow {model or 'inverter'}"}
-        # If this inverter is already set up via the cloud, offer to add fast local Modbus
-        # to that entry (hybrid) rather than creating a duplicate device (#218).
-        cloud_entry = self._find_cloud_entry_for_serial(serial)
-        if cloud_entry is not None:
-            self._cloud_entry_id = cloud_entry.entry_id
-            return await self.async_step_attach_modbus()
+        # Always a standalone local entry — never mash Modbus into the cloud entry.
+        # If a cloud plant already owns this serial, setup nests the local inverter under
+        # that plant via device registry (soft link only).
         return await self.async_step_zeroconf_confirm()
 
-    def _find_cloud_entry_for_serial(self, serial: str) -> ConfigEntry | None:
-        """Return a cloud entry that already monitors this inverter serial, else None (#218).
-
-        Matches on the device-registry ``serial_number`` (set from the cloud ``device_sn``),
-        which equals the WiNet-S-advertised serial for the same physical inverter. Cloud
-        entries that already have a Modbus host are skipped — they are hybrid already.
-        """
-        registry = dr.async_get(self.hass)
-        for entry in self.hass.config_entries.async_entries(DOMAIN):
-            if entry.data.get(CONF_TRANSPORT) == TRANSPORT_MODBUS_ONLY:
-                continue
-            if entry.options.get(CONF_MODBUS_HOST) or entry.data.get(CONF_MODBUS_HOST):
-                continue
-            for device in dr.async_entries_for_config_entry(registry, entry.entry_id):
-                if device.serial_number and device.serial_number == serial:
-                    return entry
-        return None
-
-    async def async_step_attach_modbus(self, user_input: dict[str, Any] | None = None) -> ConfigFlowResult:
-        """Offer to enable local Modbus on the existing cloud entry for this inverter (#218).
-
-        Confirming writes the discovered host into the cloud entry's options and reloads it,
-        so the Phase 2 hybrid overlay serves Modbus-preferred values with cloud fallback —
-        one device, no duplicate.
-        """
-        cloud_entry = self.hass.config_entries.async_get_entry(self._cloud_entry_id or "")
-        if cloud_entry is None:
-            # The cloud entry vanished between steps; fall back to a standalone local entry.
-            return await self.async_step_zeroconf_confirm()
-        if user_input is not None:
-            self.hass.config_entries.async_update_entry(
-                cloud_entry,
-                options={**cloud_entry.options, CONF_MODBUS_HOST: self._discovered_modbus_host},
-            )
-            self.hass.async_create_task(self.hass.config_entries.async_reload(cloud_entry.entry_id))
-            return self.async_abort(reason="modbus_enabled_on_cloud")
-        self._set_confirm_only()
-        return self.async_show_form(
-            step_id="attach_modbus",
-            description_placeholders={
-                "model": self.init_info.get(CONF_MODEL, "Inverter"),
-                "host": self._discovered_modbus_host or "",
-                "cloud": cloud_entry.title,
+    async def async_step_import(self, user_input: dict[str, Any]) -> ConfigFlowResult:
+        """Import a Modbus-only entry (legacy hybrid split / programmatic setup)."""
+        serial = str(user_input.get(CONF_SERIAL) or "").strip()
+        host = str(user_input.get(CONF_MODBUS_HOST) or "").strip()
+        if not serial or not host:
+            return self.async_abort(reason="not_sungrow_device")
+        model = str(user_input.get(CONF_MODEL) or "Inverter")
+        await self.async_set_unique_id(f"modbus_{serial}")
+        self._abort_if_unique_id_configured(updates={CONF_MODBUS_HOST: host})
+        options: dict[str, Any] = {
+            CONF_SCAN_INTERVAL: int(user_input.get(CONF_SCAN_INTERVAL, DEFAULT_MODBUS_SCAN_INTERVAL)),
+        }
+        if user_input.get(CONF_MODBUS_DEBUG_DAILY_YIELD):
+            options[CONF_MODBUS_DEBUG_DAILY_YIELD] = True
+        return self.async_create_entry(
+            title=f"Sungrow {model} (local)",
+            data={
+                CONF_TRANSPORT: TRANSPORT_MODBUS_ONLY,
+                CONF_SERIAL: serial,
+                CONF_MODEL: model,
+                CONF_MODBUS_HOST: host,
             },
+            options=options,
         )
 
     async def async_step_zeroconf_confirm(self, user_input: dict[str, Any] | None = None) -> ConfigFlowResult:
@@ -622,13 +590,8 @@ class SungrowConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
             await self.async_set_unique_id(str(self.init_info[CONF_APP_ID]))
             self._abort_if_unique_id_configured()
-            # Local-first users often already have a Modbus-only entry for the same
-            # inverter. Offer to attach that host and remove the duplicate (#218 reverse).
-            local = self._find_modbus_only_entry()
-            if local is not None:
-                self._pending_cloud_data = data
-                self._modbus_only_entry_id = local.entry_id
-                return await self.async_step_merge_local_modbus()
+            # Cloud and local stay separate: if a Modbus-only entry already exists it is
+            # left alone (soft-linked by serial at device setup, never merged).
             return self.async_create_entry(title=f"Sungrow {self.init_info[CONF_APP_ID]}", data=data)
 
         except data_entry_flow.AbortFlow:
@@ -639,54 +602,6 @@ class SungrowConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         except Exception as e:  # pylint: disable=broad-except
             _LOGGER.exception("Unexpected exception in async_step_finish: %s", e)
             return self._finish_error_result("unknown")
-
-    def _find_modbus_only_entry(self) -> ConfigEntry | None:
-        """Return the first Modbus-only entry that still has a host, if any."""
-        for entry in self.hass.config_entries.async_entries(DOMAIN):
-            if entry.data.get(CONF_TRANSPORT) != TRANSPORT_MODBUS_ONLY:
-                continue
-            if entry.data.get(CONF_MODBUS_HOST) or entry.options.get(CONF_MODBUS_HOST):
-                return entry
-        return None
-
-    async def async_step_merge_local_modbus(self, user_input: dict[str, Any] | None = None) -> ConfigFlowResult:
-        """Offer to adopt an existing Modbus-only entry when finishing cloud OAuth.
-
-        Confirming creates the cloud entry with that host in options (hybrid) and removes
-        the standalone local entry so the user is not left with duplicate devices.
-        Declining creates a cloud-only entry and leaves the local entry alone.
-        """
-        local = self.hass.config_entries.async_get_entry(self._modbus_only_entry_id or "")
-        data = self._pending_cloud_data
-        if data is None:
-            return self.async_abort(reason="missing_code")
-        if local is None:
-            return self.async_create_entry(title=f"Sungrow {self.init_info[CONF_APP_ID]}", data=data)
-
-        host = str(local.data.get(CONF_MODBUS_HOST) or local.options.get(CONF_MODBUS_HOST) or "")
-        if user_input is not None:
-            options: dict[str, Any] = {}
-            if user_input.get("merge_local", True) and host:
-                options[CONF_MODBUS_HOST] = host
-                # Keep the snappy local poll interval the user already chose.
-                if CONF_SCAN_INTERVAL in local.options:
-                    options[CONF_SCAN_INTERVAL] = local.options[CONF_SCAN_INTERVAL]
-                self.hass.async_create_task(self.hass.config_entries.async_remove(local.entry_id))
-            return self.async_create_entry(
-                title=f"Sungrow {self.init_info[CONF_APP_ID]}",
-                data=data,
-                options=options,
-            )
-
-        return self.async_show_form(
-            step_id="merge_local_modbus",
-            data_schema=vol.Schema({vol.Required("merge_local", default=True): bool}),
-            description_placeholders={
-                "host": host,
-                "local_title": local.title,
-                "model": str(local.data.get(CONF_MODEL) or "inverter"),
-            },
-        )
 
 
 def _parse_extra_measure_points(raw: str | None) -> dict[str, str]:
@@ -740,16 +655,14 @@ class SungrowOptionsFlow(config_entries.OptionsFlowWithReload):
                 _LOGGER.warning("Invalid extra measure points input: %s", exc)
             else:
                 data = {**user_input, CONF_EXTRA_MEASURE_POINTS: extras}
-                # Normalise the Modbus host; blank/whitespace means "cloud only".
-                data[CONF_MODBUS_HOST] = (user_input.get(CONF_MODBUS_HOST) or "").strip()
-                data[CONF_MODBUS_DEBUG_DAILY_YIELD] = bool(user_input.get(CONF_MODBUS_DEBUG_DAILY_YIELD, False))
+                # Cloud options never carry Modbus — local is a separate entry.
+                data.pop(CONF_MODBUS_HOST, None)
+                data.pop(CONF_MODBUS_DEBUG_DAILY_YIELD, None)
                 return self.async_create_entry(title="", data=data)
 
         current_interval = self.config_entry.options.get(CONF_SCAN_INTERVAL, DEFAULT_SCAN_INTERVAL)
         current_extras = self.config_entry.options.get(CONF_EXTRA_MEASURE_POINTS, {})
         current_device_sensors = self.config_entry.options.get(CONF_ENABLE_DEVICE_SENSORS, False)
-        current_modbus_host = self.config_entry.options.get(CONF_MODBUS_HOST, "")
-        current_debug_daily = bool(self.config_entry.options.get(CONF_MODBUS_DEBUG_DAILY_YIELD, False))
         extras_str = ",".join(f"{pid}={code}" for pid, code in current_extras.items())
         return self.async_show_form(
             step_id="init",
@@ -765,13 +678,6 @@ class SungrowOptionsFlow(config_entries.OptionsFlowWithReload):
                         description={"suggested_value": extras_str},
                     ): str,
                     vol.Optional(CONF_ENABLE_DEVICE_SENSORS, default=current_device_sensors): bool,
-                    # Optional local Modbus transport (#159): the WiNet-S IP/host. Empty = cloud only.
-                    vol.Optional(
-                        CONF_MODBUS_HOST,
-                        default=current_modbus_host,
-                        description={"suggested_value": current_modbus_host},
-                    ): str,
-                    vol.Optional(CONF_MODBUS_DEBUG_DAILY_YIELD, default=current_debug_daily): bool,
                 }
             ),
             errors=errors,

--- a/custom_components/sungrow/coordinator.py
+++ b/custom_components/sungrow/coordinator.py
@@ -28,6 +28,7 @@ from .const import (
     CONF_MODBUS_PORT,
     CONF_MODBUS_UNIT,
     CONF_SCAN_INTERVAL,
+    CONF_TRANSPORT,
     DEFAULT_MODBUS_PORT,
     DEFAULT_MODBUS_UNIT,
     DEFAULT_SCAN_INTERVAL,
@@ -37,6 +38,7 @@ from .const import (
     INVERTER_DIAGNOSTIC_POINTS,
     INVERTER_OPERATING_STATUS_POINT,
     METER_DEVICE_POINTS,
+    TRANSPORT_MODBUS_ONLY,
 )
 from .energy_units import normalize_energy_units, tag_source
 
@@ -203,11 +205,15 @@ class SungrowPlantCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         # persist and curtail PV (#157/#148). 0 disables auto-revert (legacy behaviour).
         # Owned by the "Forced Dispatch Duration" number; read by the command select.
         self.forced_dispatch_duration_minutes: float = 0
-        # Optional local Modbus transport (#159): when a WiNet-S host is configured, the
-        # coordinator reads fast local values and merges them over the cloud data
-        # (Modbus preferred). None -> cloud only. Built lazily to avoid importing
-        # pymodbus for cloud-only installs.
+        # Local Modbus client is only built for Modbus-only entries (cloud-free). Cloud
+        # entries never attach Modbus — hybrid merge was removed in favour of a separate
+        # local config entry with a soft device link (serial / via_device).
         self._modbus_client = self._build_modbus_client(config_entry)
+        # Optional plant-device parent for device-registry nesting when a cloud plant
+        # already owns this inverter serial (set by Modbus-only setup).
+        self.via_plant_id: str | None = None
+        # WiNet-S web UI URL for local inverter DeviceInfo (Modbus-only).
+        self.local_configuration_url: str | None = None
         # Raw-wire diagnostic for #223 (daily_yield register window). Populated on each
         # successful Modbus poll and surfaced on the daily_yield sensor for inspection.
         # The *entity value* is no longer taken from that register — see
@@ -225,11 +231,13 @@ class SungrowPlantCoordinator(DataUpdateCoordinator[dict[str, Any]]):
 
     @staticmethod
     def _build_modbus_client(config_entry: ConfigEntry) -> Any:
-        """Return a SungrowModbusClient if a Modbus host is configured, else None.
+        """Return a SungrowModbusClient for a Modbus-only entry, else None.
 
-        The host lives in options for a cloud entry (opt-in hybrid) or in data for a
-        discovery-created Modbus-only entry (#159).
+        Cloud entries never get a Modbus client (no hybrid overlay). The WiNet-S host
+        lives in entry data for discovery/import-created local entries (#159).
         """
+        if config_entry.data.get(CONF_TRANSPORT) != TRANSPORT_MODBUS_ONLY:
+            return None
         host = config_entry.options.get(CONF_MODBUS_HOST) or config_entry.data.get(CONF_MODBUS_HOST)
         if not host:
             return None
@@ -300,30 +308,7 @@ class SungrowPlantCoordinator(DataUpdateCoordinator[dict[str, Any]]):
 
         # pysolarcloud is untyped, so the realtime payload is Any.
         cloud_data = cast("dict[str, Any]", all_plants_data.get(self.plant_id, {}))
-        cloud_data = normalize_energy_units(tag_source(cloud_data, "cloud"))
-        # Overlay fast local Modbus values (Modbus preferred) when configured (#159).
-        return await self._async_apply_modbus(cloud_data)
-
-    async def _async_apply_modbus(self, cloud_data: dict[str, Any]) -> dict[str, Any]:
-        """Overlay live Modbus values onto the cloud data (Modbus preferred), if configured.
-
-        Best-effort: any Modbus failure keeps the cloud data, so the local transport can
-        never take the plant offline — it only ever supplies fresher values.
-        """
-        if self._modbus_client is None:
-            return cloud_data
-        from .modbus import merge_realtime
-
-        try:
-            async with asyncio.timeout(self._poll_timeout):
-                local = await self._modbus_client.async_read_realtime()
-        except Exception as err:  # pylint: disable=broad-except  (best-effort: fall back to cloud)
-            _LOGGER.debug("Local Modbus read failed for %s; using cloud data: %s", self.plant_name, err)
-            return cloud_data
-        await self._async_capture_daily_yield_diagnostic()
-        local = normalize_energy_units(local)
-        merged = merge_realtime(cloud_data, local)
-        return await self._async_apply_derived_daily_yield(merged)
+        return normalize_energy_units(tag_source(cloud_data, "cloud"))
 
     async def _async_modbus_only_update(self) -> dict[str, Any]:
         """Read realtime data from the local Modbus client only (cloud-free entry, #159)."""

--- a/custom_components/sungrow/modbus.py
+++ b/custom_components/sungrow/modbus.py
@@ -36,28 +36,6 @@ class SungrowModbusError(Exception):
     """A local Modbus connection or read failed."""
 
 
-def merge_realtime(cloud: dict[str, dict[str, Any]], modbus: dict[str, dict[str, Any]]) -> dict[str, dict[str, Any]]:
-    """Merge cloud and local-Modbus realtime, **Modbus preferred**, tagging provenance.
-
-    The cloud provides the structure (each point's ``id``/``name``, used for naming and
-    enum/device-class resolution) and any points Modbus doesn't expose; where both carry
-    a code, the live Modbus value (and its unit) win. Every returned point carries a
-    ``source`` (``"cloud"`` or ``"modbus"``) so the origin of each reading is accountable.
-    """
-    merged: dict[str, dict[str, Any]] = {code: {**point, "source": "cloud"} for code, point in cloud.items()}
-    for code, mpoint in modbus.items():
-        if code in merged:
-            merged[code] = {
-                **merged[code],
-                "value": mpoint["value"],
-                "unit": mpoint.get("unit") or merged[code].get("unit"),
-                "source": "modbus",
-            }
-        else:
-            merged[code] = dict(mpoint)
-    return merged
-
-
 class SungrowModbusClient:
     """Read realtime data from one Sungrow inverter over local Modbus TCP."""
 

--- a/custom_components/sungrow/sensor.py
+++ b/custom_components/sungrow/sensor.py
@@ -248,8 +248,16 @@ class SungrowSensor(CoordinatorEntity, SensorEntity):
         # device of the mapped type; otherwise keep it on the plant device (#158). The
         # unique_id above is unchanged, so HA re-parents the entity without renaming it.
         device = resolve_point_device(point_code, getattr(coordinator, "devices", None) or [])
+        via_plant_id = getattr(coordinator, "via_plant_id", None)
+        local_url = getattr(coordinator, "local_configuration_url", None)
         if device is not None:
-            self._attr_device_info = build_device_info(device, plant_id, fallback_name=plant_name)
+            self._attr_device_info = build_device_info(
+                device,
+                plant_id,
+                fallback_name=plant_name,
+                via_plant_id=via_plant_id,
+                configuration_url=local_url,
+            )
         else:
             self._attr_device_info = build_plant_device_info(plant_id, plant_name, console_url)
         self._apply_point_metadata(point_code, init_data, plant_name)
@@ -405,7 +413,13 @@ class SungrowDeviceSensor(SungrowSensor):
         device_name = device.get("device_name") or device.get("device_model_name") or coordinator.plant_name
         self._attr_unique_id = f"{self.plant_id}_{self.device_uuid}_{point_code}"
         # Enrich the device card with the model/serial the cloud reports.
-        self._attr_device_info = build_device_info(device, self.plant_id, fallback_name=coordinator.plant_name)
+        self._attr_device_info = build_device_info(
+            device,
+            self.plant_id,
+            fallback_name=coordinator.plant_name,
+            via_plant_id=getattr(coordinator, "via_plant_id", None),
+            configuration_url=getattr(coordinator, "local_configuration_url", None),
+        )
         self._apply_point_metadata(point_code, init_data, device_name)
         # Inverter internals (operating status, MPPT, DC power, device type, ...) are diagnostics.
         if point_code in _DIAGNOSTIC_CODES or point_code == "device_type_code":

--- a/custom_components/sungrow/strings.json
+++ b/custom_components/sungrow/strings.json
@@ -40,24 +40,13 @@
       },
       "zeroconf_confirm": {
         "title": "Set up local Sungrow inverter",
-        "description": "A Sungrow **{model}** was discovered on your network at **{host}** (WiNet-S). Set it up to read data directly over local Modbus — fast, unmetered and offline-capable, with no iSolarCloud account required."
+        "description": "A Sungrow **{model}** was discovered on your network at **{host}** (WiNet-S). Set it up as a **separate local entry** that reads the inverter over Modbus — fast, unmetered and offline-capable, with no iSolarCloud account required. If you also have a cloud entry for the same inverter, both stay independent (the local device is linked under the cloud plant when serials match)."
       },
       "reconfigure_modbus": {
         "title": "Reconfigure local Sungrow inverter",
         "description": "Update the WiNet-S IP address if it changed on your network. This is a local Modbus connection — no iSolarCloud account is involved.",
         "data": {
           "modbus_host": "Local Modbus host (WiNet-S IP)"
-        }
-      },
-      "attach_modbus": {
-        "title": "Add local Modbus to your Sungrow inverter",
-        "description": "A Sungrow **{model}** was discovered at **{host}** (WiNet-S), and it is already set up via iSolarCloud (**{cloud}**). Add fast local Modbus to that entry — its data will come from the local connection first (Modbus preferred) and fall back to the cloud — without creating a duplicate device."
-      },
-      "merge_local_modbus": {
-        "title": "Use your existing local Modbus connection?",
-        "description": "You already have a local Modbus entry (**{local_title}**, host **{host}**) for a **{model}**. Enable hybrid mode on this iSolarCloud entry so plant/grid data comes from the cloud and live inverter metrics from local Modbus (preferred), then remove the standalone local entry to avoid duplicates.",
-        "data": {
-          "merge_local": "Attach local Modbus and remove the standalone local entry"
         }
       }
     },
@@ -72,7 +61,6 @@
     },
     "abort": {
       "already_configured": "Device is already configured",
-      "modbus_enabled_on_cloud": "Local Modbus was enabled on your existing iSolarCloud entry for this inverter.",
       "not_sungrow_device": "The discovered device is not a supported Sungrow inverter.",
       "library_missing": "The pysolarcloud library is not installed. Restart Home Assistant so the integration's requirements are installed, then try again.",
       "missing_code": "Authorization code was not received. Please try again.",
@@ -89,9 +77,7 @@
         "data": {
           "scan_interval": "Polling interval (seconds)",
           "extra_measure_points": "Extra measure points (point_id=code, comma separated)",
-          "enable_device_sensors": "Create per-device sensors (EV chargers, meters, extra batteries)",
-          "modbus_host": "Local Modbus host (WiNet-S IP) — optional; leave blank for cloud only",
-          "modbus_debug_daily_yield": "Expose raw Modbus daily_yield register dump on the sensor (debug only)"
+          "enable_device_sensors": "Create per-device sensors (EV chargers, meters, extra batteries)"
         }
       },
       "modbus_options": {

--- a/custom_components/sungrow/translations/cy.json
+++ b/custom_components/sungrow/translations/cy.json
@@ -40,7 +40,7 @@
       },
       "zeroconf_confirm": {
         "title": "Gosod gwrthdröydd Sungrow lleol",
-        "description": "A Sungrow **{model}** was discovered on your network at **{host}** (WiNet-S). Set it up as a **separate local entry** that reads the inverter over Modbus — fast, unmetered and offline-capable, with no iSolarCloud account required. If you also have a cloud entry for the same inverter, both stay independent (the local device is linked under the cloud plant when serials match)."
+        "description": "Canfuwyd **{model}** Sungrow ar eich rhwydwaith yn **{host}** (WiNet-S). Crëwch ef fel **cofnod lleol ar wahân** sy'n darllen y gwrthdröydd dros Modbus — cyflym, heb fesur ac yn gweithio all-lein, heb angen cyfrif iSolarCloud. Os oes gennych chi hefyd gofnod cwmwl ar gyfer yr un gwrthdröydd, mae'r ddau'n aros annibynnol (mae'r ddyfais leol yn gysylltiedig o dan y planhigyn cwmwl pan mae'r rhifau serial yn cyfateb)."
       },
       "reconfigure_modbus": {
         "title": "Ailgyflunio gwrthdröydd Sungrow lleol",
@@ -85,7 +85,7 @@
         "description": "Addaswch pa mor aml y mae Home Assistant yn darllen y gwrthdröydd yn uniongyrchol dros Modbus lleol. Nid oes cwota API cwmwl, felly gallwch holi'n aml; yr isafswm yw 10 eiliad.",
         "data": {
           "scan_interval": "Cyfwng holi (eiliadau)",
-          "modbus_debug_daily_yield": "Expose raw Modbus daily_yield register dump on the sensor (debug only)"
+          "modbus_debug_daily_yield": "Datgelu dump cofrestr daily_yield Modbus crai ar y synhwyrydd (debug yn unig)"
         }
       }
     }

--- a/custom_components/sungrow/translations/cy.json
+++ b/custom_components/sungrow/translations/cy.json
@@ -40,24 +40,13 @@
       },
       "zeroconf_confirm": {
         "title": "Gosod gwrthdröydd Sungrow lleol",
-        "description": "Darganfuwyd Sungrow **{model}** ar eich rhwydwaith yn **{host}** (WiNet-S). Gosodwch ef i ddarllen data'n uniongyrchol dros Modbus lleol — cyflym, heb derfyn ac all-lein, heb angen cyfrif iSolarCloud."
+        "description": "A Sungrow **{model}** was discovered on your network at **{host}** (WiNet-S). Set it up as a **separate local entry** that reads the inverter over Modbus — fast, unmetered and offline-capable, with no iSolarCloud account required. If you also have a cloud entry for the same inverter, both stay independent (the local device is linked under the cloud plant when serials match)."
       },
       "reconfigure_modbus": {
         "title": "Ailgyflunio gwrthdröydd Sungrow lleol",
         "description": "Diweddarwch gyfeiriad IP y WiNet-S os yw wedi newid ar eich rhwydwaith. Cysylltiad Modbus lleol yw hwn — nid oes cyfrif iSolarCloud yn gysylltiedig.",
         "data": {
           "modbus_host": "Gwesteiwr Modbus lleol (IP WiNet-S)"
-        }
-      },
-      "attach_modbus": {
-        "title": "Ychwanegu Modbus lleol at eich gwrthdröydd Sungrow",
-        "description": "Canfuwyd Sungrow **{model}** yn **{host}** (WiNet-S), ac mae eisoes wedi'i sefydlu drwy iSolarCloud (**{cloud}**). Ychwanegwch Modbus lleol cyflym at y cofnod hwnnw — daw ei ddata o'r cysylltiad lleol yn gyntaf (Modbus a ffefrir) gan syrthio'n ôl i'r cwmwl — heb greu dyfais ddyblyg."
-      },
-      "merge_local_modbus": {
-        "title": "Use your existing local Modbus connection?",
-        "description": "You already have a local Modbus entry (**{local_title}**, host **{host}**) for a **{model}**. Enable hybrid mode on this iSolarCloud entry so plant/grid data comes from the cloud and live inverter metrics from local Modbus (preferred), then remove the standalone local entry to avoid duplicates.",
-        "data": {
-          "merge_local": "Attach local Modbus and remove the standalone local entry"
         }
       }
     },
@@ -77,8 +66,7 @@
       "reauth_successful": "Roedd yr ail-ddilysiad yn llwyddiannus",
       "reconfigure_successful": "Roedd yr ailgyflunio'n llwyddiannus",
       "wrong_account": "Nid yw'r cyfrif awdurdodedig yn cyfateb i App ID yr integreiddiad hwn. Defnyddiwch y cymhwysiad datblygwr gwreiddiol.",
-      "not_sungrow_device": "Nid yw'r ddyfais a ddarganfuwyd yn wrthdröydd Sungrow a gefnogir.",
-      "modbus_enabled_on_cloud": "Galluogwyd Modbus lleol ar eich cofnod iSolarCloud presennol ar gyfer y gwrthdröydd hwn."
+      "not_sungrow_device": "Nid yw'r ddyfais a ddarganfuwyd yn wrthdröydd Sungrow a gefnogir."
     }
   },
   "options": {
@@ -89,9 +77,7 @@
         "data": {
           "scan_interval": "Cyfwng holi (eiliadau)",
           "extra_measure_points": "Pwyntiau mesur ychwanegol (point_id=code, wedi'u gwahanu gan atalnodau)",
-          "enable_device_sensors": "Creu synwyryddion fesul dyfais (gwefrwyr EV, mesuryddion, batris ychwanegol)",
-          "modbus_host": "Gwesteiwr Modbus lleol (IP y WiNet-S) — dewisol; gadewch yn wag ar gyfer cwmwl yn unig",
-          "modbus_debug_daily_yield": "Expose raw Modbus daily_yield register dump on the sensor (debug only)"
+          "enable_device_sensors": "Creu synwyryddion fesul dyfais (gwefrwyr EV, mesuryddion, batris ychwanegol)"
         }
       },
       "modbus_options": {

--- a/custom_components/sungrow/translations/de.json
+++ b/custom_components/sungrow/translations/de.json
@@ -40,24 +40,13 @@
       },
       "zeroconf_confirm": {
         "title": "Lokalen Sungrow-Wechselrichter einrichten",
-        "description": "Ein Sungrow **{model}** wurde in Ihrem Netzwerk unter **{host}** (WiNet-S) gefunden. Richten Sie ihn ein, um Daten direkt über lokales Modbus zu lesen — schnell, ohne Limit und offline-fähig, ohne iSolarCloud-Konto."
+        "description": "A Sungrow **{model}** was discovered on your network at **{host}** (WiNet-S). Set it up as a **separate local entry** that reads the inverter over Modbus — fast, unmetered and offline-capable, with no iSolarCloud account required. If you also have a cloud entry for the same inverter, both stay independent (the local device is linked under the cloud plant when serials match)."
       },
       "reconfigure_modbus": {
         "title": "Lokalen Sungrow-Wechselrichter neu konfigurieren",
         "description": "Aktualisieren Sie die WiNet-S-IP-Adresse, falls sie sich in Ihrem Netzwerk geändert hat. Dies ist eine lokale Modbus-Verbindung — es ist kein iSolarCloud-Konto beteiligt.",
         "data": {
           "modbus_host": "Lokaler Modbus-Host (WiNet-S-IP)"
-        }
-      },
-      "attach_modbus": {
-        "title": "Lokales Modbus zu Ihrem Sungrow-Wechselrichter hinzufügen",
-        "description": "Ein Sungrow **{model}** wurde unter **{host}** (WiNet-S) erkannt und ist bereits über iSolarCloud (**{cloud}**) eingerichtet. Fügen Sie diesem Eintrag schnelles lokales Modbus hinzu — die Daten kommen zuerst aus der lokalen Verbindung (Modbus bevorzugt) und fallen auf die Cloud zurück — ohne ein doppeltes Gerät zu erstellen."
-      },
-      "merge_local_modbus": {
-        "title": "Use your existing local Modbus connection?",
-        "description": "You already have a local Modbus entry (**{local_title}**, host **{host}**) for a **{model}**. Enable hybrid mode on this iSolarCloud entry so plant/grid data comes from the cloud and live inverter metrics from local Modbus (preferred), then remove the standalone local entry to avoid duplicates.",
-        "data": {
-          "merge_local": "Attach local Modbus and remove the standalone local entry"
         }
       }
     },
@@ -77,8 +66,7 @@
       "reauth_successful": "Die erneute Authentifizierung war erfolgreich",
       "reconfigure_successful": "Die Neukonfiguration war erfolgreich",
       "wrong_account": "Das autorisierte Konto stimmt nicht mit der App ID dieser Integration überein. Verwenden Sie die ursprüngliche Entwickleranwendung.",
-      "not_sungrow_device": "Das gefundene Gerät ist kein unterstützter Sungrow-Wechselrichter.",
-      "modbus_enabled_on_cloud": "Lokales Modbus wurde für diesen Wechselrichter in Ihrem vorhandenen iSolarCloud-Eintrag aktiviert."
+      "not_sungrow_device": "Das gefundene Gerät ist kein unterstützter Sungrow-Wechselrichter."
     }
   },
   "options": {
@@ -89,9 +77,7 @@
         "data": {
           "scan_interval": "Abfrageintervall (Sekunden)",
           "extra_measure_points": "Zusätzliche Messpunkte (point_id=code, durch Kommata getrennt)",
-          "enable_device_sensors": "Sensoren pro Gerät erstellen (EV-Ladegeräte, Zähler, zusätzliche Batterien)",
-          "modbus_host": "Lokaler Modbus-Host (WiNet-S-IP) — optional; für reinen Cloud-Betrieb leer lassen",
-          "modbus_debug_daily_yield": "Expose raw Modbus daily_yield register dump on the sensor (debug only)"
+          "enable_device_sensors": "Sensoren pro Gerät erstellen (EV-Ladegeräte, Zähler, zusätzliche Batterien)"
         }
       },
       "modbus_options": {

--- a/custom_components/sungrow/translations/de.json
+++ b/custom_components/sungrow/translations/de.json
@@ -40,7 +40,7 @@
       },
       "zeroconf_confirm": {
         "title": "Lokalen Sungrow-Wechselrichter einrichten",
-        "description": "A Sungrow **{model}** was discovered on your network at **{host}** (WiNet-S). Set it up as a **separate local entry** that reads the inverter over Modbus — fast, unmetered and offline-capable, with no iSolarCloud account required. If you also have a cloud entry for the same inverter, both stay independent (the local device is linked under the cloud plant when serials match)."
+        "description": "Ein Sungrow **{model}** wurde in Ihrem Netzwerk unter **{host}** (WiNet-S) gefunden. Richten Sie ihn als **separaten lokalen Eintrag** ein, der den Wechselrichter über Modbus ausliest — schnell, unbegrenzt und offline-fähig, ohne iSolarCloud-Konto. Wenn Sie auch einen Cloud-Eintrag für denselben Wechselrichter haben, bleiben beide unabhängig (das lokale Gerät wird unter der Cloud-Anlage verknüpft, wenn die Seriennummern übereinstimmen)."
       },
       "reconfigure_modbus": {
         "title": "Lokalen Sungrow-Wechselrichter neu konfigurieren",
@@ -85,7 +85,7 @@
         "description": "Legen Sie fest, wie oft Home Assistant den Wechselrichter direkt über lokales Modbus ausliest. Es gibt kein Cloud-API-Kontingent, sodass Sie häufig abfragen können; das Minimum beträgt 10 Sekunden.",
         "data": {
           "scan_interval": "Abfrageintervall (Sekunden)",
-          "modbus_debug_daily_yield": "Expose raw Modbus daily_yield register dump on the sensor (debug only)"
+          "modbus_debug_daily_yield": "Rohdaten-Dump des Modbus-daily_yield-Registers auf dem Sensor anzeigen (nur Debug)"
         }
       }
     }

--- a/custom_components/sungrow/translations/en.json
+++ b/custom_components/sungrow/translations/en.json
@@ -40,24 +40,13 @@
       },
       "zeroconf_confirm": {
         "title": "Set up local Sungrow inverter",
-        "description": "A Sungrow **{model}** was discovered on your network at **{host}** (WiNet-S). Set it up to read data directly over local Modbus — fast, unmetered and offline-capable, with no iSolarCloud account required."
+        "description": "A Sungrow **{model}** was discovered on your network at **{host}** (WiNet-S). Set it up as a **separate local entry** that reads the inverter over Modbus — fast, unmetered and offline-capable, with no iSolarCloud account required. If you also have a cloud entry for the same inverter, both stay independent (the local device is linked under the cloud plant when serials match)."
       },
       "reconfigure_modbus": {
         "title": "Reconfigure local Sungrow inverter",
         "description": "Update the WiNet-S IP address if it changed on your network. This is a local Modbus connection — no iSolarCloud account is involved.",
         "data": {
           "modbus_host": "Local Modbus host (WiNet-S IP)"
-        }
-      },
-      "attach_modbus": {
-        "title": "Add local Modbus to your Sungrow inverter",
-        "description": "A Sungrow **{model}** was discovered at **{host}** (WiNet-S), and it is already set up via iSolarCloud (**{cloud}**). Add fast local Modbus to that entry — its data will come from the local connection first (Modbus preferred) and fall back to the cloud — without creating a duplicate device."
-      },
-      "merge_local_modbus": {
-        "title": "Use your existing local Modbus connection?",
-        "description": "You already have a local Modbus entry (**{local_title}**, host **{host}**) for a **{model}**. Enable hybrid mode on this iSolarCloud entry so plant/grid data comes from the cloud and live inverter metrics from local Modbus (preferred), then remove the standalone local entry to avoid duplicates.",
-        "data": {
-          "merge_local": "Attach local Modbus and remove the standalone local entry"
         }
       }
     },
@@ -77,8 +66,7 @@
       "reauth_successful": "Re-authentication was successful",
       "reconfigure_successful": "Reconfiguration was successful",
       "wrong_account": "The authorized account does not match this integration's App ID. Use the original developer application.",
-      "not_sungrow_device": "The discovered device is not a supported Sungrow inverter.",
-      "modbus_enabled_on_cloud": "Local Modbus was enabled on your existing iSolarCloud entry for this inverter."
+      "not_sungrow_device": "The discovered device is not a supported Sungrow inverter."
     }
   },
   "options": {
@@ -89,9 +77,7 @@
         "data": {
           "scan_interval": "Polling interval (seconds)",
           "extra_measure_points": "Extra measure points (point_id=code, comma separated)",
-          "enable_device_sensors": "Create per-device sensors (EV chargers, meters, extra batteries)",
-          "modbus_host": "Local Modbus host (WiNet-S IP) — optional; leave blank for cloud only",
-          "modbus_debug_daily_yield": "Expose raw Modbus daily_yield register dump on the sensor (debug only)"
+          "enable_device_sensors": "Create per-device sensors (EV chargers, meters, extra batteries)"
         }
       },
       "modbus_options": {

--- a/custom_components/sungrow/translations/es.json
+++ b/custom_components/sungrow/translations/es.json
@@ -40,24 +40,13 @@
       },
       "zeroconf_confirm": {
         "title": "Configurar inversor Sungrow local",
-        "description": "Se descubrió un Sungrow **{model}** en su red en **{host}** (WiNet-S). Configúrelo para leer datos directamente por Modbus local — rápido, sin límites y sin conexión, sin necesidad de una cuenta de iSolarCloud."
+        "description": "A Sungrow **{model}** was discovered on your network at **{host}** (WiNet-S). Set it up as a **separate local entry** that reads the inverter over Modbus — fast, unmetered and offline-capable, with no iSolarCloud account required. If you also have a cloud entry for the same inverter, both stay independent (the local device is linked under the cloud plant when serials match)."
       },
       "reconfigure_modbus": {
         "title": "Reconfigurar inversor Sungrow local",
         "description": "Actualice la dirección IP del WiNet-S si ha cambiado en su red. Esta es una conexión Modbus local — no interviene ninguna cuenta de iSolarCloud.",
         "data": {
           "modbus_host": "Host Modbus local (IP del WiNet-S)"
-        }
-      },
-      "attach_modbus": {
-        "title": "Añadir Modbus local a su inversor Sungrow",
-        "description": "Se detectó un Sungrow **{model}** en **{host}** (WiNet-S), y ya está configurado a través de iSolarCloud (**{cloud}**). Añada Modbus local rápido a esa entrada — sus datos provendrán primero de la conexión local (Modbus preferido) y recurrirán a la nube — sin crear un dispositivo duplicado."
-      },
-      "merge_local_modbus": {
-        "title": "Use your existing local Modbus connection?",
-        "description": "You already have a local Modbus entry (**{local_title}**, host **{host}**) for a **{model}**. Enable hybrid mode on this iSolarCloud entry so plant/grid data comes from the cloud and live inverter metrics from local Modbus (preferred), then remove the standalone local entry to avoid duplicates.",
-        "data": {
-          "merge_local": "Attach local Modbus and remove the standalone local entry"
         }
       }
     },
@@ -77,8 +66,7 @@
       "reauth_successful": "La reautenticación se realizó correctamente",
       "reconfigure_successful": "La reconfiguración se realizó correctamente",
       "wrong_account": "La cuenta autorizada no coincide con el App ID de esta integración. Use la aplicación de desarrollador original.",
-      "not_sungrow_device": "El dispositivo descubierto no es un inversor Sungrow compatible.",
-      "modbus_enabled_on_cloud": "Se habilitó Modbus local en su entrada de iSolarCloud existente para este inversor."
+      "not_sungrow_device": "El dispositivo descubierto no es un inversor Sungrow compatible."
     }
   },
   "options": {
@@ -89,9 +77,7 @@
         "data": {
           "scan_interval": "Intervalo de sondeo (segundos)",
           "extra_measure_points": "Puntos de medición adicionales (point_id=code, separados por comas)",
-          "enable_device_sensors": "Crear sensores por dispositivo (cargadores de VE, contadores, baterías adicionales)",
-          "modbus_host": "Host Modbus local (IP del WiNet-S) — opcional; déjelo en blanco para usar solo la nube",
-          "modbus_debug_daily_yield": "Expose raw Modbus daily_yield register dump on the sensor (debug only)"
+          "enable_device_sensors": "Crear sensores por dispositivo (cargadores de VE, contadores, baterías adicionales)"
         }
       },
       "modbus_options": {

--- a/custom_components/sungrow/translations/es.json
+++ b/custom_components/sungrow/translations/es.json
@@ -40,7 +40,7 @@
       },
       "zeroconf_confirm": {
         "title": "Configurar inversor Sungrow local",
-        "description": "A Sungrow **{model}** was discovered on your network at **{host}** (WiNet-S). Set it up as a **separate local entry** that reads the inverter over Modbus — fast, unmetered and offline-capable, with no iSolarCloud account required. If you also have a cloud entry for the same inverter, both stay independent (the local device is linked under the cloud plant when serials match)."
+        "description": "Se ha descubierto un inversor Sungrow **{model}** en su red en **{host}** (WiNet-S). Configúrelo como una **entrada local separada** que lee el inversor a través de Modbus: rápido, sin límites de consumo y capaz de funcionar sin conexión, sin necesidad de cuenta de iSolarCloud. Si también tiene una entrada en la nube para el mismo inversor, ambas permanecen independientes (el dispositivo local se vincula bajo la planta en la nube cuando los números de serie coinciden)."
       },
       "reconfigure_modbus": {
         "title": "Reconfigurar inversor Sungrow local",
@@ -85,7 +85,7 @@
         "description": "Ajuste la frecuencia con la que Home Assistant lee el inversor directamente a través de Modbus local. No hay cuota de API en la nube, por lo que puede sondear con frecuencia; el mínimo es de 10 segundos.",
         "data": {
           "scan_interval": "Intervalo de sondeo (segundos)",
-          "modbus_debug_daily_yield": "Expose raw Modbus daily_yield register dump on the sensor (debug only)"
+          "modbus_debug_daily_yield": "Exponer el volcado crudo del registro daily_yield de Modbus en el sensor (solo depuración)"
         }
       }
     }

--- a/custom_components/sungrow/translations/fr.json
+++ b/custom_components/sungrow/translations/fr.json
@@ -40,7 +40,7 @@
       },
       "zeroconf_confirm": {
         "title": "Configurer l'onduleur Sungrow local",
-        "description": "A Sungrow **{model}** was discovered on your network at **{host}** (WiNet-S). Set it up as a **separate local entry** that reads the inverter over Modbus — fast, unmetered and offline-capable, with no iSolarCloud account required. If you also have a cloud entry for the same inverter, both stay independent (the local device is linked under the cloud plant when serials match)."
+        "description": "Un onduleur Sungrow **{model}** a été découvert sur votre réseau à **{host}** (WiNet-S). Configurez-le comme une **entrée locale séparée** qui lit l'onduleur via Modbus — rapide, sans limite de consommation et fonctionnant hors ligne, sans compte iSolarCloud requis. Si vous avez également une entrée cloud pour le même onduleur, les deux restent indépendantes (le dispositif local est lié sous la centrale cloud lorsque les numéros de série correspondent)."
       },
       "reconfigure_modbus": {
         "title": "Reconfigurer l'onduleur Sungrow local",
@@ -85,7 +85,7 @@
         "description": "Ajustez la fréquence à laquelle Home Assistant lit l'onduleur directement via Modbus local. Il n'y a pas de quota d'API cloud, vous pouvez donc interroger fréquemment ; le minimum est de 10 secondes.",
         "data": {
           "scan_interval": "Intervalle d'interrogation (secondes)",
-          "modbus_debug_daily_yield": "Expose raw Modbus daily_yield register dump on the sensor (debug only)"
+          "modbus_debug_daily_yield": "Exposer le dump brut du registre daily_yield Modbus sur le capteur (débogage uniquement)"
         }
       }
     }

--- a/custom_components/sungrow/translations/fr.json
+++ b/custom_components/sungrow/translations/fr.json
@@ -40,24 +40,13 @@
       },
       "zeroconf_confirm": {
         "title": "Configurer l'onduleur Sungrow local",
-        "description": "Un Sungrow **{model}** a été découvert sur votre réseau à **{host}** (WiNet-S). Configurez-le pour lire les données directement via Modbus local — rapide, sans quota et hors ligne, sans compte iSolarCloud."
+        "description": "A Sungrow **{model}** was discovered on your network at **{host}** (WiNet-S). Set it up as a **separate local entry** that reads the inverter over Modbus — fast, unmetered and offline-capable, with no iSolarCloud account required. If you also have a cloud entry for the same inverter, both stay independent (the local device is linked under the cloud plant when serials match)."
       },
       "reconfigure_modbus": {
         "title": "Reconfigurer l'onduleur Sungrow local",
         "description": "Mettez à jour l'adresse IP du WiNet-S si elle a changé sur votre réseau. Il s'agit d'une connexion Modbus locale — aucun compte iSolarCloud n'est impliqué.",
         "data": {
           "modbus_host": "Hôte Modbus local (IP du WiNet-S)"
-        }
-      },
-      "attach_modbus": {
-        "title": "Ajouter Modbus local à votre onduleur Sungrow",
-        "description": "Un Sungrow **{model}** a été découvert à **{host}** (WiNet-S), et il est déjà configuré via iSolarCloud (**{cloud}**). Ajoutez le Modbus local rapide à cette entrée — ses données proviendront d'abord de la connexion locale (Modbus préféré) et basculeront vers le cloud — sans créer de doublon."
-      },
-      "merge_local_modbus": {
-        "title": "Use your existing local Modbus connection?",
-        "description": "You already have a local Modbus entry (**{local_title}**, host **{host}**) for a **{model}**. Enable hybrid mode on this iSolarCloud entry so plant/grid data comes from the cloud and live inverter metrics from local Modbus (preferred), then remove the standalone local entry to avoid duplicates.",
-        "data": {
-          "merge_local": "Attach local Modbus and remove the standalone local entry"
         }
       }
     },
@@ -77,8 +66,7 @@
       "reauth_successful": "La ré-authentification a réussi",
       "reconfigure_successful": "La reconfiguration a réussi",
       "wrong_account": "Le compte autorisé ne correspond pas à l'App ID de cette intégration. Utilisez l'application développeur d'origine.",
-      "not_sungrow_device": "L'appareil découvert n'est pas un onduleur Sungrow pris en charge.",
-      "modbus_enabled_on_cloud": "Le Modbus local a été activé sur votre entrée iSolarCloud existante pour cet onduleur."
+      "not_sungrow_device": "L'appareil découvert n'est pas un onduleur Sungrow pris en charge."
     }
   },
   "options": {
@@ -89,9 +77,7 @@
         "data": {
           "scan_interval": "Intervalle d'interrogation (secondes)",
           "extra_measure_points": "Points de mesure supplémentaires (point_id=code, séparés par des virgules)",
-          "enable_device_sensors": "Créer des capteurs par appareil (bornes de recharge EV, compteurs, batteries supplémentaires)",
-          "modbus_host": "Hôte Modbus local (IP du WiNet-S) — optionnel ; laisser vide pour le cloud uniquement",
-          "modbus_debug_daily_yield": "Expose raw Modbus daily_yield register dump on the sensor (debug only)"
+          "enable_device_sensors": "Créer des capteurs par appareil (bornes de recharge EV, compteurs, batteries supplémentaires)"
         }
       },
       "modbus_options": {

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -199,8 +199,8 @@ Non-battery controls — **Export Limitation**, **Export Limit (Power/%)**, and
 
 ## Local Modbus (WiNet-S)
 
-These apply to the optional [local Modbus transport](local-modbus.md) (hybrid or Modbus-only
-setups). Cloud-only setups are unaffected.
+These apply to a [local Modbus entry](local-modbus.md). Cloud-only setups are unaffected.
+Cloud and local never merge values onto the same entities.
 
 ### The WiNet-S wasn't auto-discovered
 
@@ -208,47 +208,41 @@ Discovery uses **mDNS/zeroconf**, which does **not** cross subnets or VLANs by d
 
 - Make sure Home Assistant and the WiNet-S are on the **same network segment**. If they're
   on different VLANs/subnets, the discovery card won't appear.
-- You don't have to wait for discovery: on an existing cloud entry, add the dongle manually
-  via **Configure → Local Modbus host** (hybrid). This talks straight to the dongle's IP and
-  needs no mDNS.
 - If discovery is dismissed, it reappears the next time the dongle is seen; you can also
   reload the integration or restart Home Assistant to re-trigger it.
+- A **DHCP reservation** for the dongle keeps the host stable after setup.
 
 ### Local reads fail / "Cannot connect" over Modbus
 
-The dongle is reachable for mDNS (port 80) but Modbus reads use **TCP port 502**. If sensors
-are unavailable on a Modbus-only entry, or a hybrid entry keeps falling back to the cloud:
+The dongle is reachable for mDNS (port 80) but Modbus reads use **TCP port 502**. If local
+sensors are unavailable:
 
 - Confirm the WiNet-S IP is correct and **reachable on port 502** from the Home Assistant
   host (a firewall/VLAN ACL may block 502 even when the web UI on 80 is reachable).
 - The WiNet-S allows only a **limited number of Modbus TCP clients** — if another tool
   (another HA integration, a Modbus poller, node-RED) already holds the connection, reads
   here can fail intermittently. Close the other client.
-- If the dongle's IP changed, a Modbus-only entry updates it automatically on the next
-  discovery; for a hybrid entry, update the **Local Modbus host** field. A **DHCP
-  reservation** for the dongle avoids this.
+- If the dongle's IP changed, rediscovery updates the stored host, or use **Reconfigure**
+  on the local entry.
 
-### `daily_yield` reads higher over Modbus than in the cloud
+### Local `daily_yield` vs cloud daily yield
 
-Known issue on some SG-RS firmware
-([#223](https://github.com/KRoperUK/sungrow-hass/issues/223)) — a scaling/semantics mismatch
-under investigation. **`total_yield` matches the cloud**; only the daily figure diverges. If
-you rely on the daily total, use the cloud value (cloud-only or the cloud sensor on a hybrid
-entry) until it's resolved.
+Local SG-RS firmware often does not reset the daily register at midnight. The local entry
+**derives** calendar-day yield from lifetime `total_yield`. Cloud daily remains the
+iSolarCloud figure. They can differ — that is expected with two independent sources.
+Prefer the cloud daily entity or the local derived entity deliberately in Energy /
+automations.
 
-To help pin the cause down, the `sensor.sungrow_*_daily_yield` entity carries a
-`daily_yield_diagnostic` attribute when a Modbus transport is configured: the raw 16-bit
-register values around the candidate daily_yield positions and every plausible
-`(address, scale)` decoding. If you can, attach that attribute (Dev Tools → States → pick
-the entity → copy `attributes.daily_yield_diagnostic`) to a comment on #223 alongside the
-matching cloud sensor's current value and the local time.
+Optional debug: enable **Expose raw Modbus daily_yield register dump** on the **local**
+entry options, then copy `attributes.daily_yield_diagnostic` from Dev Tools if you need to
+file a register-map issue.
 
 ### My inverter model isn't read over Modbus
 
 Local Modbus currently maps only the **SG-RS single-phase string inverters**. Other models
 (SH hybrids, three-phase SG, standalone battery/meter) aren't in the register map yet
-([#219](https://github.com/KRoperUK/sungrow-hass/issues/219)) — use **cloud-only** or
-**hybrid** (the cloud half returns everything) in the meantime.
+([#219](https://github.com/KRoperUK/sungrow-hass/issues/219)) — use the **cloud** entry for
+those metrics.
 
 ---
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -70,14 +70,13 @@ manufacturer. The Fault sensor exposes an `operating_status` attribute with a hu
 reason for inverter/ESS devices (e.g. *Shut down due to faults*, *Low insulation resistance*),
 and the Connectivity sensor exposes the commissioning date as an attribute.
 
-## Local Modbus host (hybrid)
+## Local Modbus (separate entry)
 
-The options flow has a **Local Modbus host (WiNet-S IP)** field. Leave it blank for the
-default cloud-only behaviour, or enter your WiNet-S dongle's IP address to read the inverter
-**directly over your LAN** — local values are used first and the cloud is a fallback. This is
-faster and doesn't use API quota, while you keep the full cloud sensor set and all
-dispatch/control entities. See [Local Modbus (WiNet-S)](local-modbus.md) for the transport
-modes, auto-discovery, and current limitations.
+Local WiNet-S Modbus is a **separate integration entry**, not a field on the cloud options.
+Discover the dongle (or import a local entry) to get independent local sensors with their own
+poll interval. Cloud stays pure iSolarCloud. When serials match, the local inverter device is
+nested under the cloud plant in the device registry without merging values. See
+[Local Modbus (WiNet-S)](local-modbus.md).
 
 ## Energy dashboard
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -15,9 +15,10 @@ inverters** through the **iSolarCloud** cloud API, using the
 ## Features
 
 - **Cloud polling** — real-time data from the iSolarCloud API (`iot_class: cloud_polling`).
-- **Local Modbus (WiNet-S)** — optionally read the inverter directly over your LAN: as a
-  fast, quota-free overlay on a cloud entry (hybrid), or as a fully cloud-free setup created
-  by auto-discovery. See [Local Modbus](local-modbus.md).
+- **Local Modbus (WiNet-S)** — optionally read the inverter directly over your LAN as a
+  **separate local entry** (auto-discovery), independent of cloud polling. When the same
+  inverter is also on a cloud entry, the local device is soft-linked under the plant. See
+  [Local Modbus](local-modbus.md).
 - **Auto-discovery** — finds every plant linked to your account, and discovers WiNet-S
   dongles on the network for local Modbus.
 - **Rich sensors** — power, energy, battery SOC, and more, with correct device/state classes so

--- a/docs/local-modbus.md
+++ b/docs/local-modbus.md
@@ -9,10 +9,9 @@ network** using the **WiNet-S** dongle's Modbus TCP interface. Local reads are f
 don't count against any API quota, and keep working even when the internet (or
 iSolarCloud) is down.
 
-You can use local Modbus in two ways: **on its own** (a fully cloud-free setup, created by
-auto-discovery) or **alongside the cloud** (a hybrid entry that reads locally first and
-falls back to the cloud). The [transport modes](#transport-modes) section explains when to
-pick each.
+**Cloud and local are separate config entries.** They never mash values onto the same
+sensors. If both exist for the same inverter serial, the local device is nested under
+the cloud plant in the device registry (`via_device`) — a soft “related to” link only.
 
 !!! info "What's supported today"
     Local Modbus currently maps the **SG-RS single-phase string inverters** (e.g. SG3.6RS)
@@ -26,169 +25,85 @@ pick each.
 - A **WiNet-S** communication dongle on the **same LAN** as Home Assistant.
 - The dongle reachable on **TCP port 502** (Modbus TCP) from Home Assistant — the default
   Modbus port and unit ID (`1`) are used automatically.
-- **No iSolarCloud account** for a Modbus-only setup. (The hybrid mode still needs the cloud
-  account for its cloud half.)
+- **No iSolarCloud account** for a Modbus-only setup. (A cloud entry is independent and
+  still needs credentials for its own sensors and dispatch.)
 - A supported inverter — **SG-RS** today (see [limitations](#current-limitations)).
 
 !!! tip "mDNS discovery must be able to reach Home Assistant"
     The dongle is found via **mDNS/zeroconf**, which doesn't cross subnets or VLANs by
     default. If Home Assistant and the WiNet-S are on different network segments, discovery
-    won't fire — add Modbus manually instead (see
-    [Add local Modbus to a cloud entry](#hybrid-add-local-modbus-to-a-cloud-entry)).
+    won't fire — add the local entry manually when that path is available, or ensure mDNS
+    can cross the boundary.
 
 ## Transport modes
 
-The integration supports three "transport" modes. They differ in where readings come from
-and whether a cloud account is involved:
-
 | Mode | Data source | Cloud account | Control (dispatch) | Best for |
 | --- | --- | --- | --- | --- |
-| **Cloud-only** *(default)* | iSolarCloud API | Required | ✅ Yes | The standard setup — full sensor set and battery/dispatch controls. |
-| **Cloud + Modbus** *(hybrid)* | Local Modbus **first**, cloud fallback | Required | ✅ Yes (via cloud) | Fast, unmetered local reads **plus** the cloud's full sensor and control set. |
-| **Modbus-only** *(local)* | Local Modbus only | **Not needed** | ❌ Read-only | Offline / privacy-first setups, or where you don't have working cloud credentials. |
+| **Cloud-only** | iSolarCloud API | Required | ✅ Yes | Full plant sensors and battery/dispatch controls. |
+| **Modbus-only** *(local)* | Local Modbus only | **Not needed** | ❌ Read-only | Fast local metrics, offline / privacy-first. |
+| **Both** *(two entries)* | Each entry its own source | Cloud entry only | Via **cloud** entry | Compare or use cloud + local side by side. |
 
 ```mermaid
 flowchart LR
     subgraph HA["🏠 Home Assistant"]
         direction TB
-        CO["Cloud-only entry"]
-        HY["Hybrid entry"]
-        LO["Modbus-only entry"]
+        CO["Cloud entry"]
+        LO["Local entry"]
     end
     CO -->|"poll"| API["☁️ iSolarCloud OpenAPI"]
-    HY -->|"prefer"| WN["🔌 WiNet-S<br/>Modbus TCP :502"]
-    HY -.->|"fall back"| API
-    LO -->|"only"| WN
+    LO -->|"poll"| WN["🔌 WiNet-S<br/>Modbus TCP :502"]
     API --> INV["Inverter"]
     WN --> INV
+    LO -.->|"via_device when serial matches"| CO
 ```
 
 **Which should I choose?**
 
-- **Just getting started, or you want battery/dispatch control** → **Cloud-only**. Start
-  from [Installation & Setup](installation.md).
-- **You already run cloud and want faster, quota-free local reads** → **Hybrid**. Keep your
-  cloud entry and [add a Modbus host](#hybrid-add-local-modbus-to-a-cloud-entry) to it.
-- **No cloud account (or it isn't working) and you only need read-only sensors** →
-  **Modbus-only**, via [auto-discovery](#modbus-only-set-up-from-auto-discovery).
+- **Battery/dispatch control or full plant metrics** → **Cloud** entry from
+  [Installation & Setup](installation.md).
+- **Fast local power / yield without API quota** → **Local** via
+  [auto-discovery](#modbus-only-set-up-from-auto-discovery).
+- **Both** → set up each entry independently. Pick which entities to use in Energy /
+  automations deliberately (e.g. cloud daily vs local derived daily).
 
 ## Modbus-only: set up from auto-discovery
 
-When a WiNet-S dongle appears on your network, Home Assistant discovers it automatically and
-offers a **cloud-free** local setup.
-
-```mermaid
-sequenceDiagram
-    autonumber
-    participant WN as WiNet-S
-    participant HA as Home Assistant
-    actor You
-    WN-->>HA: mDNS advert (serial + model)
-    HA-->>You: "Discovered: Sungrow <model>"
-    You->>HA: Set up
-    HA->>WN: Read inverter over Modbus TCP :502
-    HA->>HA: Create local entry + sensors
-```
+When a WiNet-S dongle appears on your network, Home Assistant discovers it and offers a
+**standalone local** setup.
 
 1. Go to **Settings → Devices & Services**. A **Discovered** card reading **Sungrow
-   *&lt;model&gt;*** appears (identified from the dongle's advertised serial and model).
-2. Click **Set up**. A confirmation screen explains it will read the inverter directly over
-   local Modbus — no iSolarCloud account required.
-3. Confirm. Home Assistant creates an entry titled **"Sungrow *&lt;model&gt;* (local)"** and
-   its sensors. Polling defaults to **30 seconds** (there's no cloud quota, so you can poll
-   frequently — the minimum is 10 seconds).
+   *&lt;model&gt;*** appears (from the dongle's advertised serial and model).
+2. Click **Set up** and confirm. Home Assistant creates **"Sungrow *&lt;model&gt;* (local)"**.
+3. Polling defaults to **30 seconds** (no cloud quota; minimum 10 seconds).
 
-!!! note "Already set up via the cloud?"
-    If this same inverter is **already configured through iSolarCloud**, discovery detects
-    that (by matching the serial number) and instead offers to **add local Modbus to your
-    existing entry** — see below. This avoids creating a duplicate device.
+If the same inverter is already on a **cloud** entry (matched by serial), the local
+inverter device is placed **under that cloud plant** in the UI. Entities stay separate —
+nothing is merged.
 
-### If the inverter is already on the cloud (attach prompt)
+### Reconfigure / IP change
 
-When discovery finds a dongle for an inverter you already monitor via iSolarCloud, it shows
-an **"Add local Modbus to your Sungrow inverter"** prompt naming the discovered model, its
-host, and the matching cloud entry. Confirming enables **hybrid** mode on that existing cloud
-entry — local reads with cloud fallback, **one device, no duplicate**. To keep things
-cloud-only instead, simply ignore the discovery card.
+- **Options** on the local entry: poll interval and optional daily-yield register debug.
+- **Reconfigure** (or rediscovery): update the WiNet-S host if DHCP moved the dongle.
 
-## Hybrid: add local Modbus to a cloud entry
+## Upgrading from hybrid (old “Modbus host on cloud”)
 
-You can also enable Modbus on an existing cloud entry manually, at any time:
+Earlier builds allowed putting a WiNet-S IP on the **cloud** entry and merging Modbus
+values over cloud sensors. That mashup is removed:
 
-**Settings → Devices & Services → Sungrow iSolarCloud → Configure → Local Modbus host.**
+1. On load, any leftover `modbus_host` is **stripped** from the cloud entry.
+2. When the inverter serial is already in the device registry, a **separate local entry**
+   is created automatically with that host.
+3. If no serial is known yet, set up local Modbus via discovery once more.
 
-Enter the WiNet-S IP address and save. The entry reloads and starts serving **Modbus-preferred**
-values: each reading comes from the local dongle when available and **falls back to the cloud**
-otherwise, so you keep the full cloud sensor set and all dispatch/control entities while the
-common metrics update quickly and without using API quota. **Leave the field blank** to stay
-cloud-only.
+## Daily yield (local)
 
-!!! tip "Assign the dongle a static IP"
-    A hybrid or Modbus-only entry addresses the dongle by IP. Give the WiNet-S a **DHCP
-    reservation / static lease** on your router so the address doesn't change. If it does
-    change, discovery updates a Modbus-only entry automatically; for a hybrid entry, update
-    the **Local Modbus host** field, or use **Reconfigure** on a Modbus-only entry.
-
-## Options and reconfigure
-
-**Modbus-only entry — options** (**Configure**): only the **polling interval** (default 30 s,
-minimum 10 s). There are no cloud-specific options because no cloud account is involved.
-
-**Modbus-only entry — reconfigure**: updates the **WiNet-S IP address** if it changed on your
-network. It does **not** ask for any iSolarCloud credentials.
-
-**Hybrid (cloud) entry — options**: the usual cloud options (polling interval, custom measure
-points, per-device sensors) **plus** the **Local Modbus host** field. Clear the host to drop
-back to cloud-only.
-
-## What you get over Modbus
-
-The SG-RS register map exposes the inverter's core generation metrics directly, including:
-
-- **Total** and **daily** energy yield
-- **AC** (total active) and **DC** power
-- **MPPT** string voltages and currents
-- **Grid frequency** and AC voltage
-- **Internal temperature**
-
-In **hybrid** mode these overlay the cloud data (Modbus wins where it has a value); in
-**Modbus-only** mode they're the full sensor set for the entry.
+On some SG-RS + WiNet-S firmwares the “daily” register never resets at midnight. The local
+entry **derives** calendar-day yield from lifetime `total_yield` (baseline stored in HA).
+Cloud daily yield remains whatever iSolarCloud reports — they can differ; that is expected
+with two independent sources.
 
 ## Current limitations
 
-- **SG-RS inverters only.** The bundled register map covers the SG-RS single-phase string
-  inverters. SH hybrids, three-phase SG, and standalone battery/meter maps are tracked in
-  [#219](https://github.com/KRoperUK/sungrow-hass/issues/219). On other models, use
-  **cloud-only** or **hybrid** (the cloud half still returns everything).
-- **Read-only.** Local Modbus reads sensors; it does not yet write. Battery/dispatch control
-  still goes through the cloud, so use **hybrid** if you want both fast local reads and
-  control. Local write support is tracked in
-  [#220](https://github.com/KRoperUK/sungrow-hass/issues/220).
-- **`daily_yield` is derived from `total_yield`.** On observed SG-RS + WiNet-S firmware the
-  documented "Daily power yields" register (wire 5002) **never resets at midnight** — it
-  climbs with lifetime energy (see [#223](https://github.com/KRoperUK/sungrow-hass/issues/223)).
-  Lifetime `total_yield` matches the cloud, so the integration computes
-  `daily_yield = total_yield − total_at_start_of_local_day` and persists the baseline across
-  restarts. The sensor `source` is `modbus_derived`. An optional
-  **Expose raw Modbus daily_yield register dump** option attaches a
-  `daily_yield_diagnostic` attribute for register debugging (off by default — it is large).
-
-## Local-first, then add cloud (hybrid)
-
-If you started with **Modbus-only** (zeroconf) and later add iSolarCloud:
-
-1. Start **Add integration → Sungrow iSolarCloud** and complete OAuth as usual.
-2. When a standalone local entry already exists, the flow offers **Use your existing local
-   Modbus connection?** — confirm to attach that WiNet-S host to the new cloud entry and
-   remove the duplicate local entry.
-3. Or, after cloud is set up: **Configure** the cloud entry → set **Local Modbus host** to the
-   WiNet-S IP, then remove the old Modbus-only entry manually.
-
-Hybrid behaviour: plant/grid/tariff points from the cloud; overlapping inverter metrics from
-Modbus when available (`source` attribute: `cloud` / `modbus` / `modbus_derived`). Energy
-points reported in Wh are normalised to **kWh** so plant and inverter totals stay comparable.
-- **One local connection.** The WiNet-S serves a limited number of Modbus TCP clients; if you
-  already poll it from another tool, reads here may fail intermittently.
-
-See [Troubleshooting → Local Modbus](TROUBLESHOOTING.md#local-modbus-winet-s) if discovery
-doesn't appear or local reads fail.
+- **SG-RS register map** only (see issues above for other models).
+- **Read-only** — charge/dispatch stays on the cloud API when you have a cloud entry.
+- Local and cloud **do not share** entities; configure Energy/dashboards explicitly.

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -296,8 +296,8 @@ async def test_finish_step_missing_code(hass: HomeAssistant, mock_auth):
     assert result["reason"] == "missing_code"
 
 
-async def test_finish_offers_merge_when_modbus_only_exists(hass: HomeAssistant, mock_auth):
-    """Cloud OAuth finish offers to adopt an existing Modbus-only entry (local-first hybrid)."""
+async def test_finish_leaves_modbus_only_entry_alone(hass: HomeAssistant, mock_auth):
+    """Cloud OAuth finish creates a pure cloud entry and does not merge/remove local."""
     from custom_components.sungrow.const import CONF_MODBUS_HOST, CONF_MODEL, CONF_TRANSPORT, TRANSPORT_MODBUS_ONLY
 
     local = MockConfigEntry(
@@ -320,20 +320,14 @@ async def test_finish_offers_merge_when_modbus_only_exists(hass: HomeAssistant, 
     flow.auth_client = mock_auth
     flow.auth_client.async_authorize = AsyncMock()
 
-    result = await flow.async_step_finish()
-    assert result["type"] == data_entry_flow.FlowResultType.FORM
-    assert result["step_id"] == "merge_local_modbus"
-    assert result["description_placeholders"]["host"] == "192.168.1.93"
-
     with patch("custom_components.sungrow.async_setup_entry", return_value=True):
-        result2 = await flow.async_step_merge_local_modbus({"merge_local": True})
+        result = await flow.async_step_finish()
         await hass.async_block_till_done()
 
-    assert result2["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
-    assert result2["options"][CONF_MODBUS_HOST] == "192.168.1.93"
-    assert result2["options"][CONF_SCAN_INTERVAL] == 30
-    # Standalone local entry removed so devices are not duplicated.
-    assert hass.config_entries.async_entry_for_domain_unique_id(DOMAIN, "modbus_SN1") is None
+    assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
+    assert CONF_MODBUS_HOST not in (result.get("options") or {})
+    # Local entry untouched — separate transports.
+    assert hass.config_entries.async_entry_for_domain_unique_id(DOMAIN, "modbus_SN1") is not None
 
 
 # ---------------------------------------------------------------------------
@@ -760,27 +754,25 @@ async def test_options_flow_parses_extra_measure_points(hass: HomeAssistant, moc
     }
 
 
-async def test_options_flow_stores_and_trims_modbus_host(hass: HomeAssistant, mock_setup_auth, mock_plants_service):
-    """The Modbus host option is stored, whitespace-trimmed; blank means cloud-only (#159)."""
+async def test_options_flow_cloud_has_no_modbus_host(hass: HomeAssistant, mock_setup_auth, mock_plants_service):
+    """Cloud options do not expose or store a Modbus host (local is a separate entry)."""
     entry = MockConfigEntry(domain=DOMAIN, data=MOCK_CONFIG_DATA.copy(), unique_id="test_app_id")
     entry.add_to_hass(hass)
     await hass.config_entries.async_setup(entry.entry_id)
     await hass.async_block_till_done()
 
     result = await hass.config_entries.options.async_init(entry.entry_id)
-    # OptionsFlowWithReload reloads the entry; stub Modbus so the hybrid setup does not open sockets.
-    client = MagicMock()
-    client.async_read_realtime = AsyncMock(return_value={})
-    client.async_read_daily_yield_diagnostic = AsyncMock(return_value=None)
-    with patch("custom_components.sungrow.modbus.SungrowModbusClient", return_value=client):
-        result2 = await hass.config_entries.options.async_configure(
-            result["flow_id"],
-            user_input={CONF_SCAN_INTERVAL: 30, CONF_MODBUS_HOST: "  192.168.1.93  "},
-        )
-        await hass.async_block_till_done()
+    keys = {str(m.schema) for m in result["data_schema"].schema}
+    assert CONF_MODBUS_HOST not in keys
+
+    result2 = await hass.config_entries.options.async_configure(
+        result["flow_id"],
+        user_input={CONF_SCAN_INTERVAL: 30},
+    )
+    await hass.async_block_till_done()
 
     assert result2["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
-    assert entry.options[CONF_MODBUS_HOST] == "192.168.1.93"
+    assert CONF_MODBUS_HOST not in entry.options
 
 
 async def test_options_flow_modbus_only_hides_cloud_settings(hass: HomeAssistant):
@@ -956,48 +948,45 @@ def _add_cloud_entry_with_inverter(
     return cloud
 
 
-async def test_zeroconf_offers_attach_when_inverter_already_cloud_configured(hass: HomeAssistant):
-    """Discovering an inverter already set up via cloud offers to add local Modbus to it (#218)."""
-    _add_cloud_entry_with_inverter(hass, "A2340512345")
+async def test_zeroconf_creates_local_even_when_cloud_has_same_serial(hass: HomeAssistant):
+    """Discovery always creates a standalone local entry — never attaches Modbus to cloud."""
+    cloud = _add_cloud_entry_with_inverter(hass, "A2340512345")
 
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_ZEROCONF}, data=_winet_discovery(serial="A2340512345")
     )
 
     assert result["type"] == data_entry_flow.FlowResultType.FORM
-    assert result["step_id"] == "attach_modbus"
-    assert result["description_placeholders"]["cloud"] == "My Cloud Plant"
-
-
-async def test_zeroconf_attach_enables_hybrid_on_cloud_entry(hass: HomeAssistant):
-    """Confirming the attach step writes the Modbus host onto the cloud entry (hybrid) (#218)."""
-    cloud = _add_cloud_entry_with_inverter(hass, "SNMATCH")
-
-    result = await hass.config_entries.flow.async_init(
-        DOMAIN,
-        context={"source": config_entries.SOURCE_ZEROCONF},
-        data=_winet_discovery(host="192.168.1.77", serial="SNMATCH"),
-    )
-    assert result["step_id"] == "attach_modbus"
+    assert result["step_id"] == "zeroconf_confirm"
 
     with patch("custom_components.sungrow.async_setup_entry", return_value=True):
         result2 = await hass.config_entries.flow.async_configure(result["flow_id"], user_input={})
         await hass.async_block_till_done()
 
-    assert result2["type"] == data_entry_flow.FlowResultType.ABORT
-    assert result2["reason"] == "modbus_enabled_on_cloud"
-    # The cloud entry became hybrid: the discovered host is now in its options.
-    assert cloud.options[CONF_MODBUS_HOST] == "192.168.1.77"
+    assert result2["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
+    assert result2["data"][CONF_TRANSPORT] == TRANSPORT_MODBUS_ONLY
+    assert result2["data"][CONF_MODBUS_HOST] == "192.168.1.93"
+    # Cloud entry stays pure (no modbus_host mashup).
+    assert CONF_MODBUS_HOST not in cloud.options
 
 
-async def test_zeroconf_no_attach_when_cloud_entry_already_hybrid(hass: HomeAssistant):
-    """A cloud entry that already has a Modbus host is skipped — discovery stays standalone (#218)."""
-    cloud = _add_cloud_entry_with_inverter(hass, "A2340512345")
-    hass.config_entries.async_update_entry(cloud, options={CONF_MODBUS_HOST: "10.0.0.1"})
+async def test_import_creates_modbus_only_entry(hass: HomeAssistant):
+    """SOURCE_IMPORT creates a local Modbus entry (legacy hybrid split)."""
+    with patch("custom_components.sungrow.async_setup_entry", return_value=True):
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN,
+            context={"source": config_entries.SOURCE_IMPORT},
+            data={
+                CONF_TRANSPORT: TRANSPORT_MODBUS_ONLY,
+                CONF_SERIAL: "SNIMPORT",
+                CONF_MODEL: "SG3.6RS",
+                CONF_MODBUS_HOST: "10.0.0.5",
+                CONF_SCAN_INTERVAL: 30,
+            },
+        )
+        await hass.async_block_till_done()
 
-    result = await hass.config_entries.flow.async_init(
-        DOMAIN, context={"source": config_entries.SOURCE_ZEROCONF}, data=_winet_discovery(serial="A2340512345")
-    )
-
-    # No hybrid attach offered; falls through to the standalone Modbus-only confirm.
-    assert result["step_id"] == "zeroconf_confirm"
+    assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
+    assert result["title"] == "Sungrow SG3.6RS (local)"
+    assert result["data"][CONF_MODBUS_HOST] == "10.0.0.5"
+    assert result["result"].unique_id == "modbus_SNIMPORT"

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -19,8 +19,10 @@ from custom_components.sungrow.const import (
     CONF_MODBUS_PORT,
     CONF_MODBUS_UNIT,
     CONF_SCAN_INTERVAL,
+    CONF_TRANSPORT,
     DEVICE_REFRESH_INTERVAL,
     DOMAIN,
+    TRANSPORT_MODBUS_ONLY,
 )
 from custom_components.sungrow.coordinator import (
     BACKOFF_MAX_INTERVAL,
@@ -774,43 +776,38 @@ async def test_plant_detail_best_effort_on_error(hass: HomeAssistant):
 # ---------------------------------------------------------------------------
 
 
-async def test_build_modbus_client_from_options(hass: HomeAssistant):
-    """A configured Modbus host builds a client with the given host/port/unit."""
-    entry = _make_entry({CONF_MODBUS_HOST: "10.0.0.5", CONF_MODBUS_PORT: 1502, CONF_MODBUS_UNIT: 2})
-    client = SungrowPlantCoordinator._build_modbus_client(entry)
+async def test_build_modbus_client_only_for_modbus_only_entry(hass: HomeAssistant):
+    """Modbus client is built for transport=modbus_only with a host, never for cloud entries."""
+    local = _make_entry(
+        options={CONF_MODBUS_PORT: 1502, CONF_MODBUS_UNIT: 2},
+        data={
+            CONF_TRANSPORT: TRANSPORT_MODBUS_ONLY,
+            CONF_MODBUS_HOST: "10.0.0.5",
+        },
+    )
+    client = SungrowPlantCoordinator._build_modbus_client(local)
     assert client is not None
     assert (client.host, client.port, client.unit) == ("10.0.0.5", 1502, 2)
 
+    # Cloud entry with leftover hybrid host must NOT get a client.
+    hybrid_leftover = _make_entry({CONF_MODBUS_HOST: "10.0.0.5"})
+    assert SungrowPlantCoordinator._build_modbus_client(hybrid_leftover) is None
+
 
 def test_no_modbus_client_when_host_blank():
-    """No host (or a blank host) means cloud-only: no Modbus client."""
+    """No host (or a blank host) means no Modbus client on a local entry."""
     assert SungrowPlantCoordinator._build_modbus_client(_make_entry()) is None
-    assert SungrowPlantCoordinator._build_modbus_client(_make_entry({CONF_MODBUS_HOST: ""})) is None
-
-
-async def test_apply_modbus_merges_over_cloud(hass: HomeAssistant):
-    """Configured Modbus overlays its value over the cloud value and tags provenance."""
-    coordinator = SungrowPlantCoordinator(hass, _make_entry(), MagicMock(), "12345", "Test Plant")
-    coordinator._modbus_client = MagicMock()
-    coordinator._modbus_client.async_read_realtime = AsyncMock(
-        return_value={
-            "total_active_power": {"code": "total_active_power", "value": 256, "unit": "W", "source": "modbus"}
-        }
+    assert (
+        SungrowPlantCoordinator._build_modbus_client(
+            _make_entry(data={CONF_TRANSPORT: TRANSPORT_MODBUS_ONLY, CONF_MODBUS_HOST: ""})
+        )
+        is None
     )
-    cloud = {
-        "total_active_power": {"code": "total_active_power", "value": "250", "unit": "W", "source": "cloud"},
-        "daily_yield": {"code": "daily_yield", "value": "38", "source": "cloud"},
-    }
-    merged = await coordinator._async_apply_modbus(cloud)
-    assert merged["total_active_power"]["value"] == 256
-    assert merged["total_active_power"]["source"] == "modbus"
-    # No total_yield in this payload → derived daily is not applied; cloud daily kept.
-    assert merged["daily_yield"]["source"] == "cloud"
 
 
 async def test_modbus_debug_daily_yield_gated(hass: HomeAssistant):
     """Raw daily_yield register dump is only captured when the debug option is on."""
-    entry = _make_entry(data={CONF_MODBUS_HOST: "10.0.0.9"})
+    entry = _make_entry(data={CONF_TRANSPORT: TRANSPORT_MODBUS_ONLY, CONF_MODBUS_HOST: "10.0.0.9"})
     coordinator = SungrowPlantCoordinator(hass, entry, None, "SN", "SG")
     coordinator._modbus_client = MagicMock()
     coordinator._modbus_client.async_read_daily_yield_diagnostic = AsyncMock(return_value={"raw": {"5002": 1}})
@@ -833,7 +830,7 @@ async def test_modbus_derives_daily_yield_from_total(hass: HomeAssistant):
 
     from custom_components.sungrow.daily_yield import DailyYieldBaseline
 
-    entry = _make_entry(data={CONF_MODBUS_HOST: "10.0.0.9"})
+    entry = _make_entry(data={CONF_TRANSPORT: TRANSPORT_MODBUS_ONLY, CONF_MODBUS_HOST: "10.0.0.9"})
     coordinator = SungrowPlantCoordinator(hass, entry, None, "SN-DY", "SG")
     coordinator._modbus_client = MagicMock()
     coordinator._modbus_client.async_read_realtime = AsyncMock(
@@ -862,26 +859,6 @@ async def test_modbus_derives_daily_yield_from_total(hass: HomeAssistant):
     coordinator._daily_yield_store.async_save.assert_awaited()
 
 
-async def test_apply_modbus_falls_back_to_cloud_on_error(hass: HomeAssistant):
-    """A Modbus read failure keeps the cloud data untouched (never takes the plant offline)."""
-    from custom_components.sungrow.modbus import SungrowModbusError
-
-    coordinator = SungrowPlantCoordinator(hass, _make_entry(), MagicMock(), "12345", "Test Plant")
-    coordinator._modbus_client = MagicMock()
-    coordinator._modbus_client.async_read_realtime = AsyncMock(side_effect=SungrowModbusError("boom"))
-    cloud = {"total_active_power": {"code": "total_active_power", "value": "250"}}
-    merged = await coordinator._async_apply_modbus(cloud)
-    assert merged == cloud  # unchanged; no source tags added
-
-
-async def test_apply_modbus_noop_without_client(hass: HomeAssistant):
-    """Cloud-only (no Modbus host) returns the cloud data unchanged."""
-    coordinator = SungrowPlantCoordinator(hass, _make_entry(), MagicMock(), "12345", "Test Plant")
-    assert coordinator._modbus_client is None
-    cloud = {"x": {"value": "1"}}
-    assert await coordinator._async_apply_modbus(cloud) is cloud
-
-
 # ---------------------------------------------------------------------------
 # Modbus-only transport (cloud-free entry, #159)
 # ---------------------------------------------------------------------------
@@ -889,7 +866,7 @@ async def test_apply_modbus_noop_without_client(hass: HomeAssistant):
 
 def _modbus_only_coordinator(hass: HomeAssistant) -> SungrowPlantCoordinator:
     """A coordinator with no cloud service and a stubbed Modbus client."""
-    entry = _make_entry(data={CONF_MODBUS_HOST: "10.0.0.9"})
+    entry = _make_entry(data={CONF_TRANSPORT: TRANSPORT_MODBUS_ONLY, CONF_MODBUS_HOST: "10.0.0.9"})
     coordinator = SungrowPlantCoordinator(hass, entry, None, "SN123", "Sungrow SG3.6RS")
     assert coordinator.plants_service is None
     coordinator._modbus_client = MagicMock()
@@ -945,37 +922,11 @@ async def test_modbus_only_update_raises_outside_grace(hass: HomeAssistant):
 # ---------------------------------------------------------------------------
 
 
-async def test_apply_modbus_captures_daily_yield_diagnostic(hass: HomeAssistant):
-    """Each successful Modbus read refreshes coordinator.daily_yield_diagnostic (#223)."""
-    coordinator = SungrowPlantCoordinator(hass, _make_entry(), MagicMock(), "12345", "Test Plant")
-    coordinator._modbus_client = MagicMock()
-    coordinator._modbus_client.async_read_realtime = AsyncMock(
-        return_value={"daily_yield": {"code": "daily_yield", "value": 64.0, "unit": "kWh", "source": "modbus"}}
-    )
-    coordinator._modbus_client.async_read_daily_yield_diagnostic = AsyncMock(
-        return_value={
-            "start": 4999,
-            "raw": {"5002": 640},
-            "current_mapping": {"address": 5002, "raw": 640, "scale": 0.1, "unit": "kWh"},
-        }
-    )
-    cloud = {"daily_yield": {"code": "daily_yield", "value": "60.0", "unit": "kWh"}}
-    # Diagnostic capture is opt-in (recorder bloat when off).
-    coordinator.config_entry.options = {CONF_MODBUS_DEBUG_DAILY_YIELD: True}
-    await coordinator._async_apply_modbus(cloud)
-    assert coordinator.daily_yield_diagnostic is not None
-    assert coordinator.daily_yield_diagnostic["raw"]["5002"] == 640
-
-
-async def test_apply_modbus_keeps_previous_diagnostic_on_capture_failure(hass: HomeAssistant):
+async def test_modbus_only_keeps_previous_diagnostic_on_capture_failure(hass: HomeAssistant):
     """A Modbus diagnostic-read failure keeps the previous diagnostic in place so a
     transient blip never clears evidence the user is collecting for #223.
     """
-    coordinator = SungrowPlantCoordinator(hass, _make_entry(), MagicMock(), "12345", "Test Plant")
-    coordinator._modbus_client = MagicMock()
-    coordinator._modbus_client.async_read_realtime = AsyncMock(
-        return_value={"daily_yield": {"code": "daily_yield", "value": 64.0, "unit": "kWh", "source": "modbus"}}
-    )
+    coordinator = _modbus_only_coordinator(hass)
     previous = {
         "start": 4999,
         "raw": {"5002": 640},
@@ -986,8 +937,11 @@ async def test_apply_modbus_keeps_previous_diagnostic_on_capture_failure(hass: H
     coordinator.config_entry.options = {CONF_MODBUS_DEBUG_DAILY_YIELD: True}
     from custom_components.sungrow.modbus import SungrowModbusError
 
+    coordinator._modbus_client.async_read_realtime = AsyncMock(
+        return_value={"daily_yield": {"code": "daily_yield", "value": 64.0, "unit": "kWh", "source": "modbus"}}
+    )
     coordinator._modbus_client.async_read_daily_yield_diagnostic = AsyncMock(side_effect=SungrowModbusError("boom"))
-    await coordinator._async_apply_modbus({})
+    await coordinator._async_modbus_only_update()
     assert coordinator.daily_yield_diagnostic is previous
 
 

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -186,6 +186,75 @@ async def test_setup_modbus_only_entry(hass: HomeAssistant):
     assert entry.state is ConfigEntryState.NOT_LOADED
 
 
+async def test_setup_modbus_only_nests_under_cloud_plant(hass: HomeAssistant):
+    """Local inverter via_plant_id points at the matching cloud plant (soft link)."""
+    from homeassistant.helpers import device_registry as dr
+
+    from custom_components.sungrow import find_related_cloud_plant_id
+
+    cloud = MockConfigEntry(domain=DOMAIN, data=MOCK_CONFIG_DATA.copy(), unique_id="cloud_app")
+    cloud.add_to_hass(hass)
+    registry = dr.async_get(hass)
+    registry.async_get_or_create(
+        config_entry_id=cloud.entry_id,
+        identifiers={(DOMAIN, "plant-99")},
+        name="Plant",
+        entry_type=dr.DeviceEntryType.SERVICE,
+        manufacturer="Sungrow",
+    )
+    registry.async_get_or_create(
+        config_entry_id=cloud.entry_id,
+        identifiers={(DOMAIN, "inv-cloud")},
+        name="Inverter",
+        serial_number="SNLINK",
+        manufacturer="Sungrow",
+        via_device=(DOMAIN, "plant-99"),
+    )
+    assert find_related_cloud_plant_id(hass, "SNLINK") == "plant-99"
+
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={
+            CONF_TRANSPORT: TRANSPORT_MODBUS_ONLY,
+            CONF_SERIAL: "SNLINK",
+            CONF_MODEL: "SG3.6RS",
+            CONF_MODBUS_HOST: "10.0.0.9",
+        },
+        options={CONF_SCAN_INTERVAL: 30},
+        unique_id="modbus_SNLINK",
+    )
+    entry.add_to_hass(hass)
+    client = MagicMock()
+    client.async_read_realtime = AsyncMock(
+        return_value={"grid_frequency": {"code": "grid_frequency", "value": 50.0, "unit": "Hz", "source": "modbus"}}
+    )
+    with patch("custom_components.sungrow.modbus.SungrowModbusClient", return_value=client):
+        assert await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+
+    assert entry.runtime_data.coordinators[0].via_plant_id == "plant-99"
+
+
+async def test_cloud_setup_strips_legacy_hybrid_modbus_host(hass: HomeAssistant, mock_setup_auth, mock_plants_service):
+    """Loading a cloud entry with leftover modbus_host removes it (no hybrid mashup)."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data=MOCK_CONFIG_DATA.copy(),
+        options={CONF_MODBUS_HOST: "192.168.1.93", CONF_SCAN_INTERVAL: 60},
+        unique_id="test_app_id",
+        version=2,
+    )
+    entry.add_to_hass(hass)
+
+    assert await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert CONF_MODBUS_HOST not in entry.options
+    assert entry.options.get(CONF_SCAN_INTERVAL) == 60
+    # Coordinator is pure cloud (no Modbus client).
+    assert entry.runtime_data.coordinators[0]._modbus_client is None
+
+
 # ---------------------------------------------------------------------------
 # Heartbeat lifecycle
 # ---------------------------------------------------------------------------

--- a/tests/test_modbus.py
+++ b/tests/test_modbus.py
@@ -4,7 +4,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
-from custom_components.sungrow.modbus import SungrowModbusClient, SungrowModbusError, merge_realtime
+from custom_components.sungrow.modbus import SungrowModbusClient, SungrowModbusError
 from custom_components.sungrow.modbus_registers import (
     DAILY_YIELD_DIAG_CANDIDATE_ADDRESSES,
     DAILY_YIELD_DIAG_COUNT,
@@ -162,35 +162,6 @@ async def test_read_passes_configured_unit_as_device_id():
     with patch("custom_components.sungrow.modbus.AsyncModbusTcpClient", cls):
         await SungrowModbusClient("10.0.0.1", unit=3).async_read_realtime()
     assert inner.read_input_registers.await_args.kwargs["device_id"] == 3
-
-
-# ---------------------------------------------------------------------------
-# merge_realtime (cloud + modbus, Modbus preferred, provenance)
-# ---------------------------------------------------------------------------
-
-
-def test_merge_prefers_modbus_and_tags_provenance():
-    """Shared codes take the Modbus value/unit; every point carries its source."""
-    cloud = {
-        "total_active_power": {"code": "total_active_power", "value": "250", "unit": "W", "id": "5031", "name": "AC"},
-        "daily_yield": {"code": "daily_yield", "value": "38.0", "unit": "kWh"},
-    }
-    modbus = {"total_active_power": {"code": "total_active_power", "value": 256, "unit": "W", "source": "modbus"}}
-    merged = merge_realtime(cloud, modbus)
-    # Modbus value wins for the shared code, and cloud metadata (id/name) is kept.
-    assert merged["total_active_power"]["value"] == 256
-    assert merged["total_active_power"]["source"] == "modbus"
-    assert merged["total_active_power"]["id"] == "5031"
-    # Cloud-only point is retained and tagged cloud.
-    assert merged["daily_yield"]["value"] == "38.0"
-    assert merged["daily_yield"]["source"] == "cloud"
-
-
-def test_merge_adds_modbus_only_points():
-    """A point only Modbus exposes is added to the merged result."""
-    merged = merge_realtime({}, {"grid_frequency": {"code": "grid_frequency", "value": 49.9, "source": "modbus"}})
-    assert merged["grid_frequency"]["value"] == 49.9
-    assert merged["grid_frequency"]["source"] == "modbus"
 
 
 def test_daily_yield_diagnostic_dump_lists_every_candidate_address_and_scale():

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -722,6 +722,8 @@ async def test_device_sensors_created_when_enabled(hass: HomeAssistant):
 
     coordinator = _coordinator_with("12345", "Plant A", {"total_active_power": {"value": "5.0", "unit": "kW"}})
     coordinator.enable_device_sensors = True
+    coordinator.via_plant_id = None
+    coordinator.local_configuration_url = None
     # The platform reads the live device list from the coordinator for naming.
     coordinator.devices = [
         {


### PR DESCRIPTION
## Summary

Replaces hybrid merge (`modbus_host` on cloud + `merge_realtime`) with **two independent config entries** and a soft device link.

- **Cloud entry:** iSolarCloud only (no Modbus client, no merge).
- **Local entry:** Modbus-only as before (zeroconf / import).
- **Soft link:** when serial matches a cloud inverter, local device nests under that plant (`via_device`) without sharing entity state.
- **Migration:** leftover hybrid `modbus_host` on cloud is stripped; a local entry is auto-created when serials are in the device registry.
- **Docs / strings:** hybrid attach/merge UX removed; local-modbus + config docs updated.
- Design note: `docs/superpowers/specs/2026-07-13-separate-cloud-local-design.md`.

## Test plan

- [x] Unit tests for coordinator (no cloud Modbus client), config flow (no attach/merge), import, nest link, hybrid strip
- [ ] On dell-serve: reload with pure cloud + rediscover local (or let migration split if hybrid host still present)
- [ ] Confirm separate entities (cloud daily vs local derived daily)
- [ ] Confirm local inverter appears under cloud plant when serial matches
- [ ] Confirm cloud options no longer show Modbus host