### PR TITLE
feat: Modbus connectivity sensor, diagnostics, and re-nest improvements

### DIFF
--- a/custom_components/sungrow/__init__.py
+++ b/custom_components/sungrow/__init__.py
@@ -17,6 +17,7 @@ from homeassistant.exceptions import ConfigEntryAuthFailed, ConfigEntryNotReady
 from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.device_registry import DeviceInfo
+from homeassistant.helpers.event import async_call_later
 from homeassistant.helpers.http import HomeAssistantView
 from pysolarcloud.control import Control
 from pysolarcloud.plants import DeviceType, Plants
@@ -43,11 +44,11 @@ from .const import (
 from .coordinator import SungrowPlantCoordinator, describe_api_error, is_auth_error
 
 PLATFORMS: list[Platform] = [Platform.BINARY_SENSOR, Platform.NUMBER, Platform.SELECT, Platform.SENSOR]
-# A cloud-free Modbus-only entry has no device status or dispatch, so it sets up only
-# the sensor platform (#159). Setup and unload MUST use the same list — unloading a
-# platform that was never set up fails the unload, which breaks the options-change
-# reload and takes every entity unavailable.
-MODBUS_ONLY_PLATFORMS: list[Platform] = [Platform.SENSOR]
+# A cloud-free Modbus-only entry has no cloud device status or dispatch, but it does
+# get a local connectivity binary sensor (#159). Setup and unload MUST use the same
+# list — unloading a platform that was never set up fails the unload, which breaks the
+# options-change reload and takes every entity unavailable.
+MODBUS_ONLY_PLATFORMS: list[Platform] = [Platform.BINARY_SENSOR, Platform.SENSOR]
 
 
 def _entry_platforms(entry: SungrowConfigEntry) -> list[Platform]:
@@ -459,8 +460,9 @@ async def _async_setup_modbus_only(hass: HomeAssistant, entry: SungrowConfigEntr
     await hass.config_entries.async_forward_entry_setups(entry, _entry_platforms(entry))
 
     # If no cloud plant was found at setup time, the local entry may have set up before
-    # the cloud entry. Listen once for HA startup to finish, then re-check and reload so
-    # the inverter can nest under the cloud plant device when it exists.
+    # the cloud entry. Re-check once HA is running and reload so the inverter can nest
+    # under the cloud plant device. If HA is already running (e.g. config flow addition),
+    # schedule the check after a short delay so any in-progress cloud setups finish first.
     if cloud_plant_id is None:
 
         async def _async_recheck_nesting(_: Any) -> None:
@@ -468,7 +470,10 @@ async def _async_setup_modbus_only(hass: HomeAssistant, entry: SungrowConfigEntr
                 _LOGGER.debug("Cloud plant found after startup for %s; reloading local entry", serial)
                 await hass.config_entries.async_reload(entry.entry_id)
 
-        entry.async_on_unload(hass.bus.async_listen_once(EVENT_HOMEASSISTANT_STARTED, _async_recheck_nesting))
+        if hass.is_running:
+            entry.async_on_unload(async_call_later(hass, 5, _async_recheck_nesting))
+        else:
+            entry.async_on_unload(hass.bus.async_listen_once(EVENT_HOMEASSISTANT_STARTED, _async_recheck_nesting))
 
     return True
 

--- a/custom_components/sungrow/binary_sensor.py
+++ b/custom_components/sungrow/binary_sensor.py
@@ -16,6 +16,7 @@ from homeassistant.const import EntityCategory
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
+from pysolarcloud.plants import DeviceType
 
 from . import build_device_info
 from .coordinator import SungrowPlantCoordinator
@@ -68,6 +69,13 @@ def connectivity_is_on(status: Any) -> bool | None:
 def _build_binary_sensors(coordinator: SungrowPlantCoordinator) -> list[BinarySensorEntity]:
     """Build the fault + connectivity binary sensors for every device the plant reports."""
     sensors: list[BinarySensorEntity] = []
+    if coordinator.plants_service is None:
+        # Modbus-only path: the local inverter's connectivity is driven by the last poll.
+        for device in coordinator.devices:
+            if device.get("device_type") == DeviceType.INVERTER and device.get("uuid"):
+                sensors.append(SungrowModbusConnectivityBinarySensor(coordinator, device))
+        return sensors
+
     for device in coordinator.devices:
         if not device.get("uuid"):
             continue
@@ -195,3 +203,42 @@ class SungrowDeviceConnectivityBinarySensor(CoordinatorEntity[SungrowPlantCoordi
         """Expose static device details (commissioning date) for the device page."""
         device = self._device() or {}
         return {"commissioning_date": device.get("grid_connection_date")}
+
+
+class SungrowModbusConnectivityBinarySensor(CoordinatorEntity[SungrowPlantCoordinator], BinarySensorEntity):
+    """Connectivity sensor for a local Modbus inverter driven by poll success."""
+
+    _attr_has_entity_name = True
+    _attr_device_class = BinarySensorDeviceClass.CONNECTIVITY
+    _attr_entity_category = EntityCategory.DIAGNOSTIC
+
+    def __init__(self, coordinator: SungrowPlantCoordinator, device: dict[str, Any]) -> None:
+        """Initialize the Modbus connectivity sensor for a local inverter."""
+        super().__init__(coordinator)
+        self.device_uuid = str(device["uuid"])
+        self._attr_unique_id = f"{coordinator.plant_id}_{self.device_uuid}_online"
+        self._attr_device_info = build_device_info(
+            device,
+            coordinator.plant_id,
+            fallback_name=coordinator.plant_name,
+            via_plant_id=getattr(coordinator, "via_plant_id", None),
+            configuration_url=getattr(coordinator, "local_configuration_url", None),
+        )
+
+    @property
+    def is_on(self) -> bool | None:
+        """True when the last Modbus poll succeeded."""
+        return self.coordinator.last_update_success
+
+    @property
+    def extra_state_attributes(self) -> dict[str, Any]:
+        """Expose Modbus diagnostics (skipped blocks, last error) for troubleshooting."""
+        diag = getattr(self.coordinator, "modbus_diagnostics", {}) or {}
+        attrs: dict[str, Any] = {}
+        if diag.get("device_family"):
+            attrs["device_family"] = diag["device_family"]
+        if diag.get("skipped_blocks"):
+            attrs["skipped_blocks"] = diag["skipped_blocks"]
+        if diag.get("last_error"):
+            attrs["last_error"] = diag["last_error"]
+        return attrs

--- a/custom_components/sungrow/coordinator.py
+++ b/custom_components/sungrow/coordinator.py
@@ -219,6 +219,9 @@ class SungrowPlantCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         # The *entity value* is no longer taken from that register — see
         # ``_async_apply_derived_daily_yield`` (SG-RS firmware never resets wire 5002).
         self.daily_yield_diagnostic: dict[str, Any] | None = None
+        # Local Modbus diagnostics surfaced in the config-entry diagnostics download:
+        # detected family, unsupported register blocks skipped, and the last error string.
+        self.modbus_diagnostics: dict[str, Any] = {}
         # Persisted baseline for deriving daily_yield from total_yield when Modbus is used.
         self._daily_yield_store: Store[dict[str, Any]] | None = (
             Store(hass, 1, f"{DOMAIN}.daily_yield_baseline_{self.plant_id}")
@@ -324,6 +327,7 @@ class SungrowPlantCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                 return self.data
             raise UpdateFailed(f"Local Modbus read failed: {err}") from err
         self._last_successful_update = self.hass.loop.time()
+        self.modbus_diagnostics = dict(self._modbus_client.modbus_diagnostics)
         await self._async_capture_daily_yield_diagnostic()
         data = normalize_energy_units(cast("dict[str, Any]", data))
         return await self._async_apply_derived_daily_yield(data)

--- a/custom_components/sungrow/diagnostics.py
+++ b/custom_components/sungrow/diagnostics.py
@@ -146,6 +146,10 @@ async def async_get_config_entry_diagnostics(hass: HomeAssistant, entry: Sungrow
         if service is not None:
             all_devices, device_realtime = await _probe_plant_devices(service, plant_id)
 
+        modbus_diag: dict[str, Any] = {}
+        if getattr(coordinator, "modbus_diagnostics", None):
+            modbus_diag = dict(coordinator.modbus_diagnostics)
+
         plant_data[plant_id] = {
             "plant_name": coordinator.plant_name,
             "last_update_success": coordinator.last_update_success,
@@ -156,6 +160,8 @@ async def async_get_config_entry_diagnostics(hass: HomeAssistant, entry: Sungrow
             "all_devices": all_devices,
             # Per-device-type realtime data (best effort; {} where unsupported).
             "device_realtime": device_realtime,
+            # Local Modbus-only diagnostic metadata (skipped blocks, last error, family).
+            "modbus_diagnostics": modbus_diag,
         }
 
     return async_redact_data(

--- a/custom_components/sungrow/modbus.py
+++ b/custom_components/sungrow/modbus.py
@@ -57,6 +57,11 @@ class SungrowModbusClient:
         # Serialise reads onto the single connection the WiNet-S expects.
         self._lock = asyncio.Lock()
         self._family_detected = False
+        self.modbus_diagnostics: dict[str, Any] = {
+            "device_family": None,
+            "skipped_blocks": [],
+            "last_error": None,
+        }
 
     async def async_read_realtime(self) -> dict[str, dict[str, Any]]:
         """Read and decode the model's realtime input registers.
@@ -69,7 +74,10 @@ class SungrowModbusClient:
         :class:`SungrowModbusError` on connection/read failure so the caller can fall
         back to the cloud transport.
         """
+        self.modbus_diagnostics["skipped_blocks"] = []
+        self.modbus_diagnostics["last_error"] = None
         await self._async_ensure_family()
+        self.modbus_diagnostics["device_family"] = self.model
         points = REGISTER_MAPS.get(self.model)
         if not points:
             raise SungrowModbusError(f"No Modbus register map for model {self.model!r}")
@@ -79,6 +87,7 @@ class SungrowModbusClient:
                 try:
                     registers = await self._read_input(start, count)
                 except SungrowModbusError as err:
+                    self.modbus_diagnostics["last_error"] = str(err)
                     # Exception code 2 = Illegal Data Address: the inverter firmware
                     # does not implement any register in this block (e.g. high energy
                     # registers on a string inverter). Skip the block rather than fail
@@ -86,6 +95,7 @@ class SungrowModbusClient:
                     # empty result and can retry on the next cycle.
                     if _is_unsupported_address(err):
                         _LOGGER.debug("Skipping unsupported Modbus block at %s (count %s): %s", start, count, err)
+                        self.modbus_diagnostics["skipped_blocks"].append({"start": start, "count": count})
                         continue
                     raise
                 out.update(decode_registers(points, start, registers))

--- a/tests/test_binary_sensor.py
+++ b/tests/test_binary_sensor.py
@@ -5,13 +5,14 @@ from unittest.mock import MagicMock
 from homeassistant.components.binary_sensor import BinarySensorDeviceClass
 from homeassistant.const import EntityCategory
 from homeassistant.core import HomeAssistant
-from pysolarcloud.plants import DeviceFaultStaus
+from pysolarcloud.plants import DeviceFaultStaus, DeviceType
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 
 from custom_components.sungrow import SungrowData
 from custom_components.sungrow.binary_sensor import (
     SungrowDeviceConnectivityBinarySensor,
     SungrowDeviceFaultBinarySensor,
+    SungrowModbusConnectivityBinarySensor,
     async_setup_entry,
     connectivity_is_on,
     fault_is_on,
@@ -169,3 +170,47 @@ def test_fault_binary_sensor_device_info_enriched():
     assert info["model"] == "SG3.6RS"
     assert info["serial_number"] == "A1"
     assert (DOMAIN, "inv-1") in info["identifiers"]
+
+
+async def test_modbus_connectivity_binary_sensor(hass: HomeAssistant):
+    """A Modbus-only entry creates a connectivity sensor driven by last_update_success."""
+    entry = MockConfigEntry(domain=DOMAIN, data=MOCK_CONFIG_DATA.copy())
+    entry.add_to_hass(hass)
+    devices = [
+        {
+            "uuid": "inv-1",
+            "device_name": "Inverter1",
+            "device_type": DeviceType.INVERTER,
+            "device_model_code": "SG3.6RS",
+            "device_sn": "A1",
+            "factory_name": "SUNGROW",
+        }
+    ]
+    coordinator = _coordinator_with(devices)
+    coordinator.plants_service = None  # Modbus-only
+    coordinator.via_plant_id = None
+    coordinator.local_configuration_url = "http://10.0.0.9"
+    coordinator.modbus_diagnostics = {
+        "device_family": "sg_rs",
+        "skipped_blocks": [{"start": 13035, "count": 12}],
+        "last_error": None,
+    }
+    data = SungrowData(coordinators=[coordinator], control=None, devices={"12345": devices})
+    entry.runtime_data = data
+
+    added: list = []
+    await async_setup_entry(hass, entry, lambda entities: added.extend(entities))
+
+    conn = next((e for e in added if isinstance(e, SungrowModbusConnectivityBinarySensor)), None)
+    assert conn is not None
+    assert conn._attr_device_class == BinarySensorDeviceClass.CONNECTIVITY
+    assert conn._attr_unique_id == "12345_inv-1_online"
+    assert conn.is_on is True  # last_update_success = True
+    attrs = conn.extra_state_attributes
+    assert attrs["device_family"] == "sg_rs"
+    assert attrs["skipped_blocks"] == [{"start": 13035, "count": 12}]
+    assert "last_error" not in attrs  # None values are not exposed
+
+    # Toggle last_update_success
+    coordinator.last_update_success = False
+    assert conn.is_on is False

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -182,7 +182,7 @@ async def test_setup_modbus_only_entry(hass: HomeAssistant):
     with patch.object(hass.config_entries, "async_unload_platforms", side_effect=_spy):
         assert await hass.config_entries.async_unload(entry.entry_id)
         await hass.async_block_till_done()
-    assert seen["platforms"] == [Platform.SENSOR]
+    assert seen["platforms"] == [Platform.BINARY_SENSOR, Platform.SENSOR]
     assert entry.state is ConfigEntryState.NOT_LOADED
 
 
@@ -316,7 +316,11 @@ async def test_setup_modbus_only_reloads_when_cloud_plant_appears_after_startup(
     client.async_read_realtime = AsyncMock(
         return_value={"grid_frequency": {"code": "grid_frequency", "value": 50.0, "unit": "Hz", "source": "modbus"}}
     )
-    with patch("custom_components.sungrow.modbus.SungrowModbusClient", return_value=client):
+    # Patch is_running before setup so the code takes the listener path
+    with (
+        patch("custom_components.sungrow.modbus.SungrowModbusClient", return_value=client),
+        patch.object(hass, "is_running", False),
+    ):
         assert await hass.config_entries.async_setup(entry.entry_id)
         await hass.async_block_till_done()
 


### PR DESCRIPTION
## Summary

Follow-up improvements to the local Modbus path after the rc14/rc15 fixes.

## Changes

### 1. Modbus Connectivity Binary Sensor
- Added a new  for Modbus-only entries
- Reflects the coordinator's  state (on when poll succeeds, off when it fails)
- Exposes Modbus diagnostics as attributes:
  - : Auto-detected inverter family (e.g., , )
  - : List of register blocks skipped due to unsupported addresses
  - : Last Modbus error message (if any)
- Updated  to include  platform

### 2. Enhanced Modbus Diagnostics
- Track skipped register blocks, last error, and detected device family in 
- Expose diagnostics via  for diagnostics downloads
- Include Modbus diagnostics in the config entry diagnostics output

### 3. Re-nest Listener Improvements
- Fixed re-nest listener to handle already-running HA (e.g., config flow additions)
- When HA is already running, use  with a 5-second delay to allow cloud setups to complete
- When HA is not yet running, listen for  as before
- Ensures local Modbus entries can nest under cloud plants regardless of setup order

### 4. Tests
- Added test for Modbus connectivity binary sensor creation and behavior
- Updated test for re-nest listener to mock  before setup
- All 450 tests pass

## Verification
- ✅  / 
- ✅ 
- ✅  — 450 passed, 2 deselected

## Files Changed
-  - Re-nest listener improvements
-  - Modbus connectivity sensor
-  - Diagnostics tracking
-  - Include Modbus diagnostics
-  - Track diagnostics in client
-  - Modbus connectivity sensor tests
-  - Re-nest listener test updates