### PR TITLE
fix: nest all local Modbus sensors under the inverter and clean up stale plant device

### DIFF
--- a/custom_components/sungrow/__init__.py
+++ b/custom_components/sungrow/__init__.py
@@ -11,7 +11,7 @@ from typing import Any
 import voluptuous as vol
 from aiohttp import web
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import Platform
+from homeassistant.const import EVENT_HOMEASSISTANT_STARTED, Platform
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.exceptions import ConfigEntryAuthFailed, ConfigEntryNotReady
 from homeassistant.helpers import device_registry as dr
@@ -239,6 +239,25 @@ def find_related_cloud_plant_id(hass: HomeAssistant, serial: str) -> str | None:
     return None
 
 
+def _remove_synthetic_local_plant_device(hass: HomeAssistant, entry: SungrowConfigEntry, serial: str) -> None:
+    """Remove a stale synthetic local-plant anchor device created before a cloud plant existed.
+
+    When the local Modbus entry sets up before the cloud entry is ready, it creates a
+    synthetic plant service device keyed by the inverter serial. Once the cloud plant
+    appears and we nest under it, that synthetic device is orphaned and should be
+    removed so the UI does not show two plant-level devices for the same inverter.
+    """
+    registry = dr.async_get(hass)
+    for device in dr.async_entries_for_config_entry(registry, entry.entry_id):
+        if device.entry_type != dr.DeviceEntryType.SERVICE:
+            continue
+        for domain_key, ident in device.identifiers:
+            if domain_key == DOMAIN and str(ident) == serial:
+                registry.async_remove_device(device.id)
+                _LOGGER.debug("Removed synthetic local plant device %s for serial %s", device.id, serial)
+                return
+
+
 _HYBRID_OPTION_KEYS = frozenset(
     {
         CONF_MODBUS_HOST,
@@ -432,14 +451,25 @@ async def _async_setup_modbus_only(hass: HomeAssistant, entry: SungrowConfigEntr
     await coordinator.async_config_entry_first_refresh()
 
     entry.runtime_data = SungrowData(coordinators=[coordinator], control=None, devices={serial: [inverter]})
-    # Only create a synthetic local plant anchor when there is no cloud plant to nest under.
-    if cloud_plant_id is None:
-        dr.async_get(hass).async_get_or_create(
-            config_entry_id=entry.entry_id,
-            **build_plant_device_info(serial, f"Sungrow {model} (local)", winet_url or DEFAULT_CONSOLE_URL),
-        )
+    # Local Modbus sensors now live on the single inverter device (which is nested under
+    # a matching cloud plant when one exists). Remove any legacy synthetic local plant
+    # anchor left over from earlier builds so the UI does not show two plant devices.
+    _remove_synthetic_local_plant_device(hass, entry, serial)
     # Only the sensor platform: a Modbus-only entry has no cloud device status or dispatch.
     await hass.config_entries.async_forward_entry_setups(entry, _entry_platforms(entry))
+
+    # If no cloud plant was found at setup time, the local entry may have set up before
+    # the cloud entry. Listen once for HA startup to finish, then re-check and reload so
+    # the inverter can nest under the cloud plant device when it exists.
+    if cloud_plant_id is None:
+
+        async def _async_recheck_nesting(_: Any) -> None:
+            if find_related_cloud_plant_id(hass, serial):
+                _LOGGER.debug("Cloud plant found after startup for %s; reloading local entry", serial)
+                await hass.config_entries.async_reload(entry.entry_id)
+
+        entry.async_on_unload(hass.bus.async_listen_once(EVENT_HOMEASSISTANT_STARTED, _async_recheck_nesting))
+
     return True
 
 

--- a/custom_components/sungrow/const.py
+++ b/custom_components/sungrow/const.py
@@ -234,6 +234,11 @@ POINT_DEVICE_TYPE: dict[str, frozenset[DeviceType]] = {
     "pv_active_power_ems": _PV_TYPES,
     "total_dc_power": _PV_TYPES,
     "daily_equivalent_hours_of_inverter": _PV_TYPES,
+    "phase_a_voltage": _PV_TYPES,
+    "phase_b_voltage": _PV_TYPES,
+    "phase_c_voltage": _PV_TYPES,
+    "reactive_power": _PV_TYPES,
+    "power_factor": _PV_TYPES,
     # Battery / ESS
     "battery_level_soc": _BATTERY_TYPES,
     "battery_soc": _BATTERY_TYPES,

--- a/custom_components/sungrow/sensor.py
+++ b/custom_components/sungrow/sensor.py
@@ -10,6 +10,7 @@ from homeassistant.const import PERCENTAGE, EntityCategory
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
+from pysolarcloud.plants import DeviceType
 
 from . import build_device_info, build_plant_device_info, resolve_point_device
 from .const import (
@@ -250,6 +251,17 @@ class SungrowSensor(CoordinatorEntity, SensorEntity):
         device = resolve_point_device(point_code, getattr(coordinator, "devices", None) or [])
         via_plant_id = getattr(coordinator, "via_plant_id", None)
         local_url = getattr(coordinator, "local_configuration_url", None)
+
+        # A Modbus-only entry represents a single inverter; plant-level points that are
+        # not otherwise mapped should live on that inverter device so no orphaned local
+        # plant device is needed and nesting under a cloud plant works for every sensor.
+        if device is None and coordinator.plants_service is None:
+            inverters = [
+                d for d in (getattr(coordinator, "devices", None) or []) if d.get("device_type") == DeviceType.INVERTER
+            ]
+            if len(inverters) == 1:
+                device = inverters[0]
+
         if device is not None:
             self._attr_device_info = build_device_info(
                 device,
@@ -259,7 +271,7 @@ class SungrowSensor(CoordinatorEntity, SensorEntity):
                 configuration_url=local_url,
             )
         else:
-            self._attr_device_info = build_plant_device_info(plant_id, plant_name, console_url)
+            self._attr_device_info = build_plant_device_info(via_plant_id or plant_id, plant_name, console_url)
         self._apply_point_metadata(point_code, init_data, plant_name)
 
     def _apply_point_metadata(self, point_code: str, init_data: dict[str, Any], label: str) -> None:

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -7,7 +7,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pysolarcloud
 from aiohttp.test_utils import make_mocked_request
 from homeassistant.config_entries import ConfigEntryState
-from homeassistant.const import Platform
+from homeassistant.const import EVENT_HOMEASSISTANT_STARTED, Platform
 from homeassistant.core import HomeAssistant
 from pysolarcloud.plants import DeviceType
 from pytest_homeassistant_custom_component.common import MockConfigEntry
@@ -233,6 +233,121 @@ async def test_setup_modbus_only_nests_under_cloud_plant(hass: HomeAssistant):
         await hass.async_block_till_done()
 
     assert entry.runtime_data.coordinators[0].via_plant_id == "plant-99"
+
+    # No synthetic local plant device is created when nesting under a cloud plant.
+    registry = dr.async_get(hass)
+    assert registry.async_get_device(identifiers={(DOMAIN, "SNLINK")}) is None
+
+
+async def test_setup_modbus_only_cleans_stale_local_plant_when_cloud_present(hass: HomeAssistant):
+    """A stale synthetic local-plant device is removed once a cloud plant is found."""
+    from homeassistant.helpers import device_registry as dr
+
+    cloud = MockConfigEntry(domain=DOMAIN, data=MOCK_CONFIG_DATA.copy(), unique_id="cloud_app")
+    cloud.add_to_hass(hass)
+    registry = dr.async_get(hass)
+    registry.async_get_or_create(
+        config_entry_id=cloud.entry_id,
+        identifiers={(DOMAIN, "plant-99")},
+        name="Plant",
+        entry_type=dr.DeviceEntryType.SERVICE,
+        manufacturer="Sungrow",
+    )
+    registry.async_get_or_create(
+        config_entry_id=cloud.entry_id,
+        identifiers={(DOMAIN, "inv-cloud")},
+        name="Inverter",
+        serial_number="SNLINK",
+        manufacturer="Sungrow",
+        via_device=(DOMAIN, "plant-99"),
+    )
+
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={
+            CONF_TRANSPORT: TRANSPORT_MODBUS_ONLY,
+            CONF_SERIAL: "SNLINK",
+            CONF_MODEL: "SG3.6RS",
+            CONF_MODBUS_HOST: "10.0.0.9",
+        },
+        options={CONF_SCAN_INTERVAL: 30},
+        unique_id="modbus_SNLINK",
+    )
+    entry.add_to_hass(hass)
+
+    # Simulate a previous setup that left a synthetic local plant device behind.
+    stale_plant = registry.async_get_or_create(
+        config_entry_id=entry.entry_id,
+        identifiers={(DOMAIN, "SNLINK")},
+        name="Stale local plant",
+        entry_type=dr.DeviceEntryType.SERVICE,
+        manufacturer="Sungrow",
+    )
+
+    client = MagicMock()
+    client.async_read_realtime = AsyncMock(
+        return_value={"grid_frequency": {"code": "grid_frequency", "value": 50.0, "unit": "Hz", "source": "modbus"}}
+    )
+    with patch("custom_components.sungrow.modbus.SungrowModbusClient", return_value=client):
+        assert await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+
+    assert registry.async_get(stale_plant.id) is None
+
+
+async def test_setup_modbus_only_reloads_when_cloud_plant_appears_after_startup(hass: HomeAssistant):
+    """If no cloud plant exists at setup, a startup listener reloads when one appears."""
+    from homeassistant.helpers import device_registry as dr
+
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={
+            CONF_TRANSPORT: TRANSPORT_MODBUS_ONLY,
+            CONF_SERIAL: "SNLINK",
+            CONF_MODEL: "SG3.6RS",
+            CONF_MODBUS_HOST: "10.0.0.9",
+        },
+        options={CONF_SCAN_INTERVAL: 30},
+        unique_id="modbus_SNLINK",
+    )
+    entry.add_to_hass(hass)
+
+    client = MagicMock()
+    client.async_read_realtime = AsyncMock(
+        return_value={"grid_frequency": {"code": "grid_frequency", "value": 50.0, "unit": "Hz", "source": "modbus"}}
+    )
+    with patch("custom_components.sungrow.modbus.SungrowModbusClient", return_value=client):
+        assert await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+
+    # No cloud plant yet, so no synthetic local plant device is created.
+    registry = dr.async_get(hass)
+    assert registry.async_get_device(identifiers={(DOMAIN, "SNLINK")}) is None
+
+    # Now the cloud entry/device appears before HA finishes startup.
+    cloud = MockConfigEntry(domain=DOMAIN, data=MOCK_CONFIG_DATA.copy(), unique_id="cloud_app")
+    cloud.add_to_hass(hass)
+    registry.async_get_or_create(
+        config_entry_id=cloud.entry_id,
+        identifiers={(DOMAIN, "plant-99")},
+        name="Plant",
+        entry_type=dr.DeviceEntryType.SERVICE,
+        manufacturer="Sungrow",
+    )
+    registry.async_get_or_create(
+        config_entry_id=cloud.entry_id,
+        identifiers={(DOMAIN, "inv-cloud")},
+        name="Inverter",
+        serial_number="SNLINK",
+        manufacturer="Sungrow",
+        via_device=(DOMAIN, "plant-99"),
+    )
+
+    with patch.object(hass.config_entries, "async_reload", new=AsyncMock(return_value=True)) as mock_reload:
+        hass.bus.async_fire(EVENT_HOMEASSISTANT_STARTED)
+        await hass.async_block_till_done()
+
+    mock_reload.assert_awaited_once_with(entry.entry_id)
 
 
 async def test_cloud_setup_strips_legacy_hybrid_modbus_host(hass: HomeAssistant, mock_setup_auth, mock_plants_service):
@@ -792,6 +907,13 @@ def test_resolve_point_device_unmapped_and_hybrid():
 def test_resolve_point_device_ignores_uuidless():
     """A device without a uuid can't own a point."""
     assert resolve_point_device("inverter_ac_power", [{"device_type": DeviceType.INVERTER}]) is None
+
+
+def test_resolve_point_device_local_inverter_electrical_points():
+    """Local Modbus electrical points (phase/reactive/power factor) re-home to the inverter."""
+    inv = _dev("inv-1", DeviceType.INVERTER)
+    for code in ("phase_a_voltage", "phase_b_voltage", "phase_c_voltage", "reactive_power", "power_factor"):
+        assert resolve_point_device(code, [inv]) is inv, code
 
 
 async def test_plant_device_registered_as_anchor(hass: HomeAssistant, mock_setup_auth, mock_plants_service):

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -77,6 +77,8 @@ def _coord_with_devices(devices, data=None):
     coordinator.data = data or {}
     coordinator.devices = devices
     coordinator.plant_name = "Plant"
+    coordinator.plants_service = MagicMock()  # cloud-backed coordinator
+    coordinator.via_plant_id = None
     return coordinator
 
 
@@ -372,6 +374,8 @@ class TestSungrowSensor:
         coordinator = MagicMock()
         coordinator.data = data or {}
         coordinator.devices = []  # #158: SungrowSensor reads this to pick its device
+        coordinator.plants_service = MagicMock()  # cloud-backed coordinator
+        coordinator.via_plant_id = None
         return coordinator
 
     def test_sensor_name_from_code(self):


### PR DESCRIPTION
## Summary

Follow-up hardening for the local Modbus path after the rc14/rc15 fixes.

### Problem
After the Modbus startup fix (#238), a local-only entry still created a synthetic local plant service device. When a matching cloud entry appeared later (or set up second), the local inverter could be nested under the cloud plant, but:
1. The synthetic local plant device was left orphaned in the UI.
2. Plant-level local sensors (e.g. `grid_frequency`, `internal_temperature`, phase voltages) stayed on that synthetic local plant device instead of moving with the inverter.
3. If the local entry set up before the cloud entry at startup, the user had to manually reload the local entry to trigger re-nesting.

### Fixes
- **All local Modbus sensors now live on the single inverter device.** Since a Modbus-only entry represents exactly one inverter, plant-level sensors that have no explicit `POINT_DEVICE_TYPE` mapping are re-homed onto that inverter. This removes the need for a synthetic local plant device and makes the cloud-plant nesting apply to every local sensor.
- **Remove legacy synthetic local plant devices.** Any stale local plant service device left over from earlier builds is cleaned up on setup.
- **Auto-reload when the cloud plant appears.** If no cloud plant exists at setup time, a one-time `EVENT_HOMEASSISTANT_STARTED` listener re-checks and reloads the local entry once the cloud plant is available.
- **Map local electrical points to the inverter.** Added `phase_a_voltage`, `phase_b_voltage`, `phase_c_voltage`, `reactive_power`, and `power_factor` to `POINT_DEVICE_TYPE` so they also land on the inverter device.

### Verification
- `ruff check` / `ruff format --check` ✅
- `mypy custom_components/sungrow` ✅
- `pytest tests/` — 449 passed, 2 deselected ✅
