### PR TITLE
fix: skip unsupported Modbus blocks and remove speculative SG-RS high registers

### DIFF
--- a/custom_components/sungrow/modbus.py
+++ b/custom_components/sungrow/modbus.py
@@ -76,7 +76,18 @@ class SungrowModbusClient:
         out: dict[str, dict[str, Any]] = {}
         async with self._lock:
             for start, count in block_partitions(points):
-                registers = await self._read_input(start, count)
+                try:
+                    registers = await self._read_input(start, count)
+                except SungrowModbusError as err:
+                    # Exception code 2 = Illegal Data Address: the inverter firmware
+                    # does not implement any register in this block (e.g. high energy
+                    # registers on a string inverter). Skip the block rather than fail
+                    # the whole poll; if every block fails the caller still sees an
+                    # empty result and can retry on the next cycle.
+                    if _is_unsupported_address(err):
+                        _LOGGER.debug("Skipping unsupported Modbus block at %s (count %s): %s", start, count, err)
+                        continue
+                    raise
                 out.update(decode_registers(points, start, registers))
         return out
 
@@ -128,3 +139,9 @@ class SungrowModbusClient:
     def close(self) -> None:
         """Close the underlying connection."""
         self._client.close()
+
+
+def _is_unsupported_address(err: SungrowModbusError) -> bool:
+    """Return True when ``err`` is a Modbus 'Illegal Data Address' exception."""
+    # pymodbus renders ExceptionResponse with exception_code=2 in its repr.
+    return "exception_code=2" in str(err)

--- a/custom_components/sungrow/modbus_registers.py
+++ b/custom_components/sungrow/modbus_registers.py
@@ -79,10 +79,6 @@ SG_RS_INPUT_POINTS: tuple[ModbusPoint, ...] = (
     ModbusPoint(5032, "reactive_power", "s32", 1, "W", nan_value=NAN_S32),
     ModbusPoint(5034, "power_factor", "s16", 0.001, None, nan_value=NAN_S16),
     ModbusPoint(5035, "grid_frequency", "u16", 0.1, "Hz"),
-    ModbusPoint(13035, "daily_imported_energy", "u16", 0.1, "kWh", nan_value=NAN_U16),
-    ModbusPoint(13036, "total_imported_energy", "u32", 0.1, "kWh", nan_value=NAN_U16),
-    ModbusPoint(13044, "daily_exported_energy", "u16", 0.1, "kWh", nan_value=NAN_U16),
-    ModbusPoint(13045, "total_exported_energy", "u32", 0.1, "kWh", nan_value=NAN_U16),
 )
 
 # Hybrid inverter (SH-RT / SH-RS) input registers — Modbus function 0x04.

--- a/tests/test_modbus.py
+++ b/tests/test_modbus.py
@@ -238,6 +238,42 @@ async def test_read_error_raises_and_drops_connection():
     inner.close.assert_called_once()
 
 
+async def test_unsupported_address_block_is_skipped_but_other_blocks_return_data():
+    """An Illegal Data Address (exception_code=2) block is skipped; other blocks are decoded."""
+    test_points = (
+        ModbusPoint(0, "ok", "u16", 1),
+        # Far enough away to force a second read block.
+        ModbusPoint(300, "also_unsupported", "u16", 1),
+    )
+    cls, inner = _mock_client_cls([], is_error=True)
+
+    def side_effect(address, count, device_id):
+        result = MagicMock()
+        result.isError.return_value = True
+        if address == 0:
+            result.__str__ = lambda _s: "ExceptionResponse(dev_id=1, function_code=132, exception_code=2)"
+        else:
+            result.__str__ = lambda _s: "ExceptionResponse(dev_id=1, function_code=132, exception_code=4)"
+        return result
+
+    inner.read_input_registers = AsyncMock(side_effect=side_effect)
+    with patch("custom_components.sungrow.modbus.AsyncModbusTcpClient", cls):
+        client = SungrowModbusClient("10.0.0.1")
+        _skip_family_detect(client)
+        client.model = "_test_skip"
+        with (
+            patch.dict(
+                "custom_components.sungrow.modbus.REGISTER_MAPS",
+                {"_test_skip": test_points},
+                clear=False,
+            ),
+            pytest.raises(SungrowModbusError, match="exception_code=4"),
+        ):
+            await client.async_read_realtime()
+    # The illegal-address block was skipped; the second block raised a different error.
+    assert inner.read_input_registers.await_count == 2
+
+
 async def test_unknown_model_raises():
     """An unmapped model raises rather than silently returning nothing."""
     cls, _ = _mock_client_cls([])


### PR DESCRIPTION
## Summary

Follow-up fix for the merged Modbus extension work (#237).

### Problem
On an SG3.6RS (device-type code 9732) the inverter firmware rejects input-register reads at wire addresses 13035+ with:

```
ExceptionResponse(dev_id=1, function_code=132, exception_code=2)
```

`exception_code=2` = Illegal Data Address. The SG-RS map included speculative high registers (daily/total imported/exported energy) that do not exist on string inverters, causing the whole local Modbus poll to fail at startup.

### Fixes
- Removed registers `13035`–`13045` from the `SG_RS_INPUT_POINTS` map; they remain in the `SH_RT` / `SH_RS` hybrid map.
- Made `SungrowModbusClient.async_read_realtime()` skip any read block that returns Modbus exception code 2 (Illegal Data Address). This prevents a single unsupported register range from failing the entire poll, while other errors still propagate and retry normally.

### Verification
- `ruff check` / `ruff format --check` ✅
- `mypy custom_components/sungrow` ✅
- `pytest tests/` — 446 passed, 2 deselected ✅
