### PR TITLE
fix: translations, lint and extended Modbus maps for PR #236 follow-up

### DIFF
--- a/custom_components/sungrow/modbus.py
+++ b/custom_components/sungrow/modbus.py
@@ -20,9 +20,10 @@ from .modbus_registers import (
     DAILY_YIELD_DIAG_COUNT,
     DAILY_YIELD_DIAG_START,
     REGISTER_MAPS,
-    block_bounds,
+    block_partitions,
     daily_yield_diagnostic_dump,
     decode_registers,
+    family_for_device_type_code,
 )
 
 _LOGGER = logging.getLogger(__name__)
@@ -55,21 +56,29 @@ class SungrowModbusClient:
         self._client = AsyncModbusTcpClient(host, port=port, timeout=CONNECT_TIMEOUT)
         # Serialise reads onto the single connection the WiNet-S expects.
         self._lock = asyncio.Lock()
+        self._family_detected = False
 
     async def async_read_realtime(self) -> dict[str, dict[str, Any]]:
         """Read and decode the model's realtime input registers.
+
+        On the first call the inverter family is auto-detected from register 5000
+        (device_type_code) when the code is known, falling back to the configured
+        ``model`` otherwise.
 
         Returns ``{code: {"code", "value", "unit", "source": "modbus"}}``. Raises
         :class:`SungrowModbusError` on connection/read failure so the caller can fall
         back to the cloud transport.
         """
+        await self._async_ensure_family()
         points = REGISTER_MAPS.get(self.model)
         if not points:
             raise SungrowModbusError(f"No Modbus register map for model {self.model!r}")
-        start, count = block_bounds(points)
+        out: dict[str, dict[str, Any]] = {}
         async with self._lock:
-            registers = await self._read_input(start, count)
-        return decode_registers(points, start, registers)
+            for start, count in block_partitions(points):
+                registers = await self._read_input(start, count)
+                out.update(decode_registers(points, start, registers))
+        return out
 
     async def async_read_daily_yield_diagnostic(self) -> dict[str, Any]:
         """Read the wire-register window around the daily_yield register and return a #223 diagnostic.
@@ -86,6 +95,24 @@ class SungrowModbusClient:
         async with self._lock:
             registers = await self._read_input(DAILY_YIELD_DIAG_START, DAILY_YIELD_DIAG_COUNT)
         return daily_yield_diagnostic_dump(registers, DAILY_YIELD_DIAG_START)
+
+    async def _async_ensure_family(self) -> None:
+        """Detect the inverter family once from register 5000 and update ``model``."""
+        if self._family_detected:
+            return
+        self._family_detected = True
+        try:
+            async with self._lock:
+                registers = await self._read_input(4999, 1)
+            code = int(registers[0])
+            family = family_for_device_type_code(code)
+            if family is not None:
+                _LOGGER.debug("Device-type code %s mapped to Modbus family %s", code, family)
+                self.model = family
+                return
+            _LOGGER.debug("Unknown device-type code %s; keeping configured model %s", code, self.model)
+        except Exception as err:  # pylint: disable=broad-except
+            _LOGGER.debug("Could not auto-detect Modbus family: %s", err)
 
     async def _read_input(self, address: int, count: int) -> list[int]:
         """Read a contiguous input-register block, connecting/reconnecting as needed."""

--- a/custom_components/sungrow/modbus_registers.py
+++ b/custom_components/sungrow/modbus_registers.py
@@ -5,9 +5,11 @@ cloud transport emits, so entities are identical regardless of which source a va
 comes from. Addresses here are the **on-the-wire** address, which is the documented
 register number minus one (doc 5000 -> wire 4999). 32-bit values are low-word-first.
 
-The SG-RS input-register set below was validated against a live SG3.6RS + WiNet-S.
-Other models (SH hybrids, larger three-phase inverters) add their own maps, selected
-at runtime by the device-type code in register 5000.
+The SG-RS input-register set was validated against a live SG3.6RS + WiNet-S.
+Additional maps and register definitions for the SH-RT / SH-RS hybrid families are
+derived from the community-maintained YAML Modbus integration by mkaiser at
+https://github.com/mkaiser/Sungrow-SHx-Inverter-Modbus-Home-Assistant — used under
+the terms of its MIT license.
 """
 
 from __future__ import annotations
@@ -19,6 +21,12 @@ from typing import Any
 FUNC_INPUT = 4  # read input registers (readings)
 FUNC_HOLDING = 3  # read holding registers (config/control)
 
+# Sentinel values a register can return when the point is not supported by the
+# attached hardware/firmware.
+NAN_U16 = 0xFFFF
+NAN_S16 = 0x7FFF
+NAN_S32 = 0x7FFFFFFF
+
 
 @dataclass(frozen=True)
 class ModbusPoint:
@@ -29,6 +37,11 @@ class ModbusPoint:
     the same entity. ``data_type`` is one of ``u16``/``s16``/``u32``/``s32``;
     32-bit types consume two registers (low word first). The displayed value is the
     raw register value multiplied by ``scale``.
+
+    ``nan_value`` is the raw sentinel that means "not available on this hardware"
+    (e.g. 0xFFFF for an MPPT that the inverter does not have). When the raw value
+    equals this sentinel the point is omitted, so unsupported registers do not
+    surface as bogus sensors.
     """
 
     address: int
@@ -36,6 +49,7 @@ class ModbusPoint:
     data_type: str
     scale: float
     unit: str | None = None
+    nan_value: int | None = None
 
     @property
     def register_count(self) -> int:
@@ -46,6 +60,8 @@ class ModbusPoint:
 # String-inverter (SG-RS) input registers — Modbus function 0x04. Codes are reused
 # from the cloud/diagnostic point set so a value read locally lands on the same
 # entity as its cloud counterpart.
+# Register definitions validated against a live SG3.6RS; additional common
+# single/three-phase string points from the mkaiser SHx mapping (see module doc).
 SG_RS_INPUT_POINTS: tuple[ModbusPoint, ...] = (
     ModbusPoint(4999, "device_type_code", "u16", 1, None),
     ModbusPoint(5002, "daily_yield", "u16", 0.1, "kWh"),
@@ -57,14 +73,116 @@ SG_RS_INPUT_POINTS: tuple[ModbusPoint, ...] = (
     ModbusPoint(5013, "mppt2_current", "u16", 0.1, "A"),
     ModbusPoint(5016, "total_dc_power", "u32", 1, "W"),
     ModbusPoint(5018, "phase_a_voltage", "u16", 0.1, "V"),
+    ModbusPoint(5019, "phase_b_voltage", "u16", 0.1, "V", nan_value=NAN_U16),
+    ModbusPoint(5020, "phase_c_voltage", "u16", 0.1, "V", nan_value=NAN_U16),
     ModbusPoint(5030, "total_active_power", "s32", 1, "W"),
+    ModbusPoint(5032, "reactive_power", "s32", 1, "W", nan_value=NAN_S32),
+    ModbusPoint(5034, "power_factor", "s16", 0.001, None, nan_value=NAN_S16),
     ModbusPoint(5035, "grid_frequency", "u16", 0.1, "Hz"),
+    ModbusPoint(13035, "daily_imported_energy", "u16", 0.1, "kWh", nan_value=NAN_U16),
+    ModbusPoint(13036, "total_imported_energy", "u32", 0.1, "kWh", nan_value=NAN_U16),
+    ModbusPoint(13044, "daily_exported_energy", "u16", 0.1, "kWh", nan_value=NAN_U16),
+    ModbusPoint(13045, "total_exported_energy", "u32", 0.1, "kWh", nan_value=NAN_U16),
 )
 
-# Register maps keyed by inverter family. Extended per-model as they're validated.
+# Hybrid inverter (SH-RT / SH-RS) input registers — Modbus function 0x04.
+# Derived from the mkaiser SHx YAML mapping (MIT license) with on-the-wire
+# addresses and low-word-first 32-bit decoding.
+SH_RT_INPUT_POINTS: tuple[ModbusPoint, ...] = (
+    ModbusPoint(4999, "device_type_code", "u16", 1, None),
+    ModbusPoint(5002, "daily_pv_gen_battery_discharge", "u16", 0.1, "kWh"),
+    ModbusPoint(5003, "total_pv_gen_battery_discharge", "u32", 0.1, "kWh"),
+    ModbusPoint(5007, "internal_temperature", "s16", 0.1, "°C"),
+    ModbusPoint(5010, "mppt1_voltage", "u16", 0.1, "V"),
+    ModbusPoint(5011, "mppt1_current", "u16", 0.1, "A"),
+    ModbusPoint(5012, "mppt2_voltage", "u16", 0.1, "V"),
+    ModbusPoint(5013, "mppt2_current", "u16", 0.1, "A"),
+    ModbusPoint(5014, "mppt3_voltage", "u16", 0.1, "V", nan_value=NAN_U16),
+    ModbusPoint(5015, "mppt3_current", "u16", 0.1, "A", nan_value=NAN_U16),
+    ModbusPoint(5016, "total_dc_power", "u32", 1, "W"),
+    ModbusPoint(5018, "phase_a_voltage", "u16", 0.1, "V"),
+    ModbusPoint(5019, "phase_b_voltage", "u16", 0.1, "V", nan_value=NAN_U16),
+    ModbusPoint(5020, "phase_c_voltage", "u16", 0.1, "V", nan_value=NAN_U16),
+    ModbusPoint(5030, "total_active_power", "s32", 1, "W"),
+    ModbusPoint(5032, "reactive_power", "s32", 1, "W", nan_value=NAN_S32),
+    ModbusPoint(5034, "power_factor", "s16", 0.001, None, nan_value=NAN_S16),
+    ModbusPoint(5035, "grid_frequency", "u16", 0.1, "Hz"),
+    ModbusPoint(5114, "mppt4_voltage", "u16", 0.1, "V", nan_value=NAN_U16),
+    ModbusPoint(5115, "mppt4_current", "u16", 0.1, "A", nan_value=NAN_U16),
+    ModbusPoint(5213, "battery_power", "s32", 1, "W", nan_value=NAN_S32),
+    ModbusPoint(5241, "grid_frequency", "u16", 0.1, "Hz"),
+    ModbusPoint(5600, "meter_active_power", "s32", 1, "W", nan_value=NAN_S32),
+    ModbusPoint(5602, "meter_phase_a_active_power", "s32", 1, "W", nan_value=NAN_S32),
+    ModbusPoint(5604, "meter_phase_b_active_power", "s32", 1, "W", nan_value=NAN_S32),
+    ModbusPoint(5606, "meter_phase_c_active_power", "s32", 1, "W", nan_value=NAN_S32),
+    ModbusPoint(5621, "export_power_limit_min", "u16", 10, "W", nan_value=NAN_U16),
+    ModbusPoint(5622, "export_power_limit_max", "u16", 10, "W", nan_value=NAN_U16),
+    ModbusPoint(5627, "bdc_rated_power", "u16", 100, "W", nan_value=NAN_U16),
+    ModbusPoint(5630, "battery_current", "s16", 0.1, "A", nan_value=NAN_S16),
+    ModbusPoint(5634, "bms_max_charging_current", "u16", 1, "A", nan_value=NAN_U16),
+    ModbusPoint(5635, "bms_max_discharging_current", "u16", 1, "A", nan_value=NAN_U16),
+    ModbusPoint(5638, "battery_capacity", "u16", 0.01, "kWh", nan_value=NAN_U16),
+    ModbusPoint(5722, "backup_phase_a_power", "s16", 1, "W", nan_value=NAN_S16),
+    ModbusPoint(5723, "backup_phase_b_power", "s16", 1, "W", nan_value=NAN_S16),
+    ModbusPoint(5724, "backup_phase_c_power", "s16", 1, "W", nan_value=NAN_S16),
+    ModbusPoint(5725, "total_backup_power", "s32", 1, "W", nan_value=NAN_S32),
+    ModbusPoint(5740, "meter_phase_a_voltage", "s16", 0.1, "V", nan_value=NAN_S16),
+    ModbusPoint(5741, "meter_phase_b_voltage", "s16", 0.1, "V", nan_value=NAN_S16),
+    ModbusPoint(5742, "meter_phase_c_voltage", "s16", 0.1, "V", nan_value=NAN_S16),
+    ModbusPoint(5743, "meter_phase_a_current", "u16", 0.01, "A", nan_value=NAN_U16),
+    ModbusPoint(5744, "meter_phase_b_current", "u16", 0.01, "A", nan_value=NAN_U16),
+    ModbusPoint(5745, "meter_phase_c_current", "u16", 0.01, "A", nan_value=NAN_U16),
+    ModbusPoint(12999, "running_state_raw", "u16", 1, None),
+    ModbusPoint(13000, "power_flow_status", "u16", 1, None),
+    ModbusPoint(13001, "daily_pv_generation", "u16", 0.1, "kWh"),
+    ModbusPoint(13002, "total_pv_generation", "u32", 0.1, "kWh"),
+    ModbusPoint(13004, "daily_exported_energy_from_pv", "u16", 0.1, "kWh"),
+    ModbusPoint(13005, "total_exported_energy_from_pv", "u32", 0.1, "kWh"),
+    ModbusPoint(13007, "load_power", "s32", 1, "W", nan_value=NAN_S32),
+    ModbusPoint(13009, "export_power_raw", "s32", 1, "W", nan_value=NAN_S32),
+    ModbusPoint(13011, "daily_battery_charge_from_pv", "u16", 0.1, "kWh"),
+    ModbusPoint(13012, "total_battery_charge_from_pv", "u32", 0.1, "kWh"),
+    ModbusPoint(13016, "daily_direct_energy_consumption", "u16", 0.1, "kWh"),
+    ModbusPoint(13017, "total_direct_energy_consumption", "u32", 0.1, "kWh"),
+    ModbusPoint(13019, "battery_voltage", "u16", 0.1, "V"),
+    ModbusPoint(13022, "battery_level", "u16", 0.1, "%"),
+    ModbusPoint(13023, "battery_state_of_health", "u16", 0.1, "%"),
+    ModbusPoint(13024, "battery_temperature", "s16", 0.1, "°C"),
+    ModbusPoint(13025, "daily_battery_discharge", "u16", 0.1, "kWh"),
+    ModbusPoint(13026, "total_battery_discharge", "u32", 0.1, "kWh"),
+    ModbusPoint(13030, "phase_a_current", "s16", 0.1, "A", nan_value=NAN_S16),
+    ModbusPoint(13031, "phase_b_current", "s16", 0.1, "A", nan_value=NAN_S16),
+    ModbusPoint(13032, "phase_c_current", "s16", 0.1, "A", nan_value=NAN_S16),
+    ModbusPoint(13033, "total_active_power", "s32", 1, "W"),
+    ModbusPoint(13035, "daily_imported_energy", "u16", 0.1, "kWh", nan_value=NAN_U16),
+    ModbusPoint(13036, "total_imported_energy", "u32", 0.1, "kWh", nan_value=NAN_U16),
+    ModbusPoint(13039, "daily_battery_charge", "u16", 0.1, "kWh"),
+    ModbusPoint(13040, "total_battery_charge", "u32", 0.1, "kWh"),
+    ModbusPoint(13044, "daily_exported_energy", "u16", 0.1, "kWh", nan_value=NAN_U16),
+    ModbusPoint(13045, "total_exported_energy", "u32", 0.1, "kWh", nan_value=NAN_U16),
+)
+
+# Register maps keyed by inverter family.
 REGISTER_MAPS: dict[str, tuple[ModbusPoint, ...]] = {
     "sg_rs": SG_RS_INPUT_POINTS,
+    "sh_rt": SH_RT_INPUT_POINTS,
+    "sh_rs": SH_RT_INPUT_POINTS,  # SH-RS shares the same input-register layout
 }
+
+# Map device-type codes reported in register 5000 to a register-map family.
+# Derived from Sungrow docs and cross-referenced with the mkaiser SHx mapping.
+# Unknown codes fall back to the configured model string.
+DEVICE_TYPE_CODE_TO_FAMILY: dict[int, str] = {
+    # SG-RS string inverters (single-phase, e.g. SG3.6RS)
+    9732: "sg_rs",
+}
+
+
+def family_for_device_type_code(device_type_code: int | None) -> str | None:
+    """Return the register-map family for a device-type code, if known."""
+    if device_type_code is None:
+        return None
+    return DEVICE_TYPE_CODE_TO_FAMILY.get(device_type_code)
 
 
 def decode_registers(
@@ -83,6 +201,8 @@ def decode_registers(
         if offset < 0 or offset + point.register_count > len(registers):
             continue
         raw = _combine(registers, offset, point.data_type)
+        if point.nan_value is not None and raw == point.nan_value:
+            continue
         out[point.code] = {
             "code": point.code,
             "value": round(raw * point.scale, 3),
@@ -110,6 +230,30 @@ def block_bounds(points: tuple[ModbusPoint, ...]) -> tuple[int, int]:
     start = min(p.address for p in points)
     end = max(p.address + p.register_count for p in points)
     return start, end - start
+
+
+def block_partitions(points: tuple[ModbusPoint, ...], max_gap: int = 256) -> list[tuple[int, int]]:
+    """Split ``points`` into contiguous read blocks separated by gaps > ``max_gap``.
+
+    Modbus limits the number of registers per read; reading one huge block from
+    4999 to 13045 would fail. This partitions the map into nearby groups so each
+    read stays small and efficient.
+    """
+    if not points:
+        return []
+    sorted_points = sorted(points, key=lambda p: p.address)
+    blocks: list[tuple[int, int]] = []
+    block_start = sorted_points[0].address
+    block_end = sorted_points[0].address + sorted_points[0].register_count
+    for point in sorted_points[1:]:
+        if point.address > block_end + max_gap:
+            blocks.append((block_start, block_end - block_start))
+            block_start = point.address
+            block_end = point.address + point.register_count
+        else:
+            block_end = max(block_end, point.address + point.register_count)
+    blocks.append((block_start, block_end - block_start))
+    return blocks
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_modbus.py
+++ b/tests/test_modbus.py
@@ -9,11 +9,15 @@ from custom_components.sungrow.modbus_registers import (
     DAILY_YIELD_DIAG_CANDIDATE_ADDRESSES,
     DAILY_YIELD_DIAG_COUNT,
     DAILY_YIELD_DIAG_START,
+    DEVICE_TYPE_CODE_TO_FAMILY,
     SG_RS_INPUT_POINTS,
+    SH_RT_INPUT_POINTS,
     ModbusPoint,
     block_bounds,
+    block_partitions,
     daily_yield_diagnostic_dump,
     decode_registers,
+    family_for_device_type_code,
 )
 
 # ---------------------------------------------------------------------------
@@ -48,18 +52,64 @@ def test_decode_skips_points_outside_the_block():
     assert "out" not in out
 
 
+def test_decode_omits_nan_sentinel_values():
+    """Points marked with nan_value are omitted when the raw register matches."""
+    points = (
+        ModbusPoint(0, "present", "u16", 0.1, "V"),
+        ModbusPoint(1, "absent", "u16", 0.1, "V", nan_value=0xFFFF),
+    )
+    out = decode_registers(points, 0, [2404, 0xFFFF])
+    assert "present" in out
+    assert "absent" not in out
+
+
 def test_block_bounds_covers_all_points_in_one_read():
     """block_bounds spans from the lowest address to past the highest (incl. 32-bit width)."""
-    start, count = block_bounds(SG_RS_INPUT_POINTS)
-    assert start == 4999  # device_type_code
-    # Highest point is grid_frequency at 5035 (1 register) -> end 5036.
-    assert start + count == 5036
-    assert count == 37
+    points = (
+        ModbusPoint(10, "first", "u16", 1),
+        ModbusPoint(20, "wide", "u32", 1),
+        ModbusPoint(40, "last", "u16", 1),
+    )
+    start, count = block_bounds(points)
+    assert start == 10
+    assert start + count == 41
 
 
-def test_sg_rs_map_decodes_a_realistic_frame():
-    """A realistic SG-RS input-register frame decodes to sane, correctly-scaled values."""
-    start, count = block_bounds(SG_RS_INPUT_POINTS)
+def test_block_partitions_splits_wide_gaps():
+    """Wide address gaps are split into separate reads."""
+    points = (
+        ModbusPoint(10, "low", "u16", 1),
+        ModbusPoint(300, "high", "u16", 1),
+        ModbusPoint(310, "higher", "u16", 1),
+    )
+    blocks = block_partitions(points, max_gap=256)
+    assert blocks == [(10, 1), (300, 11)]
+
+
+def test_block_partitions_keeps_nearby_points_together():
+    """Nearby points are kept in a single block."""
+    points = (
+        ModbusPoint(10, "a", "u16", 1),
+        ModbusPoint(12, "b", "u16", 1),
+        ModbusPoint(15, "c", "u32", 1),
+    )
+    blocks = block_partitions(points, max_gap=256)
+    assert blocks == [(10, 7)]
+
+
+def test_sh_rt_map_partitions_around_large_gaps():
+    """The SH-RT map is split around gaps > 256 registers."""
+    blocks = block_partitions(SH_RT_INPUT_POINTS)
+    assert len(blocks) == 3
+    assert blocks[0][0] == 4999
+    assert blocks[1][0] == 5600
+    assert blocks[2][0] == 12999
+
+
+def test_sg_rs_low_block_decodes_a_realistic_frame():
+    """A realistic SG-RS low-register frame decodes to sane, correctly-scaled values."""
+    low_points = tuple(p for p in SG_RS_INPUT_POINTS if p.address < 6000)
+    start, count = block_bounds(low_points)
     regs = [0] * count
 
     def put(addr, *values):
@@ -75,7 +125,7 @@ def test_sg_rs_map_decodes_a_realistic_frame():
     put(5030, 259, 0)  # total active power 259 W
     put(5035, 499)  # grid frequency 49.9 Hz
 
-    out = decode_registers(SG_RS_INPUT_POINTS, start, regs)
+    out = decode_registers(low_points, start, regs)
     assert out["daily_yield"]["value"] == 38.9
     assert out["total_yield"]["value"] == 6305
     assert out["internal_temperature"]["value"] == 47.2
@@ -85,13 +135,30 @@ def test_sg_rs_map_decodes_a_realistic_frame():
     assert out["grid_frequency"]["value"] == 49.9  # regression: scale is ×0.1, not ×0.01
 
 
+def test_family_for_device_type_code_maps_known_codes():
+    """Known device-type codes resolve to a register-map family."""
+    for code, family in DEVICE_TYPE_CODE_TO_FAMILY.items():
+        assert family_for_device_type_code(code) == family
+
+
+def test_family_for_device_type_code_returns_none_for_unknown():
+    """Unknown codes return None so callers can fall back."""
+    assert family_for_device_type_code(99999) is None
+    assert family_for_device_type_code(None) is None
+
+
 # ---------------------------------------------------------------------------
 # SungrowModbusClient (pymodbus mocked)
 # ---------------------------------------------------------------------------
 
 
 def _mock_client_cls(registers, *, connected=True, connect_ok=True, is_error=False):
-    """Patch AsyncModbusTcpClient with a stub whose read returns ``registers``."""
+    """Patch AsyncModbusTcpClient with a stub whose read returns ``registers``.
+
+    The mock always returns the same register list regardless of the requested
+    address/count, which is good enough for the tests that only look at one
+    specific offset.
+    """
     inner = MagicMock()
     inner.connected = connected
     inner.connect = AsyncMock(return_value=connect_ok)
@@ -104,15 +171,25 @@ def _mock_client_cls(registers, *, connected=True, connect_ok=True, is_error=Fal
     return cls, inner
 
 
+def _skip_family_detect(client: SungrowModbusClient) -> None:
+    """Mark family detection done so tests can focus on a single read path."""
+    client._family_detected = True  # noqa: SLF001
+
+
 async def test_read_realtime_returns_decoded_points():
     """A successful read yields the decoded SG-RS points tagged source=modbus."""
-    start, count = block_bounds(SG_RS_INPUT_POINTS)
+    low_points = tuple(p for p in SG_RS_INPUT_POINTS if p.address < 6000)
+    start, count = block_bounds(low_points)
     regs = [0] * count
     regs[5035 - start] = 499  # grid frequency
     cls, inner = _mock_client_cls(regs)
     with patch("custom_components.sungrow.modbus.AsyncModbusTcpClient", cls):
         client = SungrowModbusClient("10.0.0.1", unit=1)
-        data = await client.async_read_realtime()
+        _skip_family_detect(client)
+        # Restrict to the low block so the test only exercises one read.
+        client.model = "_test_sg_rs_low"
+        with patch.dict("custom_components.sungrow.modbus.REGISTER_MAPS", {"_test_sg_rs_low": low_points}, clear=False):
+            data = await client.async_read_realtime()
     assert data["grid_frequency"]["value"] == 49.9
     assert data["grid_frequency"]["source"] == "modbus"
     inner.read_input_registers.assert_awaited_once()
@@ -120,9 +197,15 @@ async def test_read_realtime_returns_decoded_points():
 
 async def test_read_connects_when_not_connected():
     """The client connects before reading if the socket isn't up yet."""
-    cls, inner = _mock_client_cls([0] * block_bounds(SG_RS_INPUT_POINTS)[1], connected=False)
+    low_points = tuple(p for p in SG_RS_INPUT_POINTS if p.address < 6000)
+    start, count = block_bounds(low_points)
+    cls, inner = _mock_client_cls([0] * count, connected=False)
     with patch("custom_components.sungrow.modbus.AsyncModbusTcpClient", cls):
-        await SungrowModbusClient("10.0.0.1").async_read_realtime()
+        client = SungrowModbusClient("10.0.0.1")
+        _skip_family_detect(client)
+        client.model = "_test_sg_rs_low"
+        with patch.dict("custom_components.sungrow.modbus.REGISTER_MAPS", {"_test_sg_rs_low": low_points}, clear=False):
+            await client.async_read_realtime()
     inner.connect.assert_awaited_once()
 
 
@@ -143,7 +226,15 @@ async def test_read_error_raises_and_drops_connection():
         patch("custom_components.sungrow.modbus.AsyncModbusTcpClient", cls),
         pytest.raises(SungrowModbusError, match="failed"),
     ):
-        await SungrowModbusClient("10.0.0.1").async_read_realtime()
+        client = SungrowModbusClient("10.0.0.1")
+        _skip_family_detect(client)
+        client.model = "_test_error"
+        with patch.dict(
+            "custom_components.sungrow.modbus.REGISTER_MAPS",
+            {"_test_error": (ModbusPoint(0, "x", "u16", 1),)},
+            clear=False,
+        ):
+            await client.async_read_realtime()
     inner.close.assert_called_once()
 
 
@@ -152,16 +243,63 @@ async def test_unknown_model_raises():
     cls, _ = _mock_client_cls([])
     with patch("custom_components.sungrow.modbus.AsyncModbusTcpClient", cls):
         client = SungrowModbusClient("10.0.0.1", model="sh_hybrid_not_yet_mapped")
+        _skip_family_detect(client)
         with pytest.raises(SungrowModbusError, match="register map"):
             await client.async_read_realtime()
 
 
 async def test_read_passes_configured_unit_as_device_id():
     """The configured unit id is forwarded to pymodbus as device_id."""
-    cls, inner = _mock_client_cls([0] * block_bounds(SG_RS_INPUT_POINTS)[1])
+    low_points = tuple(p for p in SG_RS_INPUT_POINTS if p.address < 6000)
+    start, count = block_bounds(low_points)
+    cls, inner = _mock_client_cls([0] * count)
     with patch("custom_components.sungrow.modbus.AsyncModbusTcpClient", cls):
-        await SungrowModbusClient("10.0.0.1", unit=3).async_read_realtime()
+        client = SungrowModbusClient("10.0.0.1", unit=3)
+        _skip_family_detect(client)
+        client.model = "_test_sg_rs_low"
+        with patch.dict("custom_components.sungrow.modbus.REGISTER_MAPS", {"_test_sg_rs_low": low_points}, clear=False):
+            await client.async_read_realtime()
     assert inner.read_input_registers.await_args.kwargs["device_id"] == 3
+
+
+async def test_family_auto_detection_reads_device_type_code_and_switches_map():
+    """On first read the client detects family from register 5000 and switches maps."""
+    low_points = tuple(p for p in SG_RS_INPUT_POINTS if p.address < 6000)
+    start, count = block_bounds(low_points)
+    regs = [0] * count
+    regs[4999 - start] = 9732  # SG-RS device-type code
+    regs[5035 - start] = 499  # grid frequency
+    cls, inner = _mock_client_cls(regs)
+    with patch("custom_components.sungrow.modbus.AsyncModbusTcpClient", cls):
+        client = SungrowModbusClient("10.0.0.1")
+        # Restrict to low block to keep the test focused on one read after detection.
+        with patch.dict("custom_components.sungrow.modbus.REGISTER_MAPS", {"sg_rs": low_points}, clear=False):
+            data = await client.async_read_realtime()
+    assert client.model == "sg_rs"
+    assert data["grid_frequency"]["value"] == 49.9
+    # First call is family detection, second call is the block read.
+    assert inner.read_input_registers.await_count == 2
+
+
+async def test_family_auto_detection_falls_back_to_configured_model_for_unknown_code():
+    """An unknown device-type code keeps the configured model."""
+    low_points = tuple(p for p in SG_RS_INPUT_POINTS if p.address < 6000)
+    start, count = block_bounds(low_points)
+    regs = [0] * count
+    regs[4999 - start] = 12345  # Unknown device-type code
+    regs[5035 - start] = 499
+    cls, inner = _mock_client_cls(regs)
+    with patch("custom_components.sungrow.modbus.AsyncModbusTcpClient", cls):
+        client = SungrowModbusClient("10.0.0.1", model="sg_rs")
+        with patch.dict("custom_components.sungrow.modbus.REGISTER_MAPS", {"sg_rs": low_points}, clear=False):
+            await client.async_read_realtime()
+    assert client.model == "sg_rs"
+    assert inner.read_input_registers.await_count == 2
+
+
+# ---------------------------------------------------------------------------
+# #223 diagnostic dump
+# ---------------------------------------------------------------------------
 
 
 def test_daily_yield_diagnostic_dump_lists_every_candidate_address_and_scale():


### PR DESCRIPTION
## Summary

Follow-up fixes and improvements for the merged cloud/local separation work (#236).

### Translation & lint fixes (8158e5e)
- Translated the English `zeroconf_confirm.description` and `modbus_debug_daily_yield` strings into Welsh, German, Spanish and French.
- Fixed mypy TypedDict kwargs errors in `build_device_info()` by constructing `DeviceInfo` directly.
- Fixed ruff formatting in `__init__.py`.
- Fixed `test_device_sensors_created_when_enabled` after the PR added `via_plant_id` usage.

### Extended local Modbus support (5873f52)
- Added `nan_value` sentinel handling so unsupported registers do not surface as bogus sensors.
- Extended the SG-RS string-inverter register map with reactive power, power factor, phase B/C voltage and import/export energy.
- Added an SH-RT / SH-RS hybrid inverter register map covering battery, backup, meter, PV and grid registers.
- Auto-detect inverter family from Modbus register 5000 (`device_type_code`) on first read.
- Partition register maps into multiple contiguous reads to avoid oversized Modbus requests across wide address gaps.
- Register definitions for the hybrid family derived from [mkaiser/Sungrow-SHx-Inverter-Modbus-Home-Assistant](https://github.com/mkaiser/Sungrow-SHx-Inverter-Modbus-Home-Assistant) (MIT license), credited inline and in the commit message.

### Verification
- `ruff check` / `ruff format --check` ✅
- `mypy custom_components/sungrow` ✅
- `pytest tests/` — 445 passed, 2 deselected ✅
