### PR TITLE
feat!: transport-mode selector, backfill statistics, hybrid MPPT fix

### DIFF
--- a/.kiro/specs/backfill-historical-statistics/.config.kiro
+++ b/.kiro/specs/backfill-historical-statistics/.config.kiro
@@ -1,0 +1,1 @@
+{"specId": "9b514785-c81d-47f6-9d56-2e72b197602b", "workflowType": "requirements-first", "specType": "feature"}

--- a/.kiro/specs/backfill-historical-statistics/design.md
+++ b/.kiro/specs/backfill-historical-statistics/design.md
@@ -1,0 +1,632 @@
+# Design Document
+
+## Overview
+
+This feature adds a **Backfill** capability to the Sungrow iSolarCloud integration: on first
+setup (and on demand thereafter) it pulls minute-level historical measure-point data from
+iSolarCloud through `pysolarcloud`'s `Plants.async_get_historical_data`, aggregates it into
+whole-hour Home Assistant long-term statistics, and imports it so the History and Energy
+dashboards are populated immediately instead of filling in slowly from live polling.
+
+The core of the feature is a new module, `backfill.py`, whose `BackfillEngine` orchestrates
+exactly one Backfill run per `SungrowPlantCoordinator`. A run:
+
+1. Resolves the set of **Backfill_Points** (cumulative yield/energy points and power points)
+   for the plant, and for each resolves the target **Statistic_Id** and unit from the live
+   sensor (falling back to a `sungrow:`-prefixed external series).
+2. Splits the bounded **History_Window** into **Time_Chunks** (fitting the endpoint's per-call
+   window) and the points into **Point_Batches** of ≤ 50, then issues throttled
+   `async_get_historical_data` calls in ascending chronological order.
+3. Aggregates the returned minute rows into hourly `StatisticData`: a monotonic running `sum`
+   plus per-hour `state` for cumulative energy, and `mean`/`min`/`max` for power.
+4. Imports the statistics through the recorder helpers (`async_import_statistics` for series
+   backed by a live entity, `async_add_external_statistics` for external series), which
+   overwrite cleanly by `(statistic_id, start_hour)` and so make re-runs idempotent.
+5. Persists a completion marker (via `Store`) recording the covered window, so an automatic
+   run happens only once per plant.
+
+The engine runs as a background `asyncio.Task` tracked on `entry.runtime_data`, entirely
+separate from the coordinator's realtime poll loop, so realtime polling is never blocked or
+delayed. It reuses the existing E998/E999 rate-limit classification (`is_rate_limit_error`)
+and the `ConfigEntryAuthFailed` reauth path, and surfaces partial failures as a HA Repair.
+
+This feature is cloud-only. A Modbus-only (cloud-free) entry has no `plants_service` and never
+runs a Backfill (Requirement 1.2).
+
+### Requirements coverage map
+
+| Design section | Requirements |
+| --- | --- |
+| Lifecycle & startup (Architecture, `BackfillEngine`) | 1.1, 1.2, 1.3, 1.4, 1.5 |
+| On-demand service (`BackfillService`) | 2.1, 2.2, 2.3, 2.4, 2.5 |
+| History window resolution (`WindowResolver`) | 3.1, 3.2, 3.3, 3.4, 3.5 |
+| Chunking (`chunk_time_window`, `batch_points`) | 4.1, 4.2, 4.3, 4.4 |
+| Statistics builder (`build_hourly_statistics`) | 4.5, 6.3, 7.1, 7.2, 7.6 |
+| Rate-limit/throttle (`Throttle`, run loop) | 5.1, 5.2, 5.3, 5.4, 5.5, 5.6 |
+| Idempotent import (`import_statistics`) | 6.1, 6.2, 6.4 |
+| Series identification (`resolve_series`) | 7.3, 7.4, 7.5, 9.2 |
+| Failure handling & summary (run loop, Repairs) | 8.1, 8.2, 8.3, 8.4, 8.5, 8.6 |
+| Multi-plant orchestration (`BackfillManager`) | 9.1, 9.2, 9.3, 9.4 |
+
+## Architecture
+
+### Component overview
+
+```mermaid
+flowchart TD
+    subgraph Entry["Config entry (cloud)"]
+        Setup["async_setup_entry\n(__init__.py)"]
+        RT["runtime_data: SungrowData\n(+ backfill: BackfillManager)"]
+    end
+    Setup -->|after first refresh| Mgr
+    subgraph Mgr["BackfillManager (per config entry)"]
+        Throttle["Throttle\n(shared across plants)"]
+        Store["Store\n(sungrow.backfill_state_{entry_id})"]
+        E1["BackfillEngine\n(plant A)"]
+        E2["BackfillEngine\n(plant B)"]
+    end
+    Svc["BackfillService\n(services.yaml + admin service)"] --> Mgr
+    E1 --> Coord1["SungrowPlantCoordinator A\n(plants_service, plant_id)"]
+    E1 --> API["pysolarcloud Plants.\nasync_get_historical_data"]
+    E1 --> Builder["Statistics builder\n(build_hourly_statistics)"]
+    Builder --> Rec["Recorder statistics API\n(async_import_statistics /\nasync_add_external_statistics)"]
+    E1 -.->|reads live entity_id + unit| Reg["entity registry /\nstate machine"]
+    Coord1 -.->|independent, unaffected| Poll["realtime poll loop"]
+```
+
+- **`BackfillManager`** — one per config entry, stored on `runtime_data.backfill`. Owns the
+  shared `Throttle`, the persistence `Store`, and one `BackfillEngine` per coordinator. It
+  starts automatic runs after setup, dispatches on-demand service calls, and tracks the
+  background tasks so unload can cancel them (Requirements 1.5, 9.1, 9.4).
+- **`BackfillEngine`** — orchestrates one run for one plant: window resolution, chunking,
+  throttled API calls, aggregation, import, marker persistence, and run summary.
+- **Statistics builder** — pure functions that turn minute rows into hourly `StatisticData`.
+  No I/O, so they are the primary property-test surface.
+- **`BackfillService`** — registers the `sungrow.backfill` service and translates a call into
+  `BackfillManager` invocations.
+
+### Ownership and lifecycle
+
+The engine is owned **per config entry** through `BackfillManager`, with one `BackfillEngine`
+**per coordinator**. This mirrors the existing structure (`SungrowData.coordinators` is a list;
+heartbeats are tracked per plant on `runtime_data`).
+
+`SungrowData` gains one field:
+
+```python
+@dataclass
+class SungrowData:
+    coordinators: list[SungrowPlantCoordinator]
+    control: Control | None
+    devices: dict[str, list[dict[str, Any]]]
+    heartbeats: dict[str, tuple[asyncio.Event, asyncio.Task[None]]] = field(default_factory=dict)
+    backfill: "BackfillManager | None" = None   # None for Modbus-only entries
+```
+
+**Startup (Requirements 1.1, 1.2):** In `async_setup_entry` (cloud path only), after the plant
+"service" devices are registered and platforms are forwarded, the manager is constructed and
+`manager.async_start_automatic()` is called. It is scheduled with `entry.async_create_background_task`
+so it never delays setup completion or the first realtime poll. The Modbus-only setup path
+(`_async_setup_modbus_only`) never constructs a manager, satisfying 1.2. Automatic start is
+also gated on `EVENT_HOMEASSISTANT_STARTED` / recorder readiness so imports never race the
+recorder starting up.
+
+**Per-plant gating (Requirements 1.1, 1.4):** For each coordinator, the engine loads its
+persisted marker; if a completed marker already covers the default window, no automatic run is
+started for that plant. Otherwise one run is started covering the default window.
+
+**Cancellation on unload (Requirement 1.5):** Every run is an `asyncio.Task` tracked in
+`BackfillManager._tasks`. `async_unload_entry` calls `manager.async_shutdown()` which cancels
+outstanding tasks and awaits them. Because each recorder import is an atomic call that only
+ever *overwrites* whole hours already fully aggregated, cancelling between imports cannot
+corrupt previously imported statistics — at worst a run stops partway with earlier hours
+already durably imported, which a later run re-imports identically.
+
+### Concurrency and realtime isolation (Requirements 5.4, 5.5)
+
+The Backfill run loop is `await`-based and lives on its own task. The coordinator's poll loop
+is driven independently by `DataUpdateCoordinator`'s timer. The only shared resource is the
+iSolarCloud quota, handled by the throttle rather than by mutual exclusion, so a Backfill in
+progress never defers a due realtime poll. Within a config entry, all engines share a single
+`Throttle` so the combined call rate across concurrently-backfilling plants stays under the
+limit (Requirement 9.4).
+
+### End-to-end sequence (one plant)
+
+```mermaid
+sequenceDiagram
+    participant M as BackfillManager
+    participant E as BackfillEngine
+    participant W as WindowResolver
+    participant T as Throttle
+    participant API as pysolarcloud
+    participant B as Statistics builder
+    participant R as Recorder stats API
+    participant S as Store
+
+    M->>E: async_run(window override?)
+    E->>W: resolve(window)
+    W-->>E: [start, end] (clamped, validated)
+    E->>E: resolve_series() -> per-point Statistic_Id + unit + kind
+    loop each Time_Chunk (ascending) x each Point_Batch (<=50)
+        E->>T: await acquire()
+        T-->>E: (throttled slot)
+        E->>API: async_get_historical_data(plant, s, e, points, 5min)
+        alt Rate_Limit_Error (E998/E999)
+            API-->>E: raise
+            E->>T: back off; retry same chunk
+        else transient error
+            API-->>E: raise
+            E->>E: retry <= N; else mark chunk failed
+        else auth error
+            API-->>E: raise
+            E->>M: stop run, defer to reauth
+        else ok
+            API-->>E: minute rows
+            E->>B: build_hourly_statistics(rows, series, carry_sum)
+            B-->>E: StatisticData[] + updated carry_sum
+            E->>R: import/add statistics (overwrite by start_hour)
+        end
+    end
+    E->>S: persist marker(window, outcome)
+    E->>M: run summary (imported hours, empty ranges, failed chunks)
+```
+
+## Components and Interfaces
+
+### `BackfillManager`
+
+```python
+class BackfillManager:
+    """Owns one BackfillEngine per coordinator for a config entry, plus the shared throttle."""
+
+    def __init__(self, hass: HomeAssistant, entry: SungrowConfigEntry) -> None: ...
+
+    async def async_start_automatic(self) -> None:
+        """Start an automatic run for each coordinator lacking a completed default-window marker.
+        Requirements: 1.1, 1.4, 9.1."""
+
+    async def async_run_on_demand(
+        self, *, plant_ids: list[str] | None, start_date: datetime | None
+    ) -> None:
+        """Start on-demand runs for the addressed coordinators (all if plant_ids is None).
+        Rejects a plant already running. Requirements: 2.2, 2.3, 2.4, 9.1."""
+
+    def is_running(self, plant_id: str) -> bool:
+        """Requirement 2.4."""
+
+    async def async_shutdown(self) -> None:
+        """Cancel and await all in-flight run tasks. Requirement 1.5."""
+```
+
+Internals: `_engines: dict[str, BackfillEngine]` keyed by `plant_id`; `_tasks: dict[str, asyncio.Task]`;
+`_throttle: Throttle` shared to all engines; `_store: Store` shared for the marker record.
+Starting a run creates a task via `entry.async_create_background_task`; on task completion the
+manager logs the returned `RunSummary`, raises/clears the partial-failure Repair, and drops the
+task from `_tasks`. Per-plant runs are wrapped so one plant's failure does not stop the others
+(Requirement 9.3).
+
+### `BackfillEngine`
+
+```python
+class BackfillEngine:
+    def __init__(
+        self,
+        hass: HomeAssistant,
+        coordinator: SungrowPlantCoordinator,
+        throttle: "Throttle",
+        store: "BackfillStore",
+    ) -> None: ...
+
+    async def async_run(self, *, start_date: datetime | None = None) -> "RunSummary":
+        """Execute one full Backfill run for this plant. Requirements: 1.3, 4.*, 5.*, 6.*, 8.*."""
+
+    async def async_resolve_series(self) -> list["SeriesTarget"]:
+        """Map each Backfill_Point to its Statistic_Id, unit and kind. Requirements: 7.3–7.6, 9.2."""
+```
+
+Key responsibilities and how each maps to existing code:
+
+- **Backfill_Point selection.** Backfill imports two classes of points:
+  - *Cumulative energy* (state_class `TOTAL_INCREASING`): e.g. `total_yield` (83024),
+    `total_pv_yield`, `feed_in_energy_total`, `total_purchased_energy`, meter totals — resolved
+    by asking `resolve_classification` for `(SensorDeviceClass.ENERGY, TOTAL_INCREASING)`.
+  - *Power* (state_class `MEASUREMENT`, device class POWER): e.g. `power` (83033), `load_power`,
+    `grid_active_power` — resolved by `(SensorDeviceClass.POWER, MEASUREMENT)`.
+  The candidate point codes come from `coordinator.plants_service.measure_points`, classified via
+  the same `resolve_classification`/`_UNIT_CLASS_MAP` the sensor platform uses, so backfilled
+  series line up with the live sensors by construction.
+
+- **Series resolution (`async_resolve_series`, Requirements 7.3–7.6, 9.2).** The live sensor's
+  `unique_id` is `f"{plant_id}_{point_code}"`. The engine looks it up in the entity registry:
+  `entity_registry.async_get_entity_id("sensor", DOMAIN, f"{plant_id}_{point_code}")`.
+  - If found → **live-entity series**: `statistic_id = entity_id` (e.g. `sensor.plant_total_yield`),
+    imported with `async_import_statistics` and `StatisticMetaData(source="recorder")`. The unit
+    is taken from the live entity's current statistics/`unit_of_measurement` (the recorder's
+    metadata or the entity's `native_unit_of_measurement`) so historical and live share one
+    series with a matching unit (7.3, 7.5).
+  - If not found → **external series**: `statistic_id = f"sungrow:{plant_id}_{point_code}"`,
+    imported with `async_add_external_statistics` and `StatisticMetaData(source=DOMAIN)` (7.4).
+    Scoping by `plant_id` guarantees no cross-plant collisions (9.2).
+  - The `has_mean`/`has_sum` metadata is derived from kind: energy → `has_sum=True`,
+    `has_mean=False`; power → `has_mean=True`, `has_sum=False`, matching the live sensor's
+    `state_class` so the import is accepted by the recorder (7.1, 7.2).
+
+- **Unit conversion (Requirements 7.5, 7.6).** The historical endpoint returns Wh for energy
+  points; the live sensors normalise Wh→kWh via `energy_units.normalize_energy_point`. The engine
+  reuses that exact function on each minute row before aggregation, so the imported series unit
+  (kWh) equals the live series unit. Power values are already W. If a resolved live unit differs
+  from the source unit for any point, the same normalisation table is applied before import.
+
+### `WindowResolver` (Requirement 3)
+
+```python
+@dataclass(frozen=True)
+class HistoryWindow:
+    start: datetime  # UTC
+    end: datetime    # UTC, = now
+
+def resolve_window(
+    *, now: datetime, option_days: int | None, start_override: datetime | None
+) -> HistoryWindow:
+    """Requirements 3.1–3.5. Raises InvalidRangeError when start_override > now (3.5)."""
+```
+
+- Default length `DEFAULT_BACKFILL_DAYS = 30` (3.1); configurable via option
+  `CONF_BACKFILL_DAYS` (3.2); clamped to `MAX_BACKFILL_DAYS = 365` with a log line when exceeded
+  (3.3). Every resolved window is finite (3.4). A `start_override` after `now` raises
+  `InvalidRangeError` (3.5). `end` is always `dt_util.utcnow()`.
+
+### Chunking (Requirement 4)
+
+```python
+def chunk_time_window(window: HistoryWindow, chunk: timedelta) -> list[tuple[datetime, datetime]]:
+    """Split [start, end) into consecutive, non-overlapping sub-ranges each <= chunk,
+    returned in ascending chronological order. Requirements 4.2, 4.3, 4.4."""
+
+def batch_points(points: list[SeriesTarget], max_size: int = 50) -> list[list[SeriesTarget]]:
+    """Partition points into batches of at most max_size. Requirement 4.1."""
+```
+
+- `MAX_POINTS_PER_CALL = 50` (4.1). The endpoint's default window is 3h; the engine uses a
+  conservative `CHUNK_WINDOW = timedelta(hours=3)` with an explicit `start_time` and `end_time`
+  on every call (4.3), and requests `interval = timedelta(minutes=5)` to match iSolarCloud's ~5
+  minute cadence while keeping row counts bounded. Chunks are consumed in ascending order so a
+  cumulative point's running `sum` is built forward in time (4.4).
+
+### Statistics builder (pure functions — primary test surface)
+
+```python
+@dataclass(frozen=True)
+class SeriesTarget:
+    point_code: str
+    statistic_id: str
+    unit: str | None
+    kind: Literal["energy", "power"]
+    is_external: bool
+    metadata: StatisticMetaData
+
+def build_hourly_statistics(
+    rows: list[MinuteRow],           # minute rows for ONE series, any order
+    kind: Literal["energy", "power"],
+    *,
+    running_sum: float = 0.0,        # carried across chunks for energy (Requirement 4.5)
+) -> tuple[list[StatisticData], float]:
+    """Aggregate minute rows into hourly StatisticData aligned to hour start (UTC).
+
+    energy: per hour, state = last cumulative value in that hour; sum = running total that is
+            non-decreasing across the whole window (4.5, 7.1). Returns updated running_sum.
+    power:  per hour, mean/min/max over the hour's samples (7.2).
+    Requirements: 6.3 (whole-hour alignment), 4.5, 7.1, 7.2.
+    """
+```
+
+Hour alignment uses `dt_util` with UTC: each row's timestamp is floored to the hour
+(`start_hour = ts.replace(minute=0, second=0, microsecond=0)`, tz=UTC). For energy, the hourly
+`state` is the cumulative reading at (or last within) the hour; `sum` is the running cumulative
+delta from the window start, and the builder enforces non-decreasing `sum` by clamping any
+negative minute-to-minute delta to zero (guards meter resets / spurious dips) (4.5).
+
+### Import (Requirement 6)
+
+```python
+def import_statistics(hass: HomeAssistant, target: SeriesTarget, data: list[StatisticData]) -> None:
+    """Route to async_add_external_statistics (external) or async_import_statistics (live entity).
+    Both overwrite by (statistic_id, start_hour), giving idempotency. Requirements 6.1, 6.2, 6.4."""
+```
+
+Both recorder helpers replace any existing row with the same `(statistic_id, start)` rather than
+appending, so re-importing the same hours is a clean overwrite (6.1, 6.2), and re-importing a
+retried chunk only touches that chunk's hours (6.4).
+
+### `Throttle` (Requirements 5.1, 5.2, 5.3, 9.4)
+
+```python
+class Throttle:
+    def __init__(self, min_interval: float, hass: HomeAssistant) -> None: ...
+    async def acquire(self) -> None:
+        """Await until at least min_interval has elapsed since the previous acquire.
+        Serialises calls across all engines of the entry (shared instance). Requirements 5.1, 9.4."""
+    async def backoff(self) -> None:
+        """Sleep an escalating delay after a Rate_Limit_Error before the next attempt (5.2)."""
+    def reset_backoff(self) -> None: ...
+```
+
+Backoff escalation mirrors the coordinator's doubling scheme (`_adjust_poll_backoff`), capped at
+one hour. On resume after a rate-limit backoff, the run continues from the first not-yet-imported
+`(Time_Chunk, Point_Batch)`, tracked by an index cursor (5.3).
+
+### `BackfillService` (Requirement 2)
+
+Registers `sungrow.backfill` via `hass.services.async_register` at component `async_setup` (or
+first cloud entry setup), described by `services.yaml`:
+
+```yaml
+backfill:
+  name: Backfill historical statistics
+  description: Import historical iSolarCloud data into long-term statistics.
+  fields:
+    config_entry:
+      selector: { config_entry: { integration: sungrow } }
+    start_date:
+      selector: { date: {} }
+```
+
+The handler resolves the addressed config entries/plants, then calls
+`manager.async_run_on_demand(plant_ids=..., start_date=...)` (2.1, 2.2, 2.3). A plant already
+running is rejected and reported (2.4). Registered as an admin service.
+
+## Data Models
+
+### `MinuteRow` (parsed from `async_get_historical_data`)
+
+```python
+@dataclass(frozen=True)
+class MinuteRow:
+    timestamp: datetime  # UTC
+    value: float         # normalised to the target unit (Wh->kWh for energy)
+```
+
+Source shape per point (from `pysolarcloud`): `{"timestamp": datetime, "id": str, "code": str,
+"value": float|str, "unit": str, "name": str}`. Rows whose `value` is `None`/`""`/non-numeric are
+dropped before aggregation.
+
+### `StatisticData` and `StatisticMetaData` (HA recorder)
+
+Energy (cumulative) series:
+
+```python
+StatisticMetaData(
+    has_mean=False, has_sum=True,
+    name=None,
+    source="recorder",                       # or DOMAIN for external
+    statistic_id="sensor.<plant>_total_yield",  # or "sungrow:<plant_id>_total_yield"
+    unit_of_measurement="kWh",
+)
+StatisticData(start=<hour, UTC>, state=<cumulative reading>, sum=<running total>)
+```
+
+Power (measurement) series:
+
+```python
+StatisticMetaData(
+    has_mean=True, has_sum=False,
+    name=None, source="recorder", statistic_id="sensor.<plant>_power",
+    unit_of_measurement="W",
+)
+StatisticData(start=<hour, UTC>, mean=<avg>, min=<min>, max=<max>)
+```
+
+### Persisted marker (`Store`)
+
+`Store[dict]` at key `f"{DOMAIN}.backfill_state_{entry.entry_id}"`, version 1:
+
+```json
+{
+  "plants": {
+    "<plant_id>": {
+      "completed": true,
+      "partial": false,
+      "window_start": "2024-01-01T00:00:00+00:00",
+      "window_end": "2024-01-31T00:00:00+00:00",
+      "last_run": "2024-01-31T09:12:00+00:00",
+      "failed_chunks": 0
+    }
+  }
+}
+```
+
+`completed` + `window_*` drive the "don't auto-run again" gate (1.3, 1.4, 2.5). `partial`/`failed_chunks`
+drive the Repair and let a re-run target gaps (8.1).
+
+### New options / constants (`const.py`)
+
+```python
+CONF_BACKFILL_DAYS = "backfill_days"
+DEFAULT_BACKFILL_DAYS = 30
+MAX_BACKFILL_DAYS = 365
+BACKFILL_INTERVAL = timedelta(minutes=5)
+BACKFILL_CHUNK_WINDOW = timedelta(hours=3)
+MAX_POINTS_PER_CALL = 50
+BACKFILL_MIN_CALL_INTERVAL = 1.0     # seconds between historical calls (throttle)
+BACKFILL_MAX_RETRIES = 3             # transient-error retries per chunk (5.6)
+```
+
+## Correctness Properties
+
+*A property is a characteristic or behavior that should hold true across all valid executions of
+a system — essentially, a formal statement about what the system should do. Properties serve as
+the bridge between human-readable specifications and machine-verifiable correctness guarantees.*
+
+The Backfill logic is dominated by pure functions (window resolution, chunking, aggregation,
+unit conversion, series-id derivation), which makes property-based testing a strong fit. The
+following properties are derived from the prework analysis, consolidated to remove redundancy
+(the window-resolution criteria collapse to one property; the chunk-structure criteria to one;
+and the idempotency/hour-alignment/locality criteria to one).
+
+### Property 1: Window resolution is bounded and honors configuration
+
+*For any* `now`, optional configured day count, and optional `start_date` that is not later than
+`now`, `resolve_window` returns a finite window whose `end` equals `now`, whose length is
+`clamp(requested_length, 1 day, MAX_BACKFILL_DAYS)`, and whose `start` equals the explicit
+`start_date` when one is supplied (subject to the same clamp). When `start_date` is later than
+`now`, it raises `InvalidRangeError`.
+
+**Validates: Requirements 2.3, 3.1, 3.2, 3.3, 3.4, 3.5**
+
+### Property 2: Point batching preserves all points and never exceeds the cap
+
+*For any* list of `SeriesTarget`s and any `max_size` ≤ 50, `batch_points` produces batches that
+each contain at most `max_size` points, and whose in-order concatenation equals the original list
+(no point dropped, duplicated, or reordered).
+
+**Validates: Requirements 4.1**
+
+### Property 3: Time chunking covers the window in ascending, bounded, non-overlapping pieces
+
+*For any* `HistoryWindow` and positive chunk size, `chunk_time_window` returns chunks that are
+sorted ascending by start, are contiguous and non-overlapping, together exactly cover
+`[start, end)`, and each have a duration no greater than the chunk size.
+
+**Validates: Requirements 4.2, 4.3, 4.4**
+
+### Property 4: Cumulative energy sum is non-decreasing across the whole window
+
+*For any* sequence of minute rows for an energy series (including rows split across multiple
+chunks and aggregated with a carried `running_sum`), the hourly `sum` values produced by
+`build_hourly_statistics` are non-decreasing in chronological order.
+
+**Validates: Requirements 4.5, 7.1**
+
+### Property 5: Aggregation is deterministic and import is idempotent and hour-local
+
+*For any* set of minute rows, `build_hourly_statistics` is deterministic (equal input yields
+equal output) and produces exactly one `StatisticData` per (series, hour) with every `start`
+aligned to an exact UTC hour boundary. Consequently, importing the rows into an
+`(statistic_id, start_hour)`-keyed store — whether all at once or chunk-by-chunk, and whether run
+once or twice — yields an identical stored map, and re-importing one chunk changes only that
+chunk's hours.
+
+**Validates: Requirements 6.1, 6.2, 6.3, 6.4**
+
+### Property 6: Energy unit conversion is correct and stable
+
+*For any* numeric source value reported in Wh, normalisation yields `round(value / 1000, 3)` with
+unit `kWh`; for any value already in kWh (or a non-energy unit), the value is unchanged.
+
+**Validates: Requirements 7.5, 7.6**
+
+### Property 7: Statistic_Ids are scoped per plant and never collide
+
+*For any* two distinct `plant_id`s and any point code, the external `Statistic_Id`s derived by
+series resolution (`f"sungrow:{plant_id}_{code}"`) are distinct, so different plants' series
+cannot collide.
+
+**Validates: Requirements 9.2**
+
+## Error Handling
+
+The run loop classifies every `async_get_historical_data` failure and reacts per its class,
+reusing the coordinator's existing helpers so behaviour matches the realtime path:
+
+- **Authentication errors (`is_auth_error`, Requirement 8.5).** Stop the run immediately and
+  defer to the integration's existing reauth handling. The engine does not open its own reauth
+  flow; the coordinator's realtime poll (or setup) raises `ConfigEntryAuthFailed` as it already
+  does. The run records its partial outcome so far and exits.
+- **Rate-limit errors (`is_rate_limit_error`, E998/E999, Requirements 5.2, 5.3).** Pause the run,
+  call `Throttle.backoff` (escalating delay, capped at 1 hour), then resume from the first
+  `(Time_Chunk, Point_Batch)` not yet successfully imported using the progress cursor. The engine
+  does not touch the coordinator's Repairs; a long rate-limit is expected on the free plan.
+- **Transient errors (anything else non-auth, non-rate-limit; Requirement 5.6).** Retry the same
+  call up to `BACKFILL_MAX_RETRIES` times with a short delay. On exhaustion, mark that chunk as
+  failed, continue with the remaining chunks (Requirement 8.1), and count it in the summary.
+- **Empty ranges (Requirement 8.3).** A call that returns no rows for its range logs at debug and
+  contributes no statistics; the run continues and completes normally.
+- **Partial failure (Requirements 8.1, 8.2).** If any chunk is marked failed, the run still
+  imports every successfully retrieved chunk, records the marker as `partial=true` with a
+  `failed_chunks` count, and the manager raises a non-fixable HA Repair
+  (`ir.async_create_issue`, translation key `backfill_partial`, learn-more pointing at the
+  troubleshooting doc) describing the partial failure and how to re-run. A later fully successful
+  run clears the Repair.
+- **Cancellation (Requirement 1.5).** On unload/reload, `async_shutdown` cancels the task; the
+  loop catches `asyncio.CancelledError` between imports, leaving all already-imported hours
+  durable and re-importable identically on the next run.
+- **Logging & summary (Requirements 8.4, 8.6).** The engine logs run start (plant, window),
+  per-chunk progress, and a final outcome. It returns a `RunSummary(imported_hours,
+  skipped_empty_ranges, failed_chunks, statistic_ids)` that the manager logs and uses to decide
+  the marker and Repair state.
+
+```python
+@dataclass(frozen=True)
+class RunSummary:
+    plant_id: str
+    window: HistoryWindow
+    imported_hours: int
+    skipped_empty_ranges: int
+    failed_chunks: int
+    completed: bool          # True when no failed chunks
+```
+
+## Testing Strategy
+
+The feature separates cleanly into a **pure logic core** (property-tested) and an **I/O
+orchestration shell** (example/integration-tested with mocks), matching the prework
+classification.
+
+### Property-based tests
+
+Library: **Hypothesis** (already the ecosystem standard for pytest; add to the test deps if not
+present). Each property test runs a minimum of **100 iterations** (`@settings(max_examples=100)`)
+and is tagged with a comment referencing its design property:
+
+`# Feature: backfill-historical-statistics, Property N: <property text>`
+
+- **Property 1 — Window resolution.** Generate `now`, `option_days` (including values > MAX and
+  ≤ 0), and optional `start_date` (before and after `now`). Assert finiteness, `end == now`,
+  clamped length, honored override, and `InvalidRangeError` for future start dates. Generators
+  cover the edge cases from 3.5/8.3.
+- **Property 2 — Point batching.** Generate random point lists and `max_size ∈ [1, 50]`; assert
+  batch-size cap and order-preserving concatenation.
+- **Property 3 — Time chunking.** Generate windows and chunk sizes; assert ascending, contiguous,
+  non-overlapping, full coverage, and per-chunk duration bound.
+- **Property 4 — Non-decreasing sum.** Generate minute rows (monotonic-ish cumulative readings
+  plus noise, gaps, resets); split them across chunks and feed `running_sum` forward; assert the
+  concatenated hourly `sum` sequence is non-decreasing.
+- **Property 5 — Determinism + idempotent, hour-local import.** Generate minute rows; assert
+  `build_hourly_statistics` is deterministic, every `start` is on an exact UTC hour, hours are
+  unique; then, using a **fake recorder store** (a dict keyed by `(statistic_id, start)` that
+  overwrites on collision, mimicking `async_add_external_statistics`/`async_import_statistics`),
+  assert the stored map is identical for all-at-once vs per-chunk and for one run vs two runs.
+- **Property 6 — Unit conversion.** Generate numeric values and units; assert Wh→kWh rounding and
+  no-op for kWh/other units (reuses `energy_units.normalize_energy_point`).
+- **Property 7 — Statistic_Id scoping.** Generate distinct plant-id pairs and codes; assert
+  external ids differ.
+
+### Unit / example tests (mocked)
+
+Using `pytest` + `pytest-asyncio` with a mocked `plants_service` (an `AsyncMock` whose
+`async_get_historical_data` returns canned minute rows or raises classified errors) and mocked
+recorder helpers (`homeassistant.components.recorder.statistics.async_add_external_statistics`
+and `async_import_statistics` patched to record calls):
+
+- Automatic start gating (1.1, 1.4), Modbus-only skip (1.2), marker persistence (1.3, 2.5),
+  cancellation leaving imports intact (1.5).
+- Service registration smoke test (2.1); service dispatch to multiple plants (2.2); already-running
+  rejection (2.4).
+- Explicit call-kwargs bounding a chunk (4.3).
+- Metadata shapes and unit propagation for energy (7.1) and power (7.2); live-entity resolution
+  (7.3, 7.5) via a populated entity registry and external fallback (7.4) when absent.
+- Rate-limit backoff + resume (5.2, 5.3); throttle spacing with a mocked clock (5.1, 9.4);
+  realtime-poll-not-blocked (5.4, 5.5) by asserting the coordinator poll runs while a run task is
+  parked on the throttle; bounded transient retries then chunk-failed (5.6).
+- Partial-failure marker + Repair (8.1, 8.2); empty-range skip + log (8.3); start/progress/outcome
+  logs via `caplog` (8.4); auth-error stop/defer (8.5); `RunSummary` counts (8.6).
+- Multi-plant: run per coordinator (9.1), one plant failing without stopping others (9.3), shared
+  throttle across engines (9.4).
+
+### Notes on balance
+
+Property tests own the combinatorial input space (dates, point lists, minute-row shapes, numeric
+values). Unit tests own specific wiring, error branches, HA registry/recorder integration, and
+logging — kept to representative examples rather than exhaustive enumeration, since the pure-logic
+coverage comes from the property tests.

--- a/.kiro/specs/backfill-historical-statistics/requirements.md
+++ b/.kiro/specs/backfill-historical-statistics/requirements.md
@@ -1,0 +1,234 @@
+# Requirements Document
+
+## Introduction
+
+On initial setup, Home Assistant has no history for a Sungrow plant, so the History and
+Energy dashboards start empty and only fill in as live polling accumulates data over days.
+iSolarCloud exposes minute-level historical data through the plant-level endpoint
+`getPowerStationPointMinuteDataList`, already wrapped by
+`pysolarcloud`'s `Plants.async_get_historical_data`. This feature imports that historical
+data into Home Assistant long-term statistics for yield/energy and power measure points,
+so users see populated history and Energy-dashboard graphs immediately after setup.
+
+The import runs once automatically after setup and can be re-run or extended on demand. It
+must respect the iSolarCloud rate limit and quota, chunk requests to satisfy the endpoint's
+per-call limits, produce statistics that line up with the live sensors, and never duplicate
+or corrupt existing statistics when re-run. It must never block or degrade normal realtime
+polling.
+
+This feature covers historical import only. It is not a realtime polling change and does not
+use the local Modbus transport.
+
+## Glossary
+
+- **Integration**: The Sungrow Home Assistant custom integration (`custom_components/sungrow`).
+- **Backfill**: The process that retrieves historical measure-point data from iSolarCloud and
+  imports it into Home Assistant long-term statistics.
+- **Backfill_Engine**: The Integration component that orchestrates one Backfill run for one
+  plant, including time/point chunking, ordering, throttling, and statistics import.
+- **Plant_Coordinator**: An existing per-plant `SungrowPlantCoordinator` instance. A single
+  config entry may own multiple Plant_Coordinators.
+- **Historical_Data_API**: The `pysolarcloud` method
+  `Plants.async_get_historical_data(plant_id, start_time, end_time, *, measure_points, interval)`,
+  which wraps iSolarCloud's `getPowerStationPointMinuteDataList` endpoint.
+- **Measure_Point**: A named cloud data channel (e.g. total yield, plant power) identified by
+  a point code/id, as defined in `pysolarcloud` `Plants.measure_points`.
+- **Backfill_Point**: A Measure_Point that the Backfill imports into statistics (yield/energy
+  and power points).
+- **Statistic_Id**: The Home Assistant long-term-statistics key for one series. For a live
+  entity it is the entity's `entity_id`; for an external series it uses the `sungrow:` prefix.
+- **Long_Term_Statistics**: Home Assistant's recorder statistics store, keyed by
+  `(statistic_id, start_hour)`, holding hourly `sum`/`state` (for cumulative energy) and
+  `mean`/`min`/`max` (for measurements).
+- **Recorder_Statistics_API**: The Home Assistant recorder helpers
+  `homeassistant.components.recorder.statistics.async_add_external_statistics` (external
+  series with the `sungrow:` prefix) and `async_import_statistics` (real entity series).
+- **History_Window**: The time range, ending at the current time and extending a bounded
+  number of days into the past, that a Backfill run imports.
+- **Point_Batch**: A group of at most 50 Backfill_Points sent in a single Historical_Data_API
+  call, as required by the endpoint's per-call point limit.
+- **Time_Chunk**: A sub-range of the History_Window sized to satisfy the endpoint's per-call
+  query-window limit.
+- **Rate_Limit_Error**: An iSolarCloud quota/throttle rejection with result code E998 (monthly)
+  or E999 (hourly), as classified by the existing coordinator `RATE_LIMIT_ERRORS` set.
+- **Backfill_Service**: The Home Assistant service the user invokes to run a Backfill on demand.
+- **Repair_Issue**: A Home Assistant Repairs entry surfaced to the user for an actionable
+  failure.
+
+## Requirements
+
+### Requirement 1: Automatic Backfill on initial setup
+
+**User Story:** As a Sungrow user, I want history to be imported automatically when I first
+set up the integration, so that my History and Energy dashboards are populated without any
+manual steps.
+
+#### Acceptance Criteria
+
+1. WHEN a config entry completes its first successful setup and no prior Backfill has been
+   recorded for a Plant_Coordinator, THE Backfill_Engine SHALL start one Backfill run for
+   that Plant_Coordinator covering the default History_Window.
+2. WHERE a config entry uses the local Modbus-only transport, THE Backfill_Engine SHALL NOT
+   start a Backfill run for that config entry.
+3. WHEN a Backfill run completes, THE Backfill_Engine SHALL persist a record of the run's
+   completion and the covered History_Window for the Plant_Coordinator.
+4. WHILE a Plant_Coordinator has a persisted completed Backfill record covering the default
+   History_Window, THE Backfill_Engine SHALL NOT start an automatic Backfill run for that
+   Plant_Coordinator on subsequent setups.
+5. WHEN a config entry is reloaded while a Backfill run for one of its Plant_Coordinators is
+   in progress, THE Backfill_Engine SHALL allow the in-progress run to be cancelled without
+   corrupting previously imported statistics.
+
+### Requirement 2: On-demand Backfill
+
+**User Story:** As a Sungrow user, I want to re-run or extend the historical import on demand,
+so that I can fill gaps or import a longer range after setup.
+
+#### Acceptance Criteria
+
+1. THE Integration SHALL register a Backfill_Service that triggers a Backfill run.
+2. WHEN the Backfill_Service is invoked with a target config entry or plant, THE
+   Backfill_Engine SHALL start a Backfill run for each addressed Plant_Coordinator.
+3. WHERE the Backfill_Service is invoked with an explicit start date, THE Backfill_Engine SHALL
+   use that start date as the beginning of the History_Window instead of the default.
+4. IF the Backfill_Service is invoked for a Plant_Coordinator that already has a Backfill run
+   in progress, THEN THE Backfill_Engine SHALL reject the new invocation for that
+   Plant_Coordinator and report that a run is already in progress.
+5. WHEN an on-demand Backfill run completes, THE Backfill_Engine SHALL update the persisted
+   Backfill record for the Plant_Coordinator with the covered History_Window.
+
+### Requirement 3: Bounded, configurable History Window
+
+**User Story:** As a Sungrow user, I want control over how far back history is imported, so
+that I get useful history without unbounded API usage.
+
+#### Acceptance Criteria
+
+1. THE Backfill_Engine SHALL use a default History_Window that extends a fixed default number
+   of days into the past from the current time.
+2. WHERE the user configures a History_Window length in the integration options, THE
+   Backfill_Engine SHALL use the configured length instead of the default.
+3. IF a requested History_Window length exceeds the maximum supported length, THEN THE
+   Backfill_Engine SHALL clamp the History_Window to the maximum supported length and log the
+   clamping.
+4. THE Backfill_Engine SHALL bound every Backfill run to a finite History_Window so that a run
+   cannot request time ranges indefinitely.
+5. IF a requested start date is later than the current time, THEN THE Backfill_Engine SHALL
+   reject the run and report an invalid range.
+
+### Requirement 4: Chunking by points and by time
+
+**User Story:** As a maintainer, I want requests chunked to satisfy the endpoint's limits, so
+that Backfill calls succeed instead of being rejected.
+
+#### Acceptance Criteria
+
+1. THE Backfill_Engine SHALL divide the Backfill_Points into Point_Batches of at most 50
+   points per Historical_Data_API call.
+2. THE Backfill_Engine SHALL divide the History_Window into Time_Chunks that each fall within
+   the endpoint's maximum per-call query window.
+3. WHEN issuing a Historical_Data_API call, THE Backfill_Engine SHALL pass an explicit
+   `start_time` and `end_time` bounding one Time_Chunk.
+4. WHEN a Backfill run covers multiple Time_Chunks for a cumulative energy Backfill_Point, THE
+   Backfill_Engine SHALL process and import those Time_Chunks in ascending chronological order.
+5. THE Backfill_Engine SHALL import the cumulative energy statistics for each Backfill_Point so
+   that the imported hourly `sum` values are non-decreasing across the History_Window.
+
+### Requirement 5: Rate-limit and quota safety
+
+**User Story:** As a Sungrow user on the free plan, I want Backfill to respect the API quota,
+so that it does not exhaust my calls or break live updates.
+
+#### Acceptance Criteria
+
+1. THE Backfill_Engine SHALL throttle Historical_Data_API calls so that the configured rate
+   limit is not exceeded across a Backfill run.
+2. WHEN a Historical_Data_API call raises a Rate_Limit_Error, THE Backfill_Engine SHALL pause
+   further calls and back off before retrying.
+3. WHEN a Rate_Limit_Error back-off expires, THE Backfill_Engine SHALL resume the Backfill run
+   from the first Time_Chunk and Point_Batch not yet successfully imported.
+4. THE Backfill_Engine SHALL run without blocking or delaying the Plant_Coordinator's realtime
+   poll cycle.
+5. IF a Backfill run is in progress WHEN a realtime poll is due, THEN THE Plant_Coordinator
+   SHALL perform its realtime poll on its normal schedule.
+6. WHEN a transient (non-authentication, non-Rate_Limit) error occurs on a Historical_Data_API
+   call, THE Backfill_Engine SHALL retry that call up to a bounded number of attempts before
+   marking the affected chunk as failed.
+
+### Requirement 6: Idempotent statistics import
+
+**User Story:** As a Sungrow user, I want re-running Backfill to be safe, so that repeated
+imports never duplicate or corrupt my history.
+
+#### Acceptance Criteria
+
+1. WHEN the Backfill_Engine imports statistics for a `(Statistic_Id, start_hour)` that already
+   exists, THE Backfill_Engine SHALL overwrite the existing hourly value rather than create a
+   duplicate.
+2. WHEN a Backfill run is executed twice over the same History_Window with the same source
+   data, THE Long_Term_Statistics for each affected Statistic_Id SHALL be identical after the
+   second run as after the first run.
+3. THE Backfill_Engine SHALL aggregate minute-level source data into whole-hour statistics
+   aligned to `(Statistic_Id, start_hour)` before import.
+4. IF a Time_Chunk fails and is later retried, THEN THE Backfill_Engine SHALL re-import that
+   chunk's hours without altering statistics outside that chunk's hours.
+
+### Requirement 7: Selection and identification of backfilled series
+
+**User Story:** As a Sungrow user, I want the imported history to line up with my live
+sensors, so that the same graph shows both historical and live data continuously.
+
+#### Acceptance Criteria
+
+1. THE Backfill_Engine SHALL import statistics for cumulative yield energy Backfill_Points in
+   kilowatt-hours as `TOTAL` (cumulative) statistics.
+2. THE Backfill_Engine SHALL import statistics for power Backfill_Points as measurement
+   statistics with the power unit reported for the corresponding live sensor.
+3. WHERE a live sensor exists for a Backfill_Point, THE Backfill_Engine SHALL import the
+   statistics under a Statistic_Id that matches that live sensor's long-term-statistics
+   series so historical and live data share one series.
+4. WHERE no live sensor exists for a Backfill_Point, THE Backfill_Engine SHALL import the
+   statistics as an external series using a `sungrow:` prefixed Statistic_Id.
+5. THE Backfill_Engine SHALL set each imported series' unit to match the unit of the
+   corresponding live sensor's statistics.
+6. IF a Backfill_Point's source unit differs from the target statistics unit, THEN THE
+   Backfill_Engine SHALL convert the source values to the target unit before import.
+
+### Requirement 8: Failure handling and user feedback
+
+**User Story:** As a Sungrow user, I want to understand when Backfill partially fails or finds
+no data, so that I know whether my history is complete and what to do.
+
+#### Acceptance Criteria
+
+1. WHEN a Backfill run finishes with one or more failed Time_Chunks, THE Backfill_Engine SHALL
+   import the successfully retrieved statistics and record the run as partially completed.
+2. WHEN a Backfill run finishes with failed chunks, THE Backfill_Engine SHALL surface a
+   Repair_Issue describing the partial failure and how to re-run the Backfill.
+3. WHEN a Historical_Data_API call for a Plant_Coordinator returns no data rows for the
+   requested range, THE Backfill_Engine SHALL log that no data was available and complete the
+   run without importing statistics for the empty range.
+4. WHEN a Backfill run starts, progresses, and completes, THE Backfill_Engine SHALL log the
+   run's start, per-chunk progress, and final outcome.
+5. IF a Historical_Data_API call fails with an authentication error, THEN THE Backfill_Engine
+   SHALL stop the Backfill run and defer to the Integration's existing re-authentication
+   handling.
+6. WHEN a Backfill run ends, THE Backfill_Engine SHALL report a summary of imported hours,
+   skipped empty ranges, and failed chunks.
+
+### Requirement 9: Multi-plant support
+
+**User Story:** As a Sungrow user with more than one plant on a config entry, I want each
+plant's history imported, so that all my plants have populated graphs.
+
+#### Acceptance Criteria
+
+1. WHEN an automatic or on-demand Backfill is triggered for a config entry with multiple
+   Plant_Coordinators, THE Backfill_Engine SHALL run a Backfill for each Plant_Coordinator.
+2. THE Backfill_Engine SHALL import each Plant_Coordinator's statistics under Statistic_Ids
+   scoped to that plant so that plants' series do not collide.
+3. IF one Plant_Coordinator's Backfill run fails, THEN THE Backfill_Engine SHALL continue
+   Backfill runs for the remaining Plant_Coordinators.
+4. WHILE multiple Plant_Coordinators are being backfilled, THE Backfill_Engine SHALL apply the
+   rate-limit throttle across all concurrent runs of the config entry so the combined call
+   rate does not exceed the limit.

--- a/.kiro/specs/backfill-historical-statistics/tasks.md
+++ b/.kiro/specs/backfill-historical-statistics/tasks.md
@@ -1,0 +1,273 @@
+# Implementation Plan: Backfill Historical Statistics
+
+## Overview
+
+This plan implements the Backfill feature for the Sungrow iSolarCloud integration
+(`custom_components/sungrow`). It follows the design's separation of a **pure-logic core**
+(window resolution, chunking, batching, hourly aggregation, unit conversion, statistic-id
+scoping) that is exercised by **Hypothesis property tests**, from the **I/O orchestration shell**
+(series resolution, recorder import, throttle, engine run loop, manager, wiring, service, and
+Repairs) that is exercised by mocked `pytest` + `pytest-asyncio` unit/integration tests.
+
+Tasks are ordered by dependency: constants and data models first, then the pure functions with
+their property tests, then the orchestration shell wired into `__init__.py`, the on-demand
+service, and failure feedback. Property tests use `@settings(max_examples=100)` (minimum 100
+examples) and reference their design property and requirement IDs. Test sub-tasks are marked
+optional with `*`.
+
+Target language: **Python** (Home Assistant custom integration). Test stack: `pytest`,
+`pytest-asyncio`, and **Hypothesis** (add to `requirements_test.txt` if not already present).
+
+## Tasks
+
+- [ ] 1. Add Backfill constants and options to `const.py`
+  - Add `CONF_BACKFILL_DAYS`, `DEFAULT_BACKFILL_DAYS = 30`, `MAX_BACKFILL_DAYS = 365`
+  - Add `BACKFILL_INTERVAL = timedelta(minutes=5)`, `BACKFILL_CHUNK_WINDOW = timedelta(hours=3)`
+  - Add `MAX_POINTS_PER_CALL = 50`, `BACKFILL_MIN_CALL_INTERVAL = 1.0`, `BACKFILL_MAX_RETRIES = 3`
+  - Ensure `timedelta` is imported in `const.py`
+  - _Requirements: 3.1, 3.2, 3.3, 3.4, 4.1, 4.2, 5.1, 5.6_
+
+- [ ] 2. Define core data models and persistence in `backfill.py`
+  - [ ] 2.1 Create `backfill.py` with frozen dataclasses and error type
+    - Define `MinuteRow` (`timestamp: datetime`, `value: float`), `HistoryWindow`
+      (`start`, `end`, both UTC), `SeriesTarget` (`point_code`, `statistic_id`, `unit`,
+      `kind`, `is_external`, `metadata`), and `RunSummary` (`plant_id`, `window`,
+      `imported_hours`, `skipped_empty_ranges`, `failed_chunks`, `completed`)
+    - Define `InvalidRangeError(Exception)`
+    - _Requirements: 3.4, 4.1, 7.1, 7.2, 8.6_
+  - [ ] 2.2 Implement `BackfillStore` marker persistence wrapper
+    - Wrap HA `Store[dict]` at key `f"{DOMAIN}.backfill_state_{entry.entry_id}"`, version 1
+    - Provide async read/write of per-plant markers (`completed`, `partial`, `window_start`,
+      `window_end`, `last_run`, `failed_chunks`)
+    - _Requirements: 1.3, 1.4, 2.5_
+
+- [ ] 3. Implement pure window resolution
+  - [ ] 3.1 Implement `resolve_window(*, now, option_days, start_override)` in `backfill.py`
+    - Default length `DEFAULT_BACKFILL_DAYS`; use `option_days` when provided; clamp to
+      `[1 day, MAX_BACKFILL_DAYS]` and log when clamped; `end` always equals `now`
+    - Honor `start_override` (subject to clamp); raise `InvalidRangeError` when
+      `start_override > now`
+    - _Requirements: 2.3, 3.1, 3.2, 3.3, 3.4, 3.5_
+  - [ ]* 3.2 Write property test for window resolution in `test_backfill_properties.py`
+    - **Property 1: Window resolution is bounded and honors configuration**
+    - **Validates: Requirements 2.3, 3.1, 3.2, 3.3, 3.4, 3.5**
+    - Generate `now`, `option_days` (including > MAX and ≤ 0), and optional `start_date`
+      (before and after `now`); assert finiteness, `end == now`, clamped length, honored
+      override, and `InvalidRangeError` for future start dates; `@settings(max_examples=100)`
+
+- [ ] 4. Implement time chunking and point batching
+  - [ ] 4.1 Implement `chunk_time_window(window, chunk)` in `backfill.py`
+    - Split `[start, end)` into consecutive, non-overlapping sub-ranges each ≤ `chunk`,
+      returned ascending by start
+    - _Requirements: 4.2, 4.3, 4.4_
+  - [ ]* 4.2 Write property test for time chunking in `test_backfill_properties.py`
+    - **Property 3: Time chunking covers the window in ascending, bounded, non-overlapping pieces**
+    - **Validates: Requirements 4.2, 4.3, 4.4**
+    - Generate windows and positive chunk sizes; assert ascending, contiguous, non-overlapping,
+      full coverage of `[start, end)`, and per-chunk duration bound; `@settings(max_examples=100)`
+  - [ ] 4.3 Implement `batch_points(points, max_size=50)` in `backfill.py`
+    - Partition points into batches of at most `max_size` preserving order
+    - _Requirements: 4.1_
+  - [ ]* 4.4 Write property test for point batching in `test_backfill_properties.py`
+    - **Property 2: Point batching preserves all points and never exceeds the cap**
+    - **Validates: Requirements 4.1**
+    - Generate random point lists and `max_size ∈ [1, 50]`; assert batch-size cap and
+      order-preserving concatenation equals input; `@settings(max_examples=100)`
+
+- [ ] 5. Implement statistics builder and unit conversion
+  - [ ] 5.1 Implement `build_hourly_statistics(rows, kind, *, running_sum=0.0)` in `backfill.py`
+    - Floor each row timestamp to the UTC hour; energy: per-hour `state` = last cumulative
+      value in the hour, `sum` = running total, clamp negative minute deltas to zero so `sum`
+      is non-decreasing; power: per-hour `mean`/`min`/`max`; return
+      `(list[StatisticData], updated_running_sum)`
+    - _Requirements: 4.5, 6.3, 7.1, 7.2_
+  - [ ]* 5.2 Write property test for non-decreasing energy sum in `test_backfill_properties.py`
+    - **Property 4: Cumulative energy sum is non-decreasing across the whole window**
+    - **Validates: Requirements 4.5, 7.1**
+    - Generate minute rows (monotonic-ish readings plus noise, gaps, resets) split across
+      chunks with `running_sum` carried forward; assert the concatenated hourly `sum` sequence
+      is non-decreasing; `@settings(max_examples=100)`
+  - [ ]* 5.3 Write property test for determinism + idempotent, hour-local import in `test_backfill_properties.py`
+    - **Property 5: Aggregation is deterministic and import is idempotent and hour-local**
+    - **Validates: Requirements 6.1, 6.2, 6.3, 6.4**
+    - Assert `build_hourly_statistics` is deterministic, one `StatisticData` per hour, every
+      `start` on an exact UTC hour; using a fake `(statistic_id, start_hour)`-keyed store that
+      overwrites on collision, assert identical stored map for all-at-once vs per-chunk and
+      one run vs two runs, and that re-importing one chunk changes only that chunk's hours;
+      `@settings(max_examples=100)`
+  - [ ] 5.4 Implement energy unit conversion reuse in `backfill.py`
+    - Reuse `energy_units.normalize_energy_point` on each energy minute row (Wh→kWh) before
+      aggregation; leave power (W) and already-correct units unchanged
+    - _Requirements: 7.5, 7.6_
+  - [ ]* 5.5 Write property test for unit conversion in `test_backfill_properties.py`
+    - **Property 6: Energy unit conversion is correct and stable**
+    - **Validates: Requirements 7.5, 7.6**
+    - Generate numeric values and units; assert Wh→kWh yields `round(value / 1000, 3)` with
+      unit `kWh`, and no-op for kWh/other units; `@settings(max_examples=100)`
+
+- [ ] 6. Checkpoint - Ensure all pure-core tests pass
+  - Ensure all tests pass, ask the user if questions arise.
+
+- [ ] 7. Implement series resolution and statistic-id scoping
+  - [ ] 7.1 Implement `async_resolve_series` and statistic-id derivation in `backfill.py`
+    - Select cumulative-energy and power Backfill_Points from
+      `coordinator.plants_service.measure_points` via `resolve_classification`
+    - Look up live entity by `unique_id` `f"{plant_id}_{point_code}"`; live entity →
+      `statistic_id = entity_id`, `source="recorder"`; else external →
+      `statistic_id = f"sungrow:{plant_id}_{point_code}"`, `source=DOMAIN`
+    - Derive `has_mean`/`has_sum` from kind (energy → `has_sum`; power → `has_mean`) and set
+      unit from the live entity/statistics unit
+    - _Requirements: 7.1, 7.2, 7.3, 7.4, 7.5, 7.6, 9.2_
+  - [ ]* 7.2 Write property test for statistic-id scoping in `test_backfill_properties.py`
+    - **Property 7: Statistic_Ids are scoped per plant and never collide**
+    - **Validates: Requirements 9.2**
+    - Generate distinct `plant_id` pairs and codes; assert external ids
+      `f"sungrow:{plant_id}_{code}"` differ; `@settings(max_examples=100)`
+  - [ ]* 7.3 Write unit tests for series resolution in `test_backfill.py`
+    - Live-entity resolution via a populated entity registry (7.3, 7.5); external fallback when
+      absent (7.4); energy vs power metadata shape and unit propagation (7.1, 7.2)
+    - _Requirements: 7.1, 7.2, 7.3, 7.4, 7.5_
+
+- [ ] 8. Implement idempotent import router
+  - [ ] 8.1 Implement `import_statistics(hass, target, data)` in `backfill.py`
+    - Route external series to `async_add_external_statistics` and live-entity series to
+      `async_import_statistics`; both overwrite by `(statistic_id, start_hour)`
+    - _Requirements: 6.1, 6.4, 7.3, 7.4_
+  - [ ]* 8.2 Write unit tests for import idempotency in `test_backfill.py`
+    - Use a fake `(statistic_id, start_hour)`-keyed recorder store; assert re-import overwrites
+      rather than duplicates and that a retried chunk touches only its own hours
+    - _Requirements: 6.1, 6.2, 6.4_
+
+- [ ] 9. Implement shared Throttle
+  - [ ] 9.1 Implement `Throttle` class in `backfill.py`
+    - `acquire()` waits until `min_interval` has elapsed since the previous acquire
+      (serialised across engines sharing one instance); `backoff()` sleeps an escalating delay
+      (doubling, capped at 1 hour); `reset_backoff()` clears it
+    - _Requirements: 5.1, 5.2, 5.3, 9.4_
+  - [ ]* 9.2 Write unit tests for throttle in `test_backfill.py`
+    - Mocked-clock tests for min-interval spacing across shared instance (5.1, 9.4) and
+      escalating backoff with cap (5.2)
+    - _Requirements: 5.1, 5.2, 9.4_
+
+- [ ] 10. Implement error-classification wiring
+  - [ ] 10.1 Wire error classifiers into `backfill.py`
+    - Reuse the coordinator's `is_auth_error` and `is_rate_limit_error` (E998/E999) helpers to
+      classify `async_get_historical_data` failures
+    - _Requirements: 5.2, 5.6, 8.5_
+
+- [ ] 11. Implement `BackfillEngine.async_run`
+  - [ ] 11.1 Implement the engine run loop in `backfill.py`
+    - Resolve window and series; iterate Time_Chunks ascending × Point_Batches (≤ 50); await
+      throttle before each call; pass explicit `start_time`/`end_time` and
+      `interval=BACKFILL_INTERVAL`; aggregate via `build_hourly_statistics` carrying
+      `running_sum`; import via `import_statistics`; classify errors (auth → stop/defer;
+      rate-limit → backoff + resume from progress cursor; transient → retry ≤
+      `BACKFILL_MAX_RETRIES` then mark chunk failed); handle empty ranges; persist marker; log
+      start/per-chunk/outcome; return `RunSummary`
+    - _Requirements: 1.3, 4.3, 4.4, 5.2, 5.3, 5.6, 6.4, 8.1, 8.3, 8.4, 8.6_
+  - [ ]* 11.2 Write unit tests for the happy-path run loop in `test_backfill.py`
+    - Mocked `plants_service.async_get_historical_data`; assert ascending chunk loop, explicit
+      call kwargs bounding a chunk (4.3), empty-range skip + log (8.3), start/progress/outcome
+      logs via `caplog` (8.4), and `RunSummary` counts (8.6)
+    - _Requirements: 4.3, 8.3, 8.4, 8.6_
+  - [ ]* 11.3 Write unit tests for run-loop error handling in `test_backfill.py`
+    - Rate-limit backoff + resume from cursor (5.2, 5.3); bounded transient retries then
+      chunk-failed and run continues (5.6, 8.1); auth-error stop/defer (8.5)
+    - _Requirements: 5.2, 5.3, 5.6, 8.1, 8.5_
+
+- [ ] 12. Checkpoint - Ensure engine and pure-core tests pass
+  - Ensure all tests pass, ask the user if questions arise.
+
+- [ ] 13. Implement `BackfillManager`
+  - [ ] 13.1 Implement the manager in `backfill.py`
+    - One `BackfillEngine` per coordinator sharing one `Throttle` and one `BackfillStore`;
+      `async_start_automatic` gates each plant on the completed default-window marker;
+      `async_run_on_demand(plant_ids, start_date)` starts runs for addressed coordinators and
+      rejects a plant already running; `is_running(plant_id)`; `async_shutdown` cancels and
+      awaits in-flight tasks; wrap per-plant runs so one failure does not stop the others; log
+      each `RunSummary`
+    - _Requirements: 1.1, 1.4, 1.5, 2.2, 2.3, 2.4, 9.1, 9.3, 9.4_
+  - [ ]* 13.2 Write unit tests for the manager in `test_backfill.py`
+    - Automatic-start gating on marker (1.1, 1.4); already-running rejection (2.4); multi-plant
+      run and one plant failing without stopping others (9.1, 9.3); shared throttle across
+      engines (9.4); shutdown cancels tasks leaving imports intact (1.5)
+    - _Requirements: 1.1, 1.4, 1.5, 2.4, 9.1, 9.3, 9.4_
+
+- [ ] 14. Wire Backfill into integration setup (`__init__.py`)
+  - [ ] 14.1 Add `backfill` field to `SungrowData` and wire lifecycle
+    - Add `backfill: "BackfillManager | None" = None` to `SungrowData`; in the cloud
+      `async_setup_entry` path construct the manager and schedule
+      `manager.async_start_automatic()` via `entry.async_create_background_task` (gated on
+      recorder readiness); skip construction in the Modbus-only setup path; call
+      `manager.async_shutdown()` in `async_unload_entry`
+    - _Requirements: 1.1, 1.2, 1.5, 5.4, 5.5_
+  - [ ]* 14.2 Write unit tests for setup wiring in `test_backfill.py`
+    - Cloud setup constructs manager and starts automatic run; Modbus-only skip (1.2);
+      realtime poll not blocked while a run task is parked on the throttle (5.4, 5.5); unload
+      cancellation leaves imports intact (1.5)
+    - _Requirements: 1.2, 1.5, 5.4, 5.5_
+
+- [ ] 15. Implement the on-demand `BackfillService`
+  - [ ] 15.1 Create `services.yaml` and register the admin service
+    - Add `services.yaml` `backfill` entry with `config_entry` and `start_date` selectors;
+      register `sungrow.backfill` as an admin service; handler resolves addressed config
+      entries/plants and calls `manager.async_run_on_demand(plant_ids=..., start_date=...)`
+    - _Requirements: 2.1, 2.2, 2.3_
+  - [ ]* 15.2 Write unit tests for the service in `test_backfill.py`
+    - Service registration smoke test (2.1); dispatch to multiple plants (2.2); explicit
+      `start_date` passed through to the manager (2.3)
+    - _Requirements: 2.1, 2.2, 2.3_
+
+- [ ] 16. Implement failure feedback (Repairs + translations)
+  - [ ] 16.1 Add partial-failure Repair and translations
+    - On a partial run, `ir.async_create_issue` with translation key `backfill_partial`
+      describing the failure and how to re-run; clear the issue on a later fully successful run;
+      add the `backfill_partial` strings to `strings.json` and `translations/en.json`
+    - _Requirements: 8.2_
+  - [ ]* 16.2 Write unit tests for Repair behaviour in `test_backfill.py`
+    - Assert a partial run raises the `backfill_partial` issue (8.1, 8.2) and a subsequent
+      successful run clears it
+    - _Requirements: 8.1, 8.2_
+
+- [ ] 17. Final checkpoint - Ensure the full suite and lint pass
+  - Ensure all tests pass and `ruff` is clean, ask the user if questions arise.
+
+## Notes
+
+- Tasks marked with `*` are optional test sub-tasks and can be skipped for a faster MVP.
+- Each task references specific requirement sub-clauses for traceability.
+- Property tests (Properties 1–7) own the combinatorial input space and run a minimum of 100
+  Hypothesis examples; unit tests own wiring, error branches, HA registry/recorder integration,
+  and logging as representative examples.
+- Property tests live in `tests/test_backfill_properties.py`; unit/integration tests live in
+  `tests/test_backfill.py`. Add Hypothesis to `requirements_test.txt` if absent.
+- Checkpoints ensure incremental validation of the pure core, the engine, and the full feature.
+
+## Task Dependency Graph
+
+```json
+{
+  "waves": [
+    { "id": 0, "tasks": ["1.1"] },
+    { "id": 1, "tasks": ["2.1"] },
+    { "id": 2, "tasks": ["2.2"] },
+    { "id": 3, "tasks": ["3.1"] },
+    { "id": 4, "tasks": ["3.2", "4.1"] },
+    { "id": 5, "tasks": ["4.2", "4.3"] },
+    { "id": 6, "tasks": ["4.4", "5.1"] },
+    { "id": 7, "tasks": ["5.2", "5.4"] },
+    { "id": 8, "tasks": ["5.3", "7.1"] },
+    { "id": 9, "tasks": ["5.5", "8.1"] },
+    { "id": 10, "tasks": ["7.2", "9.1"] },
+    { "id": 11, "tasks": ["7.3", "10.1"] },
+    { "id": 12, "tasks": ["8.2", "11.1"] },
+    { "id": 13, "tasks": ["9.2", "13.1"] },
+    { "id": 14, "tasks": ["11.2", "14.1"] },
+    { "id": 15, "tasks": ["11.3", "15.1"] },
+    { "id": 16, "tasks": ["13.2", "16.1"] },
+    { "id": 17, "tasks": ["14.2"] },
+    { "id": 18, "tasks": ["15.2"] },
+    { "id": 19, "tasks": ["16.2"] }
+  ]
+}
+```

--- a/.kiro/specs/hybrid-mppt-string-sensors/.config.kiro
+++ b/.kiro/specs/hybrid-mppt-string-sensors/.config.kiro
@@ -1,0 +1,1 @@
+{"specId": "1f238ace-25dc-45c7-a3c0-e5a85dbeac44", "workflowType": "requirements-first", "specType": "bugfix"}

--- a/.kiro/specs/hybrid-mppt-string-sensors/bugfix.md
+++ b/.kiro/specs/hybrid-mppt-string-sensors/bugfix.md
@@ -1,0 +1,100 @@
+# Bugfix Requirements Document
+
+## Introduction
+
+The per-string / MPPT diagnostic-sensor feature (issue #189, ~v3.4.0) surfaces MPPT
+voltage/current and per-string voltage/current as diagnostic sensors when a user enables
+per-device sensors. It works for SG-RS single-phase string inverters
+(`DeviceType.INVERTER`).
+
+On SH-family hybrids reported as `DeviceType.ENERGY_STORAGE_SYSTEM` (ESS) — e.g. the
+SH20T from Quad2000 — no MPPT/string sensors appear even with per-device sensors enabled,
+despite the MPPT data being visible in the Sungrow cloud for that inverter.
+
+Root cause: the coordinator requests the same point set (`INVERTER_DIAGNOSTIC_POINTS`) for
+both `INVERTER` and `ENERGY_STORAGE_SYSTEM` device types. That set only contains
+string-inverter MPPT point IDs (`"5"`–`"10"`) and per-string IDs (`"96"`/`"70"` ..
+`"103"`/`"77"`). SH-family hybrids report MPPT data under a different point-ID range
+(`"13001"`/`"13002"` for MPPT1, `"13105"`/`"13106"` for MPPT2, `"13107"`/`"13108"` for
+MPPT3, `"13109"`/`"13110"` for MPPT4) — IDs that already exist in the measure-point
+catalog (`measure_points_data.py`). Because the ESS branch never requests the 13xxx IDs,
+hybrid inverters return nothing for MPPT sensors.
+
+A related symmetry consideration: `sensor.py` builds `_DIAGNOSTIC_CODES` from
+`INVERTER_DIAGNOSTIC_POINTS.values()`, so any new ESS MPPT codes must also be classified
+as diagnostic sensors, otherwise they would appear as regular sensors rather than in the
+device's Diagnostic section.
+
+## Bug Analysis
+
+### Current Behavior (Defect)
+
+1.1 WHEN the device is a `DeviceType.ENERGY_STORAGE_SYSTEM` (SH-family hybrid), per-device sensors are enabled, and the model reports MPPT data on the 13xxx point IDs THEN the system requests only `INVERTER_DIAGNOSTIC_POINTS` (string-inverter IDs `"5"`–`"10"`) and never requests the hybrid MPPT IDs (`"13001"`/`"13002"`, `"13105"`/`"13106"`, `"13107"`/`"13108"`, `"13109"`/`"13110"`), so no MPPT voltage/current sensors are created.
+
+1.2 WHEN an ESS/hybrid MPPT code would be produced (if requested) THEN the system does not classify it as a diagnostic code because `_DIAGNOSTIC_CODES` is derived only from `INVERTER_DIAGNOSTIC_POINTS.values()`, which does not include the hybrid MPPT codes.
+
+### Expected Behavior (Correct)
+
+2.1 WHEN the device is a `DeviceType.ENERGY_STORAGE_SYSTEM` (SH-family hybrid), per-device sensors are enabled, and the model reports MPPT data on the 13xxx point IDs THEN the system SHALL request the hybrid MPPT point IDs (`"13001"`/`"13002"` = MPPT1 V/I, `"13105"`/`"13106"` = MPPT2 V/I, `"13107"`/`"13108"` = MPPT3 V/I, `"13109"`/`"13110"` = MPPT4 V/I) so the MPPT voltage/current sensors are surfaced the same way string inverters surface theirs.
+
+2.2 WHEN an ESS/hybrid MPPT code is produced THEN the system SHALL classify it as a diagnostic code (included in `_DIAGNOSTIC_CODES`) so it lands in the device page's Diagnostic section rather than the main sensors.
+
+2.3 WHEN the device is a hybrid but the model does not report a given MPPT point (e.g. an unpopulated MPPT3/MPPT4) THEN the system SHALL skip that point silently and create no sensor for it, consistent with the existing per-device builder behavior for string inverters.
+
+### Unchanged Behavior (Regression Prevention)
+
+3.1 WHEN the device is a `DeviceType.INVERTER` (string inverter such as an SG-RS) with per-device sensors enabled THEN the system SHALL CONTINUE TO surface its MPPT (`"5"`–`"10"`) and per-string (`"96"`/`"70"` .. `"103"`/`"77"`) diagnostic sensors exactly as before.
+
+3.2 WHEN the device is a `DeviceType.ENERGY_STORAGE_SYSTEM` THEN the system SHALL CONTINUE TO request operating status on `"13146"` and drop the inverter operating-status point `"29"` so the two do not collide on the shared `operating_status` code (#182).
+
+3.3 WHEN per-device sensors are disabled THEN the system SHALL CONTINUE TO not request any per-device diagnostic points for either inverters or hybrids.
+
+3.4 WHEN the device is a `DeviceType.BATTERY`, `DeviceType.COMMUNICATION_MODULE`, or `DeviceType.METER` THEN the system SHALL CONTINUE TO request its existing point set unchanged.
+
+3.5 WHEN a string-inverter diagnostic code is produced THEN the system SHALL CONTINUE TO classify it as a diagnostic code so it lands in the Diagnostic section as before.
+
+## Bug Condition and Properties
+
+### Bug Condition Function
+
+```pascal
+FUNCTION isBugCondition(X)
+  INPUT: X = (deviceType, enableDeviceSensors, modelReportsHybridMppt)
+  OUTPUT: boolean
+
+  // The bug is triggered for hybrid (ESS) devices with per-device sensors enabled
+  // whose model actually reports MPPT data on the 13xxx point IDs.
+  RETURN X.deviceType = DeviceType.ENERGY_STORAGE_SYSTEM
+     AND X.enableDeviceSensors = true
+     AND X.modelReportsHybridMppt = true
+END FUNCTION
+```
+
+### Property: Fix Checking
+
+```pascal
+// For every hybrid device that reports MPPT data, the fixed coordinator requests
+// the hybrid MPPT point IDs, and the produced MPPT codes are classified diagnostic.
+FOR ALL X WHERE isBugCondition(X) DO
+  requested ← requestedDiagnosticPoints'(X)
+  ASSERT {"13001","13002","13105","13106","13107","13108","13109","13110"} ⊆ requested
+  FOR ALL code IN hybridMpptCodes(requested) DO
+    ASSERT code IN _DIAGNOSTIC_CODES'
+  END FOR
+END FOR
+```
+
+### Property: Preservation Checking
+
+```pascal
+// For every non-buggy input (string inverters, disabled sensors, batteries,
+// meters, comm modules, ESS operating-status handling), the fixed code behaves
+// identically to the original.
+FOR ALL X WHERE NOT isBugCondition(X) DO
+  ASSERT requestedDiagnosticPoints(X) = requestedDiagnosticPoints'(X)
+  ASSERT _DIAGNOSTIC_CODES(stringInverterCodes) = _DIAGNOSTIC_CODES'(stringInverterCodes)
+END FOR
+```
+
+Where **F** is the original (unfixed) coordinator/point-selection behavior and **F'** is
+the fixed behavior after adding hybrid MPPT point requests and diagnostic classification.

--- a/.kiro/specs/hybrid-mppt-string-sensors/design.md
+++ b/.kiro/specs/hybrid-mppt-string-sensors/design.md
@@ -1,0 +1,381 @@
+# Hybrid MPPT / String Sensors Bugfix Design
+
+## Overview
+
+SH-family hybrid inverters that iSolarCloud reports as `DeviceType.ENERGY_STORAGE_SYSTEM`
+(ESS) never surface MPPT voltage/current diagnostic sensors, even with per-device sensors
+enabled, because the coordinator requests the string-inverter point set
+(`INVERTER_DIAGNOSTIC_POINTS`) for both `INVERTER` and `ENERGY_STORAGE_SYSTEM`. That set only
+carries the string-inverter MPPT point IDs (`"5"`–`"10"`). Hybrids report MPPT data under a
+separate 13xxx point range (`13001`/`13002`, `13105`/`13106`, `13107`/`13108`, `13109`/`13110`)
+that is already present in the measure-point catalog but is never requested for ESS devices.
+
+The fix introduces a dedicated hybrid MPPT point map (`ESS_MPPT_DIAGNOSTIC_POINTS`) that maps
+the 13xxx IDs to the **same** stable code names string inverters already use
+(`mppt1_voltage`, `mppt1_current`, …). The coordinator's ESS branch swaps the string-inverter
+MPPT IDs (`"5"`–`"10"`) for the 13xxx IDs so the shared `mpptN_*` codes cannot collide, and the
+diagnostic-classification set in `sensor.py` continues to derive automatically because the code
+names are reused. All other device handling (string inverters, batteries, meters, comm modules,
+disabled sensors, ESS operating-status handling) is left untouched.
+
+## Glossary
+
+- **Bug_Condition (C)**: An ESS/hybrid device with per-device sensors enabled whose model
+  reports MPPT data on the 13xxx point IDs, for which no MPPT sensors are produced.
+- **Property (P)**: For such devices the coordinator requests the hybrid MPPT point IDs and the
+  produced MPPT codes are classified as diagnostic — MPPT voltage/current sensors appear in the
+  device's Diagnostic section exactly as they do for string inverters.
+- **Preservation**: String inverters, batteries, meters, comm modules, disabled-sensor
+  behavior, and ESS operating-status handling (`13146` requested, `29` dropped) all stay
+  byte-for-byte identical.
+- **`_build_device_data` (per-device fetch)**: The coordinator method in
+  `custom_components/sungrow/coordinator.py` (~lines 530-570) that picks the `extra_measure_points`
+  map per device type and calls `async_get_device_realtime`.
+- **`INVERTER_DIAGNOSTIC_POINTS`**: `dict[str, str]` in `const.py` mapping documented inverter
+  point IDs to stable codes; the source of the string-inverter MPPT/string diagnostic sensors and
+  of `sensor.py`'s `_DIAGNOSTIC_CODES`.
+- **`ESS_MPPT_DIAGNOSTIC_POINTS`** (new): `dict[str, str]` in `const.py` mapping the hybrid 13xxx
+  MPPT IDs to the reused `mpptN_voltage` / `mpptN_current` codes.
+- **`_DIAGNOSTIC_CODES`**: `frozenset` in `sensor.py` built from
+  `INVERTER_DIAGNOSTIC_POINTS.values()` (plus battery/comm codes) that decides which point codes
+  get `EntityCategory.DIAGNOSTIC`.
+- **`type_id`**: `DeviceType(...).value` for the device currently being fetched.
+
+## Bug Details
+
+### Bug Condition
+
+The bug manifests when a device is an SH-family hybrid (reported as
+`DeviceType.ENERGY_STORAGE_SYSTEM`), per-device sensors are enabled, and the model reports MPPT
+data on the 13xxx point IDs. In the current `_build_device_data`, the ESS branch reuses
+`INVERTER_DIAGNOSTIC_POINTS` (minus point `"29"`), which contains only the string-inverter MPPT
+IDs `"5"`–`"10"`. The 13xxx IDs are never added to `extra_measure_points`, so the cloud returns
+no MPPT points for the hybrid and no MPPT sensors are ever created.
+
+**Formal Specification:**
+```
+FUNCTION isBugCondition(input)
+  INPUT: input of type (deviceType, enableDeviceSensors, modelReportsHybridMppt)
+  OUTPUT: boolean
+
+  RETURN input.deviceType = DeviceType.ENERGY_STORAGE_SYSTEM
+         AND input.enableDeviceSensors = true
+         AND input.modelReportsHybridMppt = true
+         AND requestedDiagnosticPoints(input) does NOT contain the 13xxx MPPT IDs
+END FUNCTION
+```
+
+### Examples
+
+- **SH20T hybrid, per-device sensors ON, reports MPPT1/MPPT2:** Expected — `mppt1_voltage`,
+  `mppt1_current`, `mppt2_voltage`, `mppt2_current` diagnostic sensors appear. Actual — none
+  appear because `13001`/`13002`/`13105`/`13106` were never requested.
+- **SH hybrid with 4 populated MPPTs:** Expected — MPPT1–4 voltage/current sensors appear.
+  Actual — none appear.
+- **SH hybrid with only MPPT1/MPPT2 populated (MPPT3/MPPT4 unwired):** Expected — MPPT1/MPPT2
+  sensors appear, MPPT3/MPPT4 silently skipped. Actual — none appear.
+- **SG-RS string inverter, per-device sensors ON (edge/control):** Expected and Actual — MPPT
+  sensors from `"5"`–`"10"` appear. This is the unchanged path and must stay working.
+
+## Expected Behavior
+
+### Preservation Requirements
+
+**Unchanged Behaviors:**
+- String inverters (`DeviceType.INVERTER`) continue to surface their MPPT (`"5"`–`"10"`) and
+  per-string (`"96"`/`"70"` .. `"103"`/`"77"`) diagnostic sensors exactly as before.
+- ESS devices continue to request operating status on `"13146"` and drop the inverter
+  operating-status point `"29"` so the two do not collide on the shared `operating_status`
+  code (#182).
+- Batteries, communication modules, and meters continue to request their existing point sets
+  (`BATTERY_DEVICE_POINTS`, `COMM_MODULE_POINTS`, `METER_DEVICE_POINTS`) unchanged.
+- With per-device sensors disabled, no per-device diagnostic points are requested for either
+  inverters or hybrids (only single operating-status points as today).
+- String-inverter diagnostic codes stay classified as diagnostic (Diagnostic section unchanged).
+
+**Scope:**
+All inputs that are NOT an ESS/hybrid with per-device sensors enabled and reporting hybrid MPPT
+data must be completely unaffected by this fix. This includes:
+- Any `DeviceType.INVERTER` device (string inverter) in any configuration.
+- Any device when per-device sensors are disabled.
+- `DeviceType.BATTERY`, `DeviceType.COMMUNICATION_MODULE`, `DeviceType.METER`, and unmapped types.
+- ESS operating-status handling (`13146` present, `29` absent) and the rest of the ESS diagnostic
+  set that is not the string-inverter MPPT IDs (grid health, per-string, temperature, etc.).
+
+**Note:** The expected correct behavior is defined in the Correctness Properties section
+(Property 1). This section focuses on what must NOT change.
+
+## Hypothesized Root Cause
+
+Based on the bug description and code inspection, the cause is confirmed rather than merely
+suspected, but framed as hypotheses for the exploratory phase:
+
+1. **Wrong point IDs requested for ESS (primary cause):** `_build_device_data` reuses
+   `INVERTER_DIAGNOSTIC_POINTS` for `ENERGY_STORAGE_SYSTEM`. That map's MPPT entries are the
+   string-inverter IDs `"5"`–`"10"`; the hybrid MPPT IDs (`13001`/`13002`, `13105`/`13106`,
+   `13107`/`13108`, `13109`/`13110`) are never added, so the cloud returns nothing for hybrid MPPT.
+
+2. **Catalog present but unreferenced:** The 13xxx MPPT IDs already exist in
+   `measure_points_data.py` (`13001` "MPPT1 Voltage" V, `13002` "MPPT1 Current" A, etc.), so once
+   requested they classify correctly by unit — no catalog change is needed. The gap is purely that
+   nothing requests them for ESS.
+
+3. **Diagnostic classification derived from the wrong-only set:** `sensor.py` builds
+   `_DIAGNOSTIC_CODES` from `INVERTER_DIAGNOSTIC_POINTS.values()`. If hybrid MPPT used *new* code
+   names, they would land in the main sensors instead of Diagnostic. Reusing the existing
+   `mpptN_*` code names sidesteps this (they are already in the set), but this must be confirmed.
+
+4. **Code-collision risk if both ID ranges requested (design constraint, not current bug):**
+   Because `"5"` and `13001` both map to `mppt1_voltage`, requesting both for one ESS would map two
+   different point IDs to the same code and silently overwrite one another in the per-device merge —
+   the same class of collision already handled for `operating_status` (`29` vs `13146`, #182).
+
+## Correctness Properties
+
+Property 1: Bug Condition - Hybrid MPPT Sensors Surfaced and Classified Diagnostic
+
+_For any_ input where the bug condition holds (an ESS/hybrid device with per-device sensors
+enabled whose model reports MPPT data on the 13xxx IDs), the fixed coordinator SHALL include the
+hybrid MPPT point IDs `{"13001","13002","13105","13106","13107","13108","13109","13110"}` in the
+requested `extra_measure_points`, and every produced hybrid MPPT code SHALL be a member of
+`_DIAGNOSTIC_CODES` so the resulting MPPT voltage/current sensors land in the device's Diagnostic
+section. MPPT points the model does not report SHALL be skipped silently (no sensor created),
+consistent with the existing string-inverter builder behavior.
+
+**Validates: Requirements 2.1, 2.2, 2.3**
+
+Property 2: Preservation - Non-Buggy Device/Config Behavior Unchanged
+
+_For any_ input where the bug condition does NOT hold (string inverters, disabled per-device
+sensors, batteries, meters, comm modules, unmapped types, and ESS operating-status handling), the
+fixed code SHALL produce exactly the same requested point set and the same diagnostic
+classification for existing codes as the original code. In particular the fixed ESS branch SHALL
+NOT request the string-inverter MPPT IDs `"5"`–`"10"` in addition to the 13xxx IDs, so no two point
+IDs map to the same `mpptN_*` code for a single ESS device.
+
+**Validates: Requirements 3.1, 3.2, 3.3, 3.4, 3.5**
+
+## Fix Implementation
+
+### Changes Required
+
+Assuming our root cause analysis is correct, three coordinated edits:
+
+**File**: `custom_components/sungrow/const.py`
+
+1. **Add `ESS_MPPT_DIAGNOSTIC_POINTS`**: A `dict[str, str]` mapping the hybrid 13xxx MPPT IDs to
+   the reused string-inverter code names so classification, naming, units, and icons all work
+   unchanged:
+   ```python
+   # SH-family hybrids/ESS report MPPT voltage/current on a separate point-ID range
+   # than string inverters (#189 follow-up). Reuse the same mpptN_* code names so the
+   # existing classification/naming/icon path treats them identically; only the point
+   # IDs differ. These are already in the measure-point catalog (units V/A), so they
+   # classify by unit automatically.
+   ESS_MPPT_DIAGNOSTIC_POINTS: dict[str, str] = {
+       "13001": "mppt1_voltage",
+       "13002": "mppt1_current",
+       "13105": "mppt2_voltage",
+       "13106": "mppt2_current",
+       "13107": "mppt3_voltage",
+       "13108": "mppt3_current",
+       "13109": "mppt4_voltage",
+       "13110": "mppt4_current",
+   }
+   ```
+
+**File**: `custom_components/sungrow/coordinator.py`
+
+2. **Import the new map** alongside `INVERTER_DIAGNOSTIC_POINTS`.
+
+3. **Rework the ESS diagnostic branch** so that for `ENERGY_STORAGE_SYSTEM` the string-inverter
+   MPPT IDs are removed and the 13xxx IDs merged in (swap, not add), preserving the existing
+   `"29"` drop:
+   ```python
+   if type_id in (DeviceType.INVERTER.value, DeviceType.ENERGY_STORAGE_SYSTEM.value):
+       diagnostic = INVERTER_DIAGNOSTIC_POINTS
+       if type_id == DeviceType.ENERGY_STORAGE_SYSTEM.value:
+           # ESS reports operating status on 13146 (requested above); drop the
+           # inverter point 29 so the two don't collide on "operating_status" (#182).
+           # ESS also reports MPPT on a separate 13xxx range: drop the string-inverter
+           # MPPT IDs (5-10) and merge the hybrid MPPT IDs instead. Both ranges share
+           # the mpptN_* codes, so requesting BOTH would map two IDs to one code and
+           # silently overwrite each other in the per-device merge.
+           string_inverter_mppt_ids = {"5", "6", "7", "8", "9", "10"}
+           diagnostic = {
+               pid: code
+               for pid, code in INVERTER_DIAGNOSTIC_POINTS.items()
+               if pid != "29" and pid not in string_inverter_mppt_ids
+           }
+           diagnostic = {**diagnostic, **ESS_MPPT_DIAGNOSTIC_POINTS}
+       extra.update(diagnostic)
+   ```
+   Notes:
+   - The `"29"` drop is preserved exactly (Requirement 3.2).
+   - Removing `"5"`–`"10"` for ESS is the collision fix required by Property 2's final clause. It
+     is also lean: hybrids do not report those IDs, so excluding them avoids requesting points a
+     hybrid never populates while guaranteeing no `mpptN_*` code maps to two IDs.
+   - The rest of the ESS set (grid health, per-string, temperature, insulation, etc.) is unchanged.
+     Per-string IDs (`"96"`/`"70"` ..) are left in place; they use `string_N_*` codes that do not
+     collide with the MPPT codes, and the per-device builder skips any a model does not report
+     (Requirement 2.3).
+
+**File**: `custom_components/sungrow/sensor.py`
+
+4. **Confirm diagnostic classification needs no code change**: `ESS_MPPT_DIAGNOSTIC_POINTS` reuses
+   `mppt1_voltage`, `mppt1_current`, `mppt2_voltage`, `mppt2_current` — all already present in
+   `INVERTER_DIAGNOSTIC_POINTS.values()` (via `"5"`–`"8"`), so they are already in
+   `_DIAGNOSTIC_CODES`. `mppt3_*` are also present (`"9"`/`"10"`). Only `mppt4_voltage` /
+   `mppt4_current` are **new** code names not present in `INVERTER_DIAGNOSTIC_POINTS`, so they are
+   NOT currently in `_DIAGNOSTIC_CODES`.
+
+   Therefore, to satisfy Property 1 for MPPT4, union the new map's values into `_DIAGNOSTIC_CODES`:
+   ```python
+   from .const import (
+       ...
+       ESS_MPPT_DIAGNOSTIC_POINTS,
+       INVERTER_DIAGNOSTIC_POINTS,
+   )
+   ...
+   _DIAGNOSTIC_CODES = (
+       frozenset(INVERTER_DIAGNOSTIC_POINTS.values())
+       | frozenset(ESS_MPPT_DIAGNOSTIC_POINTS.values())
+       | BATTERY_DIAGNOSTIC_CODES
+       | frozenset(COMM_MODULE_POINTS.values())
+   )
+   ```
+   This is safe and idempotent: the mppt1–3 codes are already members, so the union only adds
+   `mppt4_voltage` / `mppt4_current`. Doing the union unconditionally also future-proofs the set
+   against later code-name changes in `ESS_MPPT_DIAGNOSTIC_POINTS`.
+
+### Why reuse the same code names
+
+`resolve_classification(unit, code, point_id)` classifies the 13xxx points correctly by their
+catalog unit (V → `SensorDeviceClass.VOLTAGE`, A → `SensorDeviceClass.CURRENT`) regardless of code
+name, so classification does not depend on the code. But naming and icon selection for
+`mpptN_voltage` / `mpptN_current` are keyed off the code name; reusing the exact string-inverter
+code names means hybrid MPPT sensors get identical names, icons, and units with zero additional
+mapping. This is the minimal change and keeps hybrids and string inverters visually consistent.
+
+## Testing Strategy
+
+The repo uses **pytest** (async tests via `pytest-asyncio`), with coordinator tests in
+`tests/test_coordinator.py`, const-shape tests in `tests/test_const.py`, and sensor
+classification tests in `tests/test_sensor.py`. The existing ESS/collision test
+`test_ess_operating_status_avoids_point29_collision` (asserts on the
+`extra_measure_points` kwarg captured from a `MagicMock` `plants` service) is the exact pattern to
+mirror for the new coordinator assertions.
+
+### Validation Approach
+
+Two phases: first surface counterexamples that demonstrate the bug on the UNFIXED code (no 13xxx
+IDs requested for ESS), then verify the fix requests the hybrid MPPT IDs, classifies the codes
+diagnostic, and leaves every non-buggy path byte-for-byte identical.
+
+### Exploratory Bug Condition Checking
+
+**Goal**: Surface counterexamples that demonstrate the bug BEFORE implementing the fix, confirming
+root cause #1 (13xxx IDs never requested for ESS). If a test unexpectedly passes on unfixed code,
+re-hypothesize.
+
+**Test Plan**: Instantiate `SungrowPlantCoordinator` with a single
+`DeviceType.ENERGY_STORAGE_SYSTEM` device and per-device sensors enabled (`CONF_ENABLE_DEVICE_SENSORS: True`),
+mock `plants.async_get_device_realtime`, run `_async_update_data()`, and inspect the captured
+`extra_measure_points` kwarg. Run on UNFIXED code to observe the missing IDs.
+
+**Test Cases**:
+1. **ESS requests hybrid MPPT IDs**: Assert `{"13001","13002","13105","13106","13107","13108","13109","13110"}`
+   is a subset of the requested `extra` (will fail on unfixed code — none are present).
+2. **ESS drops string-inverter MPPT IDs**: Assert `"5"`–`"10"` are absent from the ESS `extra`
+   (will fail on unfixed code — they are present, which is the collision source).
+3. **Hybrid MPPT codes are diagnostic**: Assert `mppt4_voltage` / `mppt4_current` ∈
+   `_DIAGNOSTIC_CODES` (will fail on unfixed code — only mppt1–3 present).
+4. **Partial-MPPT skip (edge)**: With the mocked realtime response returning only MPPT1/MPPT2
+   points, assert only those sensors are produced and MPPT3/MPPT4 are silently skipped.
+
+**Expected Counterexamples**:
+- ESS `extra_measure_points` contains no `13xxx` MPPT IDs and still contains `"5"`–`"10"`.
+- `mppt4_voltage` / `mppt4_current` not in `_DIAGNOSTIC_CODES`.
+- Possible causes surfaced: wrong point IDs requested for ESS, classification set derived from the
+  string-inverter-only map.
+
+### Fix Checking
+
+**Goal**: Verify that for all inputs where the bug condition holds, the fixed coordinator requests
+the hybrid MPPT IDs and classifies the produced codes as diagnostic.
+
+**Pseudocode:**
+```
+FOR ALL input WHERE isBugCondition(input) DO
+  requested := requestedDiagnosticPoints_fixed(input)
+  ASSERT {"13001","13002","13105","13106","13107","13108","13109","13110"} SUBSET-OF requested
+  ASSERT {"5","6","7","8","9","10"} DISJOINT-FROM requested   // no code collision
+  FOR ALL code IN hybridMpptCodes(requested) DO
+    ASSERT code IN _DIAGNOSTIC_CODES_fixed
+  END FOR
+END FOR
+```
+
+### Preservation Checking
+
+**Goal**: Verify that for all inputs where the bug condition does NOT hold, the fixed coordinator
+requests the same point set and classifies existing codes the same as the original.
+
+**Pseudocode:**
+```
+FOR ALL input WHERE NOT isBugCondition(input) DO
+  ASSERT requestedDiagnosticPoints_original(input) = requestedDiagnosticPoints_fixed(input)
+  ASSERT _DIAGNOSTIC_CODES_original(stringInverterCodes) = _DIAGNOSTIC_CODES_fixed(stringInverterCodes)
+END FOR
+```
+
+**Testing Approach**: Property-based testing is recommended for preservation because it generates
+many device-type / config combinations automatically and catches edge cases manual tests miss.
+Candidate generators: device type ∈ {INVERTER, BATTERY, METER, COMMUNICATION_MODULE, unmapped},
+`enable_device_sensors` ∈ {true, false}. For every generated non-ESS-buggy case, assert the fixed
+`extra_measure_points` equals what the original produced (captured as a golden set for the
+INVERTER-with-sensors case, e.g. still contains `"5"`–`"10"` and the per-string IDs).
+
+**Test Plan**: Observe UNFIXED behavior for string inverters, disabled sensors, batteries, meters,
+and comm modules first, then assert the fixed code reproduces it.
+
+**Test Cases**:
+1. **String-inverter MPPT/string preserved**: `DeviceType.INVERTER` with sensors on still requests
+   `"5"`–`"10"` and `"96"`/`"70"` .. `"103"`/`"77"` (Requirement 3.1).
+2. **ESS operating-status handling preserved**: ESS `extra` contains `"13146"` and not `"29"`,
+   mirroring `test_ess_operating_status_avoids_point29_collision` (Requirement 3.2).
+3. **Disabled sensors preserved**: With per-device sensors off, inverter requests only `{"29": ...}`
+   and ESS only `{"13146": ...}`; no diagnostic sets (Requirement 3.3).
+4. **Battery/meter/comm preserved**: Each requests its existing point set unchanged (Requirement 3.4).
+5. **String-inverter diagnostic classification preserved**: All existing
+   `INVERTER_DIAGNOSTIC_POINTS` codes remain in `_DIAGNOSTIC_CODES` (Requirement 3.5).
+
+### Unit Tests
+
+- `test_ess_requests_hybrid_mppt_points` — ESS + sensors on requests the eight 13xxx IDs.
+- `test_ess_drops_string_inverter_mppt_points` — ESS + sensors on omits `"5"`–`"10"` (collision fix).
+- `test_ess_mppt_codes_are_diagnostic` — `mppt4_voltage`/`mppt4_current` ∈ `_DIAGNOSTIC_CODES`.
+- `test_inverter_mppt_points_unchanged` — INVERTER still requests `"5"`–`"10"`.
+- `test_const.py` shape test — `ESS_MPPT_DIAGNOSTIC_POINTS` maps the expected IDs to the reused
+  `mpptN_*` codes (mirrors `test_inverter_diagnostic_points_include_per_string`).
+
+### Property-Based Tests
+
+- Generate device type × `enable_device_sensors` combinations; assert the fixed
+  `extra_measure_points` for every non-buggy combination equals the original (preservation).
+- Generate ESS realtime responses with random subsets of MPPT1–4 populated; assert exactly the
+  populated MPPT sensors are produced and unpopulated ones are skipped (Requirement 2.3).
+- Assert for ESS the requested IDs never contain both a `"5"`–`"10"` ID and its 13xxx counterpart
+  (no two IDs share a `mpptN_*` code).
+
+### Integration Tests
+
+- Full `_async_update_data()` flow (HomeAssistant fixture, as in
+  `test_inverter_diagnostic_sensor_is_diagnostic_and_enum`) for an ESS device with per-device
+  sensors on: assert `SungrowDeviceSensor` entities for `mppt1_voltage`/`mppt1_current` etc. are
+  created with `EntityCategory.DIAGNOSTIC`, correct device/state class (VOLTAGE/CURRENT), and the
+  expected names/icons/units matching string inverters.
+- Mixed-plant flow: one `INVERTER` and one `ENERGY_STORAGE_SYSTEM` on the same plant — assert the
+  string inverter surfaces its `"5"`–`"10"` MPPT sensors and the hybrid surfaces its 13xxx MPPT
+  sensors, with no cross-device code collision.
+- Regression: ESS operating-status (`13146`) and battery points still surface as before.

--- a/.kiro/specs/hybrid-mppt-string-sensors/tasks.md
+++ b/.kiro/specs/hybrid-mppt-string-sensors/tasks.md
@@ -1,0 +1,162 @@
+# Implementation Plan
+
+## Overview
+
+Fix SH-family hybrid (ESS) inverters not surfacing MPPT voltage/current diagnostic sensors.
+The coordinator's ESS branch swaps the string-inverter MPPT IDs (`"5"`-`"10"`) for the hybrid
+13xxx MPPT IDs (preserving the `"29"` operating-status drop), a new `ESS_MPPT_DIAGNOSTIC_POINTS`
+map is added to `const.py`, and its values are unioned into `sensor.py`'s `_DIAGNOSTIC_CODES`.
+Tasks follow the exploratory bugfix methodology: exploration test (fails on unfixed code) and
+preservation tests (pass on unfixed code) come before the fix, followed by Fix Checking and
+Preservation Checking.
+
+## Tasks
+
+- [ ] 1. Write bug condition exploration test
+  - **Property 1: Bug Condition** - Hybrid MPPT Sensors Surfaced and Classified Diagnostic
+  - **CRITICAL**: This test MUST FAIL on unfixed code - failure confirms the bug exists
+  - **DO NOT attempt to fix the test or the code when it fails** - the failure is the goal of this task
+  - **NOTE**: This test encodes the expected behavior - it will validate the fix when it passes after implementation
+  - **GOAL**: Surface counterexamples that demonstrate the bug exists (root cause #1: the 13xxx MPPT IDs are never requested for ESS)
+  - **Scoped PBT Approach**: The bug is deterministic per device type/config, so scope the property to the concrete failing configuration: `DeviceType.ENERGY_STORAGE_SYSTEM` + `CONF_ENABLE_DEVICE_SENSORS: True`. Assert the universal invariant across the fixed set of hybrid MPPT IDs.
+  - Add to `tests/test_coordinator.py`, mirroring `test_ess_operating_status_avoids_point29_collision`: build a `SungrowPlantCoordinator` with a single `DeviceType.ENERGY_STORAGE_SYSTEM` device and `CONF_ENABLE_DEVICE_SENSORS: True`, mock `plants.async_get_device_realtime` (AsyncMock) and `plants.async_get_realtime_data`, run `await coordinator._async_update_data()`, and capture `plants.async_get_device_realtime.await_args.kwargs["extra_measure_points"]`
+  - Assertion A (from Bug Condition / isBugCondition in design): `{"13001","13002","13105","13106","13107","13108","13109","13110"}` is a subset of the captured `extra` (FAILS on unfixed code - none are present)
+  - Assertion B (collision source, from design Property 2 final clause): for the ESS `extra`, the string-inverter MPPT IDs `{"5","6","7","8","9","10"}` are absent (FAILS on unfixed code - they are present)
+  - Assertion C (diagnostic classification, from expectedBehavior): add to `tests/test_sensor.py` that `mppt4_voltage` and `mppt4_current` are members of `sensor._DIAGNOSTIC_CODES` (FAILS on unfixed code - only mppt1-3 present)
+  - Run the tests on UNFIXED code
+  - **EXPECTED OUTCOME**: Tests FAIL (this is correct - it proves the bug exists)
+  - Document counterexamples found: ESS `extra_measure_points` contains no 13xxx MPPT IDs and still contains `"5"`-`"10"`; `mppt4_voltage`/`mppt4_current` not in `_DIAGNOSTIC_CODES`
+  - Mark task complete when the tests are written, run, and the failures are documented
+  - _Requirements: 1.1, 1.2, 2.1, 2.2_
+
+- [ ] 2. Write preservation property tests (BEFORE implementing fix)
+  - **Property 2: Preservation** - Non-Buggy Device/Config Behavior Unchanged
+  - **IMPORTANT**: Follow observation-first methodology - run the UNFIXED code first, record actual outputs, then assert those observed outputs
+  - **GOAL**: Capture the baseline behavior of every non-buggy path so the fix can be proven to leave it byte-for-byte identical
+  - Observe on UNFIXED code and record: for `DeviceType.INVERTER` + sensors on, `extra` contains `"5"`-`"10"` and per-string IDs (`"96"`/`"70"` .. `"103"`/`"77"`); for ESS, `extra["13146"] == "operating_status"` and `"29"` absent; for sensors off, inverter requests only `{"29": ...}` and ESS only `{"13146": ...}` with no diagnostic set; for BATTERY/METER/COMMUNICATION_MODULE, each requests its existing point set; and all `INVERTER_DIAGNOSTIC_POINTS.values()` are in `_DIAGNOSTIC_CODES`
+  - Write property-based tests (mirroring `test_ess_operating_status_avoids_point29_collision` in `tests/test_coordinator.py`) that generate device type ∈ {INVERTER, BATTERY, METER, COMMUNICATION_MODULE, unmapped} × `enable_device_sensors` ∈ {true, false}, and for each non-buggy combination assert the captured `extra_measure_points` equals the observed golden set
+  - Add a preservation assertion in `tests/test_sensor.py` that all existing `INVERTER_DIAGNOSTIC_POINTS.values()` remain members of `_DIAGNOSTIC_CODES` (Requirement 3.5)
+  - Run the tests on UNFIXED code
+  - **EXPECTED OUTCOME**: Tests PASS (this confirms the baseline behavior to preserve)
+  - Mark task complete when tests are written, run, and passing on unfixed code
+  - _Requirements: 3.1, 3.2, 3.3, 3.4, 3.5_
+
+- [ ] 3. Fix for hybrid (ESS) MPPT diagnostic sensors not being surfaced
+
+  - [ ] 3.1 Add `ESS_MPPT_DIAGNOSTIC_POINTS` to const.py
+    - In `custom_components/sungrow/const.py`, add `ESS_MPPT_DIAGNOSTIC_POINTS: dict[str, str]` mapping the hybrid 13xxx MPPT IDs to the reused string-inverter code names: `"13001"→mppt1_voltage`, `"13002"→mppt1_current`, `"13105"→mppt2_voltage`, `"13106"→mppt2_current`, `"13107"→mppt3_voltage`, `"13108"→mppt3_current`, `"13109"→mppt4_voltage`, `"13110"→mppt4_current`
+    - Add the explanatory comment noting these IDs already exist in `measure_points_data.py` (units V/A) and classify by unit automatically
+    - _Bug_Condition: isBugCondition(input) where deviceType = ENERGY_STORAGE_SYSTEM AND enableDeviceSensors AND modelReportsHybridMppt_
+    - _Expected_Behavior: expectedBehavior(result) - hybrid MPPT IDs available to be requested and produced codes reuse mpptN_* names_
+    - _Preservation: no existing const changed; new map is additive_
+    - _Requirements: 2.1_
+
+  - [ ] 3.2 Swap string-inverter MPPT IDs for the 13xxx IDs in the coordinator ESS branch
+    - In `custom_components/sungrow/coordinator.py`, import `ESS_MPPT_DIAGNOSTIC_POINTS` alongside `INVERTER_DIAGNOSTIC_POINTS`
+    - In the `ENERGY_STORAGE_SYSTEM` diagnostic branch (~line 538), rework the existing `"29"`-drop comprehension so that for ESS it ALSO removes the string-inverter MPPT IDs `{"5","6","7","8","9","10"}`, then merge `ESS_MPPT_DIAGNOSTIC_POINTS` in (`diagnostic = {**diagnostic, **ESS_MPPT_DIAGNOSTIC_POINTS}`)
+    - Preserve the `"29"` drop exactly so the `13146`/`29` operating_status collision handling (#182) is unchanged
+    - Leave the `INVERTER` branch, battery/meter/comm branches, and the sensors-off path untouched
+    - _Bug_Condition: isBugCondition(input) - ESS + sensors on + reports hybrid MPPT_
+    - _Expected_Behavior: expectedBehavior(result) - requested extra contains the eight 13xxx IDs and none of "5"-"10"; requesting both would collide on mpptN_* codes_
+    - _Preservation: "29" dropped, "13146" requested; INVERTER and other device branches unchanged_
+    - _Requirements: 2.1, 2.3, 3.1, 3.2_
+
+  - [ ] 3.3 Union `ESS_MPPT_DIAGNOSTIC_POINTS.values()` into `_DIAGNOSTIC_CODES` in sensor.py
+    - In `custom_components/sungrow/sensor.py`, import `ESS_MPPT_DIAGNOSTIC_POINTS` from `.const`
+    - Add `| frozenset(ESS_MPPT_DIAGNOSTIC_POINTS.values())` to the `_DIAGNOSTIC_CODES` union (idempotent for mppt1-3; adds the new `mppt4_voltage`/`mppt4_current`)
+    - _Bug_Condition: isBugCondition(input) - produced hybrid MPPT codes must be diagnostic_
+    - _Expected_Behavior: expectedBehavior(result) - every produced hybrid MPPT code ∈ _DIAGNOSTIC_CODES so sensors land in the Diagnostic section_
+    - _Preservation: union is additive; all existing INVERTER/battery/comm codes remain members_
+    - _Requirements: 2.2, 3.5_
+
+  - [ ] 3.4 Verify bug condition exploration test now passes
+    - **Property 1: Expected Behavior** - Hybrid MPPT Sensors Surfaced and Classified Diagnostic
+    - **IMPORTANT**: Re-run the SAME tests from task 1 - do NOT write new tests
+    - The tests from task 1 encode the expected behavior; when they pass they confirm the fix satisfies it
+    - Run the bug condition exploration tests from task 1
+    - **EXPECTED OUTCOME**: Tests PASS (confirms the bug is fixed - the eight 13xxx IDs are requested, `"5"`-`"10"` are dropped for ESS, and `mppt4_*` are diagnostic)
+    - _Requirements: 2.1, 2.2_
+
+  - [ ] 3.5 Verify preservation tests still pass
+    - **Property 2: Preservation** - Non-Buggy Device/Config Behavior Unchanged
+    - **IMPORTANT**: Re-run the SAME tests from task 2 - do NOT write new tests
+    - Run the preservation property tests from task 2
+    - **EXPECTED OUTCOME**: Tests PASS (confirms no regressions across string inverters, disabled sensors, batteries, meters, comm modules, and ESS operating-status handling)
+    - _Requirements: 3.1, 3.2, 3.3, 3.4, 3.5_
+
+- [ ] 4. Fix Checking tests (per design Testing Strategy)
+  - Add focused unit tests in `tests/test_coordinator.py` and `tests/test_sensor.py` per the design's Fix Checking pseudocode (`FOR ALL X WHERE isBugCondition(X)`):
+  - `test_ess_requests_hybrid_mppt_points` — ESS + sensors on requests the eight 13xxx IDs (subset assertion)
+  - `test_ess_drops_string_inverter_mppt_points` — ESS + sensors on omits `"5"`-`"10"` (collision fix; the 13xxx set and `"5"`-`"10"` are disjoint in the requested points)
+  - `test_ess_mppt_codes_are_diagnostic` — `mppt4_voltage`/`mppt4_current` ∈ `_DIAGNOSTIC_CODES`
+  - Add `tests/test_const.py` shape test — `ESS_MPPT_DIAGNOSTIC_POINTS` maps the expected 13xxx IDs to the reused `mpptN_*` codes (mirror `test_inverter_diagnostic_points_include_per_string`)
+  - Property-based / partial-MPPT (Requirement 2.3): with a mocked ESS realtime response returning only MPPT1/MPPT2 points, assert only those sensors are produced and MPPT3/MPPT4 are silently skipped
+  - Run all tests; **EXPECTED OUTCOME**: PASS on fixed code
+  - _Requirements: 2.1, 2.2, 2.3_
+
+- [ ] 5. Preservation Checking tests (per design Testing Strategy)
+  - Add tests per the design's Preservation Checking pseudocode (`FOR ALL X WHERE NOT isBugCondition(X)`), asserting the fixed `extra_measure_points` equals the original golden set:
+  - `test_inverter_mppt_points_unchanged` — `DeviceType.INVERTER` + sensors on still requests `"5"`-`"10"` and per-string IDs (`"96"`/`"70"` .. `"103"`/`"77"`) (Requirement 3.1)
+  - ESS operating-status preserved — ESS `extra` contains `"13146"` and not `"29"`, mirroring `test_ess_operating_status_avoids_point29_collision` (Requirement 3.2)
+  - Disabled-sensors preserved — inverter requests only `{"29": ...}` and ESS only `{"13146": ...}`, no diagnostic sets (Requirement 3.3)
+  - Battery/meter/comm preserved — each requests its existing point set unchanged (Requirement 3.4)
+  - String-inverter diagnostic classification preserved — all existing `INVERTER_DIAGNOSTIC_POINTS.values()` remain in `_DIAGNOSTIC_CODES` (Requirement 3.5)
+  - Prefer a property-based generator over device type × `enable_device_sensors` combinations, asserting equality with the observed original set for every non-buggy case
+  - Run all tests; **EXPECTED OUTCOME**: PASS on fixed code (no regressions)
+  - _Requirements: 3.1, 3.2, 3.3, 3.4, 3.5_
+
+- [ ] 6. Checkpoint - Ensure all tests pass
+  - Run the full suite (`pytest tests/ --run` equivalent for this repo, e.g. `pytest tests/`) and confirm exploration, preservation, fix-checking, and preservation-checking tasks all pass
+  - Confirm the bug condition exploration tests from task 1 (which failed pre-fix) now pass and the preservation tests remain green
+  - Ensure all tests pass; ask the user if questions arise
+
+## Task Dependency Graph
+
+```json
+{
+  "waves": [
+    { "wave": 1, "tasks": ["1"], "description": "Bug condition exploration test - FAILS on unfixed code" },
+    { "wave": 2, "tasks": ["2"], "description": "Preservation property tests - PASS on unfixed code (observation-first baseline)" },
+    { "wave": 3, "tasks": ["3.1"], "description": "const.py: add ESS_MPPT_DIAGNOSTIC_POINTS (prerequisite for 3.2 and 3.3)" },
+    { "wave": 4, "tasks": ["3.2", "3.3"], "description": "coordinator.py swap and sensor.py union - independent, may run in parallel" },
+    { "wave": 5, "tasks": ["3.4", "3.5"], "description": "Re-run Task 1 (now PASS) and Task 2 (still PASS)" },
+    { "wave": 6, "tasks": ["4", "5"], "description": "Fix Checking and Preservation Checking tests" },
+    { "wave": 7, "tasks": ["6"], "description": "Checkpoint - full suite green" }
+  ]
+}
+```
+
+```
+Task 1 (Bug Condition exploration test - FAILS on unfixed code)
+   │   confirms bug exists (no 13xxx requested; "5"-"10" present; mppt4_* not diagnostic)
+   ▼
+Task 2 (Preservation property tests - PASS on unfixed code)
+   │   captures baseline (observation-first) for all non-buggy paths
+   ▼
+Task 3 (Fix implementation)
+   ├─ 3.1 const.py: add ESS_MPPT_DIAGNOSTIC_POINTS
+   │       │
+   │       ├─────────────┐
+   │       ▼             ▼
+   ├─ 3.2 coordinator.py │  (imports + uses 3.1)
+   │   swap "5"-"10" for │
+   │   13xxx (keep "29") │
+   │                     │
+   └─ 3.3 sensor.py ─────┘  (imports + unions 3.1 values into _DIAGNOSTIC_CODES)
+       │
+       ├─ 3.4 Re-run Task 1 tests → now PASS (Property 1: Expected Behavior)
+       └─ 3.5 Re-run Task 2 tests → still PASS (Property 2: Preservation)
+   ▼
+Task 4 (Fix Checking tests)   ← depends on 3.1, 3.2, 3.3
+   │
+Task 5 (Preservation Checking tests)   ← depends on 3.2, 3.3
+   ▼
+Task 6 (Checkpoint - full suite green)   ← depends on 1,2,3,4,5
+```
+
+## Notes
+
+- Tasks 1 and 2 must be completed and run against the UNFIXED code before Task 3.
+- 3.1 is a prerequisite for both 3.2 and 3.3 (both import `ESS_MPPT_DIAGNOSTIC_POINTS`); 3.2 and 3.3 are independent of each other and may be done in parallel.
+- 3.4/3.5 gate progression: do not proceed to Tasks 4-6 until the Property 1 test passes and the Property 2 tests remain green.
+- Repo runs pytest with pytest-asyncio; mirror `test_ess_operating_status_avoids_point29_collision` (coordinator), `test_inverter_diagnostic_points_include_per_string` (const), and the diagnostic-classification tests in `test_sensor.py`.

--- a/.kiro/specs/transport-mode-selector/.config.kiro
+++ b/.kiro/specs/transport-mode-selector/.config.kiro
@@ -1,0 +1,1 @@
+{"specId": "9b514785-c81d-47f6-9d56-2e72b197602b", "workflowType": "requirements-first", "specType": "feature"}

--- a/.kiro/specs/transport-mode-selector/design.md
+++ b/.kiro/specs/transport-mode-selector/design.md
@@ -1,0 +1,390 @@
+# Design Document: Transport Mode Selector
+
+## Overview
+
+This design adds an explicit transport-mode selector to the Sungrow iSolarCloud config flow so that users manually setting up the integration can choose between **Cloud Only**, **Cloud + Modbus** (hybrid), and **Modbus Only** connectivity before entering any credentials. The change introduces a new first step in the user-facing config flow, adapts the options and reconfigure flows, bumps the config-entry VERSION from 2 to 3 with a migration path, and adds a shared TCP reachability helper for Modbus host validation.
+
+The actual hybrid data-path logic (coordinator merging cloud + Modbus readings) is explicitly **out of scope** — deferred to issue #217. This spec covers only the flow UI, data shape, migration, options/reconfigure adaptation, runtime branching stubs, and translations.
+
+**Validates:** Requirements 1–12
+
+---
+
+## Architecture
+
+### High-Level Flow Diagram
+
+```mermaid
+flowchart TD
+    A[User clicks Add Integration] --> B[Transport Step<br/>Cloud Only / Cloud+Modbus / Modbus Only]
+    B -->|Cloud Only| C[Cloud Credentials Step]
+    B -->|Cloud + Modbus| C
+    B -->|Modbus Only| G[Local Setup Step<br/>host, serial, model]
+
+    C --> D{Cloud+Modbus?}
+    D -->|Yes| E[Modbus Host Step<br/>+ Reachability Test]
+    D -->|No| F[OAuth Authorization]
+    E -->|Success| F
+    E -->|Failure| E
+    F --> H[Create Entry]
+    G -->|Reachability Test OK| H
+```
+
+### Cloud Only Sequence
+
+```mermaid
+sequenceDiagram
+    participant U as User
+    participant CF as ConfigFlow
+    participant HA as HomeAssistant
+
+    U->>CF: async_step_user(transport=cloud_only)
+    CF->>U: Show cloud credentials form
+    U->>CF: Submit credentials
+    CF->>HA: Create entry (tokenless, triggers reauth)
+    HA->>CF: async_step_reauth
+    CF->>U: OAuth authorization flow
+    U->>CF: Code received
+    CF->>HA: Update entry with tokens
+```
+
+### Cloud + Modbus Sequence
+
+```mermaid
+sequenceDiagram
+    participant U as User
+    participant CF as ConfigFlow
+    participant TCP as async_test_modbus_host
+    participant HA as HomeAssistant
+
+    U->>CF: async_step_user(transport=cloud_modbus)
+    CF->>U: Show cloud credentials form
+    U->>CF: Submit credentials
+    CF->>U: Show Modbus host form
+    U->>CF: Submit host
+    CF->>TCP: TCP connect host:502 (5s timeout)
+    alt Success
+        TCP-->>CF: True
+        CF->>HA: Create entry (tokenless + modbus_host)
+        HA->>CF: async_step_reauth (triggers OAuth)
+    else Failure
+        TCP-->>CF: False
+        CF->>U: Show error "host_unreachable", retry
+    end
+```
+
+### Modbus Only Sequence
+
+```mermaid
+sequenceDiagram
+    participant U as User
+    participant CF as ConfigFlow
+    participant TCP as async_test_modbus_host
+    participant HA as HomeAssistant
+
+    U->>CF: async_step_user(transport=modbus_only)
+    CF->>U: Show local setup form (host, serial, model)
+    U->>CF: Submit local details
+    CF->>TCP: TCP connect host:502 (5s timeout)
+    alt Success
+        TCP-->>CF: True
+        CF->>HA: Create entry (modbus_only)
+    else Failure
+        TCP-->>CF: False
+        CF->>U: Show error "host_unreachable", retry
+    end
+```
+
+### Options Flow Transport Switching
+
+```mermaid
+sequenceDiagram
+    participant U as User
+    participant OF as OptionsFlow
+    participant TCP as async_test_modbus_host
+
+    Note over OF: Entry is cloud_only
+    U->>OF: Provide modbus_host
+    OF->>TCP: TCP connect host:502
+    alt Reachable
+        TCP-->>OF: True
+        OF->>OF: Update entry: transport=cloud_modbus, add modbus_host
+        OF->>OF: Trigger reload
+    else Unreachable
+        TCP-->>OF: False
+        OF->>U: Error, keep cloud_only
+    end
+
+    Note over OF: Entry is cloud_modbus
+    U->>OF: Clear modbus_host
+    OF->>OF: Update entry: transport=cloud_only, remove modbus_host
+    OF->>OF: Trigger reload
+```
+
+---
+
+## Components and Interfaces
+
+### Modified Files
+
+| File | Changes | Requirements |
+|------|---------|--------------|
+| `custom_components/sungrow/const.py` | Add `TRANSPORT_CLOUD_ONLY`, `TRANSPORT_CLOUD_MODBUS` constants | Req 1 |
+| `custom_components/sungrow/config_flow.py` | New `async_step_user` (transport selector), rename old user step to `async_step_cloud_credentials`, add `async_step_modbus_host`, add `async_step_local_setup`, adapt reconfigure for hybrid, bump VERSION to 3 | Req 2, 3, 8 |
+| `custom_components/sungrow/helpers.py` | New file: `async_test_modbus_host(host, port=502, timeout=5) -> bool` | Req 12 |
+| `custom_components/sungrow/__init__.py` | Extend `async_migrate_entry` (v2→v3), adapt runtime branching in `async_setup_entry` | Req 5, 11 |
+| `custom_components/sungrow/strings.json` | Add transport step, modbus host step, and options flow translation keys | Req 10 |
+| `custom_components/sungrow/translations/en.json` | Mirror all new keys from `strings.json` | Req 10 |
+
+### New Helper: `async_test_modbus_host`
+
+```python
+# custom_components/sungrow/helpers.py
+
+async def async_test_modbus_host(host: str, port: int = 502, timeout: float = 5.0) -> bool:
+    """Test TCP reachability of a Modbus host.
+
+    Attempts a TCP connection to host:port with the given timeout.
+    Returns True if connection succeeds (socket is closed immediately).
+    Returns False on any failure (timeout, refused, DNS error) without raising.
+    """
+```
+
+**Validates:** Requirement 12
+
+### Config Flow API Changes
+
+| Method | Action |
+|--------|--------|
+| `async_step_user` | **Replaced**: now shows transport selector (3 choices). Branches to `async_step_cloud_credentials` or `async_step_local_setup`. |
+| `async_step_cloud_credentials` | **New name** for old `async_step_user` logic (app key, secret, ID, gateway, redirect URI). Creates tokenless entry (or proceeds to modbus host step for hybrid). |
+| `async_step_modbus_host` | **New**: text field for WiNet-S IP. Runs `async_test_modbus_host`. On success → creates entry or proceeds to OAuth. On failure → error + retry. |
+| `async_step_local_setup` | **New**: collects host, serial, model for modbus_only path. Runs reachability test. On success → creates entry with `TRANSPORT_MODBUS_ONLY`. |
+| `async_step_reconfigure` | **Modified**: for `cloud_modbus` entries, after credentials submission shows `async_step_modbus_host` before finalizing. |
+| `SungrowOptionsFlow.async_step_init` | **Modified**: for `cloud_only` shows optional modbus_host field; for `cloud_modbus` shows host + clear option. |
+
+### Constants Added to `const.py`
+
+```python
+TRANSPORT_CLOUD_ONLY = "cloud_only"
+TRANSPORT_CLOUD_MODBUS = "cloud_modbus"
+# TRANSPORT_MODBUS_ONLY already exists as "modbus_only"
+```
+
+**Validates:** Requirement 1
+
+---
+
+## Data Models
+
+### Config Entry Data Shapes
+
+#### Cloud Only (`transport = "cloud_only"`)
+
+```python
+{
+    "transport": "cloud_only",
+    "app_key": str,
+    "app_secret": str,
+    "app_id": str,
+    "gateway": str,         # e.g. "Europe"
+    "redirect_uri": str,
+    "tokens": dict,         # OAuth tokens
+    # NO modbus_host
+}
+```
+
+**Validates:** Requirement 4.1
+
+#### Cloud + Modbus (`transport = "cloud_modbus"`)
+
+```python
+{
+    "transport": "cloud_modbus",
+    "app_key": str,
+    "app_secret": str,
+    "app_id": str,
+    "gateway": str,
+    "redirect_uri": str,
+    "tokens": dict,
+    "modbus_host": str,     # WiNet-S IP/hostname
+}
+```
+
+**Validates:** Requirement 4.2
+
+#### Modbus Only (`transport = "modbus_only"`)
+
+```python
+{
+    "transport": "modbus_only",
+    "serial": str,
+    "model": str,
+    "modbus_host": str,
+    # NO app_key, app_secret, app_id, gateway, redirect_uri, tokens
+}
+```
+
+**Validates:** Requirement 4.3
+
+### Migration: v2 → v3
+
+```python
+async def async_migrate_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> bool:
+    if config_entry.version == 1:
+        # Existing v1→v2: scan_interval minutes → seconds
+        old_interval = config_entry.options.get(CONF_SCAN_INTERVAL, 5)
+        new_options = {**config_entry.options, CONF_SCAN_INTERVAL: old_interval * 60}
+        hass.config_entries.async_update_entry(config_entry, options=new_options, version=2)
+
+    if config_entry.version == 2:
+        # v2→v3: back-fill transport field
+        new_data = dict(config_entry.data)
+        if CONF_TRANSPORT not in new_data:
+            new_data[CONF_TRANSPORT] = TRANSPORT_CLOUD_ONLY
+        hass.config_entries.async_update_entry(config_entry, data=new_data, version=3)
+
+    return True
+```
+
+**Validates:** Requirement 5
+
+### Runtime Branching (`async_setup_entry`)
+
+```python
+transport = entry.data.get(CONF_TRANSPORT)
+if transport is None:
+    _LOGGER.warning("Config entry %s missing CONF_TRANSPORT; defaulting to cloud_only", entry.title)
+    transport = TRANSPORT_CLOUD_ONLY
+
+if transport == TRANSPORT_MODBUS_ONLY:
+    # Existing Modbus-only setup path (unchanged)
+    ...
+elif transport == TRANSPORT_CLOUD_MODBUS:
+    # Cloud setup (same as cloud_only for now)
+    # Log that hybrid mode is noted; actual Modbus wiring deferred to #217
+    _LOGGER.info("Entry %s configured for cloud+modbus; Modbus wiring deferred to #217", entry.title)
+    ...  # standard cloud coordinator setup
+else:
+    # cloud_only (default)
+    ...  # standard cloud coordinator setup
+```
+
+**Validates:** Requirement 11
+
+---
+
+## Correctness Properties
+
+*A property is a characteristic or behavior that should hold true across all valid executions of a system — essentially, a formal statement about what the system should do. Properties serve as the bridge between human-readable specifications and machine-verifiable correctness guarantees.*
+
+### Property 1: Entry data shape matches transport mode schema
+
+*For any* valid config entry data dictionary, if `transport` is `"cloud_only"` then the data contains all cloud credential fields (`app_key`, `app_secret`, `app_id`, `gateway`, `redirect_uri`) and does NOT contain `modbus_host`; if `transport` is `"cloud_modbus"` then the data contains all cloud credential fields AND `modbus_host`; if `transport` is `"modbus_only"` then the data contains `serial`, `model`, `modbus_host` and does NOT contain any cloud credential fields.
+
+**Validates: Requirements 4.1, 4.2, 4.3**
+
+### Property 2: v2→v3 migration correctly sets or preserves transport
+
+*For any* version-2 config entry, after migration to v3: if `CONF_TRANSPORT` was absent, `entry.data["transport"]` equals `"cloud_only"`; if `CONF_TRANSPORT` was already `"modbus_only"`, it remains `"modbus_only"`. In both cases the entry version is 3.
+
+**Validates: Requirements 5.2, 5.3, 5.4**
+
+### Property 3: v1→v3 chained migration preserves semantics
+
+*For any* version-1 config entry with a positive integer `scan_interval` option (in minutes), after full migration the entry is at version 3, the `scan_interval` option equals the original value multiplied by 60, and `entry.data["transport"]` is set (defaulting to `"cloud_only"` when absent).
+
+**Validates: Requirements 5.5, 5.6**
+
+### Property 4: Translation key parity
+
+*For any* key path present in `strings.json` under the `config` or `options` sections, the same key path exists in `translations/en.json` with a non-empty English string value.
+
+**Validates: Requirement 10.4**
+
+### Property 5: Reachability test uses correct port and timeout
+
+*For any* host string passed to `async_test_modbus_host`, the function attempts a TCP connection on port 502 with a timeout of 5 seconds.
+
+**Validates: Requirements 12.1, 12.2**
+
+### Property 6: Reachability test returns bool without exceptions
+
+*For any* host string, `async_test_modbus_host` returns `True` when the TCP connection succeeds (and closes the socket) or `False` when it fails (timeout, refused, DNS error) — it never raises an unhandled exception to the caller.
+
+**Validates: Requirements 12.3, 12.4**
+
+---
+
+## Error Handling
+
+| Scenario | Handling | User Experience | Requirement |
+|----------|----------|-----------------|-------------|
+| Modbus host unreachable (timeout/refused) | `async_test_modbus_host` returns False | Error message on form: "The WiNet-S host is unreachable on port 502. Check the IP and ensure the dongle is online." User can correct and retry. | Req 3.4, 6.7, 8.5 |
+| DNS resolution failure for host | Caught as `OSError` inside helper | Same UX as unreachable — shown as host_unreachable error. | Req 12.4 |
+| Missing `CONF_TRANSPORT` at runtime | Default to `cloud_only` + warning log | Entry loads normally; user is not interrupted. Migration should have prevented this. | Req 11.4 |
+| Migration from v1 with missing scan_interval | Default to 5 (minutes → 300 seconds) | Transparent — existing behaviour preserved. | Req 5.5 |
+| OAuth failure after hybrid credentials step | Existing `_finish_error_result` path | Manual code entry form shown (unchanged behaviour). | — |
+| Reconfigure modbus host fails reachability | Error on form, entry data unchanged | User can correct the address or cancel. | Req 8.5 |
+| Options flow host switch fails reachability | Error on form, transport mode unchanged | Entry keeps its current mode; user informed. | Req 6.7 |
+
+---
+
+## Testing Strategy
+
+### Test Framework
+
+- **pytest** + **pytest-asyncio** (existing project setup)
+- **Property-based testing**: [Hypothesis](https://hypothesis.readthedocs.io/) (already present in `.hypothesis/` directory)
+- Minimum **100 iterations** per property test
+
+### Unit Tests (Example-Based)
+
+| Test | Validates |
+|------|-----------|
+| `test_step_user_shows_transport_selector` | Req 2.1 |
+| `test_cloud_only_flow_creates_correct_entry` | Req 2.2, 4.1 |
+| `test_cloud_modbus_flow_creates_correct_entry` | Req 2.3, 4.2 |
+| `test_modbus_only_flow_creates_correct_entry` | Req 2.4, 4.3 |
+| `test_modbus_host_step_shown_after_credentials_for_hybrid` | Req 3.1 |
+| `test_zeroconf_prefills_host_in_hybrid_flow` | Req 3.2 |
+| `test_host_unreachable_shows_error` | Req 3.4 |
+| `test_host_reachable_proceeds` | Req 3.5 |
+| `test_options_flow_cloud_only_shows_modbus_field` | Req 6.1 |
+| `test_options_flow_switch_to_hybrid` | Req 6.3 |
+| `test_options_flow_switch_back_to_cloud_only` | Req 6.5 |
+| `test_options_flow_modbus_only_no_switch` | Req 6.6 |
+| `test_zeroconf_unchanged` | Req 7.1, 7.2 |
+| `test_reconfigure_cloud_modbus_shows_host_step` | Req 8.2 |
+| `test_reconfigure_host_failure_shows_error` | Req 8.5 |
+| `test_runtime_missing_transport_defaults_cloud_only` | Req 11.4 |
+
+### Property-Based Tests (Hypothesis)
+
+Each property test runs a minimum of 100 iterations. Tests are tagged with the property they validate.
+
+| Test | Property | Tag |
+|------|----------|-----|
+| `test_entry_data_shape_per_transport_mode` | Property 1 | `Feature: transport-mode-selector, Property 1: Entry data shape matches transport mode schema` |
+| `test_v2_to_v3_migration_transport_field` | Property 2 | `Feature: transport-mode-selector, Property 2: v2→v3 migration correctly sets or preserves transport` |
+| `test_v1_to_v3_chained_migration` | Property 3 | `Feature: transport-mode-selector, Property 3: v1→v3 chained migration preserves semantics` |
+| `test_translation_key_parity` | Property 4 | `Feature: transport-mode-selector, Property 4: Translation key parity` |
+| `test_reachability_port_and_timeout` | Property 5 | `Feature: transport-mode-selector, Property 5: Reachability test uses correct port and timeout` |
+| `test_reachability_returns_bool_no_exceptions` | Property 6 | `Feature: transport-mode-selector, Property 6: Reachability test returns bool without exceptions` |
+
+### Integration Tests
+
+| Test | Validates |
+|------|-----------|
+| `test_setup_entry_cloud_only_creates_cloud_coordinator` | Req 11.1 |
+| `test_setup_entry_cloud_modbus_logs_deferred` | Req 11.2 |
+| `test_setup_entry_modbus_only_creates_modbus_coordinator` | Req 11.3 |
+| `test_full_migration_v1_through_v3` | Req 5.6 |
+
+### Smoke Tests
+
+| Test | Validates |
+|------|-----------|
+| `test_constants_defined` | Req 1.1, 1.2, 1.3 |
+| `test_config_flow_version_is_3` | Req 5.1 |
+| `test_translation_keys_exist` | Req 10.1, 10.2, 10.3 |

--- a/.kiro/specs/transport-mode-selector/requirements.md
+++ b/.kiro/specs/transport-mode-selector/requirements.md
@@ -1,0 +1,167 @@
+# Requirements Document
+
+## Introduction
+
+This spec adds an explicit transport-mode selector to the Sungrow iSolarCloud config flow so that users manually setting up the integration via the UI can choose between Cloud Only, Cloud + Modbus (hybrid), or Modbus Only connectivity. This is a **breaking change** (`feat!`) that bumps the config-entry VERSION from 2 to 3 and introduces a migration step to back-fill `transport: cloud_only` on legacy cloud entries that currently have no `CONF_TRANSPORT` field.
+
+The actual hybrid polling/merge logic for the "Cloud + Modbus" data path is out of scope (see #217). This spec covers only the setup-flow UI, config-entry data shape, migration, options-flow switching, reconfigure adaptation, and translation strings.
+
+Reference: [GitHub Issue #216](https://github.com/KRoperUK/sungrow-hass/issues/216)
+
+## Glossary
+
+- **Config_Flow**: The Home Assistant config flow (`SungrowConfigFlow`) that guides a user through integration setup.
+- **Options_Flow**: The Home Assistant options flow (`SungrowOptionsFlow`) that lets a user change runtime settings after setup.
+- **Reconfigure_Flow**: The Home Assistant reconfigure flow that lets a user change entry credentials or connection details.
+- **Config_Entry**: A Home Assistant `ConfigEntry` object persisting the integration's configuration data.
+- **Transport_Mode**: A string field (`CONF_TRANSPORT`) on the Config_Entry's `data` dict indicating how the integration communicates with the inverter/plant. One of: `cloud_only`, `cloud_modbus`, `modbus_only`.
+- **Cloud_Only**: Transport mode where data is fetched exclusively via the iSolarCloud REST API.
+- **Cloud_Modbus**: Transport mode where cloud is used for plant aggregates/tariffs and Modbus TCP is preferred for fast electrical points.
+- **Modbus_Only**: Transport mode where data is fetched exclusively via local Modbus TCP with no cloud credentials.
+- **WiNet_S**: The Sungrow WiNet-S communication dongle that exposes a Modbus TCP interface on the local network.
+- **Migration**: The `async_migrate_entry` function that upgrades old Config_Entry schemas to the current VERSION.
+- **Zeroconf_Entry**: A Config_Entry created automatically via mDNS discovery of a WiNet_S dongle.
+- **Transport_Step**: The new config-flow step presenting the three transport-mode choices to the user.
+- **Host_Reachability_Test**: A TCP connection attempt to the user-supplied WiNet_S host on the Modbus port (502) to confirm the device is accessible before committing the entry.
+- **TRANSPORT_CLOUD_ONLY**: The constant string `"cloud_only"` stored in `entry.data[CONF_TRANSPORT]`.
+- **TRANSPORT_CLOUD_MODBUS**: The constant string `"cloud_modbus"` stored in `entry.data[CONF_TRANSPORT]`.
+- **TRANSPORT_MODBUS_ONLY**: The existing constant string `"modbus_only"` stored in `entry.data[CONF_TRANSPORT]`.
+
+## Requirements
+
+### Requirement 1: Transport Mode Constants
+
+**User Story:** As a developer, I want well-defined transport-mode constants, so that the codebase uses a single source of truth for valid transport values.
+
+#### Acceptance Criteria
+
+1. THE Config_Flow SHALL define `TRANSPORT_CLOUD_ONLY` as the string `"cloud_only"` in `const.py`.
+2. THE Config_Flow SHALL define `TRANSPORT_CLOUD_MODBUS` as the string `"cloud_modbus"` in `const.py`.
+3. THE Config_Flow SHALL continue to use the existing `TRANSPORT_MODBUS_ONLY` constant (`"modbus_only"`) unchanged.
+
+### Requirement 2: Transport Step in the User Config Flow
+
+**User Story:** As a user setting up the integration manually, I want to choose my transport mode before entering credentials, so that the flow only asks for information relevant to my chosen mode.
+
+#### Acceptance Criteria
+
+1. WHEN the user initiates a manual setup via `async_step_user`, THE Config_Flow SHALL present the Transport_Step as the first step with a selector offering three choices: Cloud Only, Cloud + Modbus, and Modbus Only.
+2. WHEN the user selects Cloud Only on the Transport_Step, THE Config_Flow SHALL proceed to the existing cloud credentials step (app key, app secret, app ID, gateway, redirect URI) and store `TRANSPORT_CLOUD_ONLY` in the resulting Config_Entry data.
+3. WHEN the user selects Cloud + Modbus on the Transport_Step, THE Config_Flow SHALL proceed to the cloud credentials step followed by a Modbus host step, and store `TRANSPORT_CLOUD_MODBUS` along with `CONF_MODBUS_HOST` in the resulting Config_Entry data.
+4. WHEN the user selects Modbus Only on the Transport_Step, THE Config_Flow SHALL proceed to a local-setup step collecting the WiNet_S host, inverter serial, and model (bypassing all cloud credential steps) and store `TRANSPORT_MODBUS_ONLY` in the resulting Config_Entry data.
+5. THE Config_Flow SHALL display the Transport_Step choices using localised strings from `strings.json` / `translations/en.json`.
+
+### Requirement 3: Cloud + Modbus Host Collection
+
+**User Story:** As a user choosing hybrid mode, I want to provide the WiNet-S IP address (or have it auto-detected) so that the integration can reach the local Modbus interface.
+
+#### Acceptance Criteria
+
+1. WHEN the user selects Cloud + Modbus, THE Config_Flow SHALL show a Modbus host step after the cloud credentials step, with a text field for the WiNet_S IP or hostname.
+2. WHERE zeroconf has already discovered a WiNet_S on the same subnet, THE Config_Flow SHALL pre-fill the host field with the discovered address.
+3. WHEN the user submits the Modbus host step, THE Config_Flow SHALL perform a Host_Reachability_Test by attempting a TCP connection to the supplied host on port 502 with a 5-second timeout.
+4. IF the Host_Reachability_Test fails, THEN THE Config_Flow SHALL display an error on the Modbus host step indicating the host is unreachable and allow the user to correct the address or go back.
+5. WHEN the Host_Reachability_Test succeeds, THE Config_Flow SHALL store the host in `entry.data[CONF_MODBUS_HOST]` and proceed to the OAuth authorization step.
+
+### Requirement 4: Config Entry Data Shape
+
+**User Story:** As a developer, I want a well-defined data shape per transport mode, so that downstream components can reliably branch on transport type.
+
+#### Acceptance Criteria
+
+1. WHEN a Config_Entry has `transport` set to `cloud_only`, THE Config_Entry data SHALL contain `app_key`, `app_secret`, `app_id`, `gateway`, `redirect_uri`, `tokens`, and `transport` fields but SHALL NOT contain `modbus_host`.
+2. WHEN a Config_Entry has `transport` set to `cloud_modbus`, THE Config_Entry data SHALL contain `app_key`, `app_secret`, `app_id`, `gateway`, `redirect_uri`, `tokens`, `transport`, and `modbus_host` fields.
+3. WHEN a Config_Entry has `transport` set to `modbus_only`, THE Config_Entry data SHALL contain `transport`, `serial`, `model`, and `modbus_host` fields but SHALL NOT contain `app_key`, `app_secret`, `app_id`, `gateway`, `redirect_uri`, or `tokens`.
+
+### Requirement 5: Config Entry Migration v2 to v3
+
+**User Story:** As an existing user upgrading the integration, I want my config entries to migrate seamlessly so that the integration continues to function without manual re-setup.
+
+#### Acceptance Criteria
+
+1. THE Config_Flow SHALL set `VERSION = 3` on the `SungrowConfigFlow` class.
+2. WHEN `async_migrate_entry` is called with a Config_Entry at version 2, THE Migration SHALL check whether `CONF_TRANSPORT` is present in `entry.data`.
+3. WHEN `CONF_TRANSPORT` is absent from a version-2 Config_Entry, THE Migration SHALL set `entry.data[CONF_TRANSPORT]` to `TRANSPORT_CLOUD_ONLY` and update the entry version to 3.
+4. WHEN `CONF_TRANSPORT` is already `TRANSPORT_MODBUS_ONLY` on a version-2 Config_Entry, THE Migration SHALL leave the transport field unchanged and update the entry version to 3.
+5. THE Migration SHALL preserve the existing v1-to-v2 scan_interval conversion logic unchanged.
+6. WHEN a version-1 Config_Entry is migrated, THE Migration SHALL apply both v1-to-v2 and v2-to-v3 transformations sequentially.
+
+### Requirement 6: Options Flow Transport Mode Switching
+
+**User Story:** As a user who initially set up Cloud Only, I want to upgrade to Cloud + Modbus later from the options flow, so that I can add local Modbus without re-creating the entry.
+
+#### Acceptance Criteria
+
+1. WHILE a Config_Entry has `transport` set to `cloud_only`, THE Options_Flow SHALL show an optional field to enter a WiNet_S Modbus host address.
+2. WHEN the user provides a Modbus host in the Options_Flow for a `cloud_only` entry, THE Options_Flow SHALL perform a Host_Reachability_Test on the supplied host.
+3. IF the Host_Reachability_Test succeeds, THEN THE Options_Flow SHALL update `entry.data[CONF_TRANSPORT]` to `TRANSPORT_CLOUD_MODBUS`, add `CONF_MODBUS_HOST` to `entry.data`, and trigger a reload.
+4. WHILE a Config_Entry has `transport` set to `cloud_modbus`, THE Options_Flow SHALL show the current Modbus host with an option to clear it.
+5. WHEN the user clears the Modbus host field on a `cloud_modbus` entry, THE Options_Flow SHALL update `entry.data[CONF_TRANSPORT]` to `TRANSPORT_CLOUD_ONLY`, remove `CONF_MODBUS_HOST` from `entry.data`, and trigger a reload.
+6. WHILE a Config_Entry has `transport` set to `modbus_only`, THE Options_Flow SHALL NOT offer transport-mode switching (no cloud credentials exist to fall back on).
+7. IF the Host_Reachability_Test fails during Options_Flow switching, THEN THE Options_Flow SHALL display an error and retain the current transport mode unchanged.
+
+### Requirement 7: Zeroconf Entries Unaffected
+
+**User Story:** As a user with auto-discovered WiNet-S entries, I want the transport-mode selector to have no impact on my existing Modbus-only entries, so that local-only setups continue to work without changes.
+
+#### Acceptance Criteria
+
+1. WHEN a WiNet_S is discovered via zeroconf, THE Config_Flow SHALL continue to create the entry with `TRANSPORT_MODBUS_ONLY` as today.
+2. THE Config_Flow SHALL NOT present the Transport_Step during zeroconf or import flows.
+3. WHEN a zeroconf-created entry is loaded after the v2-to-v3 migration, THE Migration SHALL leave its `transport` field as `modbus_only`.
+
+### Requirement 8: Reconfigure Flow Adaptation
+
+**User Story:** As a user reconfiguring an existing entry, I want the reconfigure flow to adapt to my entry's transport mode, so that I can change the relevant connection details without ambiguity.
+
+#### Acceptance Criteria
+
+1. WHILE the Config_Entry has `transport` set to `cloud_only`, THE Reconfigure_Flow SHALL show the cloud credentials form (app key, app secret, gateway, redirect URI) as today.
+2. WHILE the Config_Entry has `transport` set to `cloud_modbus`, THE Reconfigure_Flow SHALL show the cloud credentials form followed by a Modbus host step allowing the user to update the WiNet_S address.
+3. WHILE the Config_Entry has `transport` set to `modbus_only`, THE Reconfigure_Flow SHALL show only the Modbus host form as today.
+4. WHEN the user updates the Modbus host during reconfigure of a `cloud_modbus` entry, THE Reconfigure_Flow SHALL perform a Host_Reachability_Test before committing the change.
+5. IF the Host_Reachability_Test fails during reconfigure, THEN THE Reconfigure_Flow SHALL display an error and allow the user to correct the address.
+
+### Requirement 9: Breaking Change Semantics
+
+**User Story:** As a maintainer, I want the commit and release to follow conventional-commit `feat!` semantics, so that release-please generates a MAJOR version bump and the CHANGELOG clearly communicates the breaking change.
+
+#### Acceptance Criteria
+
+1. THE commit introducing the VERSION bump to 3 SHALL use the `feat!:` prefix in its conventional commit message.
+2. THE commit message footer SHALL include `BREAKING CHANGE: Config entry VERSION bumped from 2 to 3; existing cloud entries are migrated to include an explicit transport field.`
+3. THE CHANGELOG entry generated by release-please SHALL appear under a "BREAKING CHANGES" heading.
+
+### Requirement 10: Translation Strings
+
+**User Story:** As a user in any supported locale, I want the new transport-mode steps and selectors to have proper translation strings, so that the UI is fully localised.
+
+#### Acceptance Criteria
+
+1. THE Config_Flow SHALL add translation keys for the Transport_Step title, description, and each selector option (Cloud Only, Cloud + Modbus, Modbus Only) in `strings.json`.
+2. THE Config_Flow SHALL add translation keys for the Modbus host step title, description, field labels, and error messages (host unreachable) in `strings.json`.
+3. THE Options_Flow SHALL add translation keys for the new Modbus host field and the transport-switch confirmation in `strings.json`.
+4. THE `translations/en.json` file SHALL mirror all keys added to `strings.json` with English text.
+
+### Requirement 11: Runtime Branching on Transport Mode
+
+**User Story:** As a developer, I want `async_setup_entry` to branch correctly on all three transport modes, so that the right coordinator behaviour is activated for each entry type.
+
+#### Acceptance Criteria
+
+1. WHEN `async_setup_entry` loads a Config_Entry with `transport` set to `cloud_only`, THE integration SHALL set up the cloud coordinator without a Modbus client (existing behaviour).
+2. WHEN `async_setup_entry` loads a Config_Entry with `transport` set to `cloud_modbus`, THE integration SHALL set up the cloud coordinator and note `CONF_MODBUS_HOST` is available for the future hybrid data path (actual Modbus client wiring is deferred to #217).
+3. WHEN `async_setup_entry` loads a Config_Entry with `transport` set to `modbus_only`, THE integration SHALL set up the Modbus-only coordinator (existing behaviour).
+4. IF `CONF_TRANSPORT` is missing from a loaded Config_Entry (should not happen after migration), THEN THE integration SHALL default to `cloud_only` behaviour and log a warning.
+
+### Requirement 12: Host Reachability Test Specification
+
+**User Story:** As a user, I want setup to verify the WiNet-S is reachable before committing, so that I do not end up with a broken hybrid entry pointing at a dead host.
+
+#### Acceptance Criteria
+
+1. THE Host_Reachability_Test SHALL attempt a TCP socket connection to the user-supplied host on port 502.
+2. THE Host_Reachability_Test SHALL use a timeout of 5 seconds.
+3. IF the TCP connection succeeds, THEN THE Host_Reachability_Test SHALL close the socket and report success.
+4. IF the TCP connection times out or is refused, THEN THE Host_Reachability_Test SHALL report failure without raising an unhandled exception.
+5. THE Host_Reachability_Test SHALL be used by the Config_Flow, Options_Flow, and Reconfigure_Flow wherever a Modbus host is accepted.

--- a/.kiro/specs/transport-mode-selector/tasks.md
+++ b/.kiro/specs/transport-mode-selector/tasks.md
@@ -1,0 +1,248 @@
+# Implementation Plan: Transport Mode Selector
+
+## Overview
+
+This plan implements an explicit transport-mode selector for the Sungrow iSolarCloud config flow, allowing users to choose between Cloud Only, Cloud + Modbus, and Modbus Only connectivity during manual setup. This is a `feat!` breaking change that bumps the config-entry VERSION from 2 to 3.
+
+The implementation follows the design's dependency order: constants first, then the reachability helper, migration, config flow restructure, options/reconfigure adaptation, translations, runtime branching, and finally property-based tests for the entry data shape.
+
+## Tasks
+
+- [ ] 1. Define transport-mode constants and smoke test
+  - [-] 1.1 Add `TRANSPORT_CLOUD_ONLY` and `TRANSPORT_CLOUD_MODBUS` constants to `const.py`
+    - Add `TRANSPORT_CLOUD_ONLY = "cloud_only"` alongside the existing `TRANSPORT_MODBUS_ONLY`
+    - Add `TRANSPORT_CLOUD_MODBUS = "cloud_modbus"` alongside the existing `TRANSPORT_MODBUS_ONLY`
+    - Ensure all three constants are exported and importable
+    - _Requirements: 1.1, 1.2, 1.3_
+
+  - [ ]* 1.2 Write smoke test for transport constants
+    - Create `tests/test_transport_constants.py`
+    - Assert `TRANSPORT_CLOUD_ONLY == "cloud_only"`, `TRANSPORT_CLOUD_MODBUS == "cloud_modbus"`, `TRANSPORT_MODBUS_ONLY == "modbus_only"`
+    - Assert `SungrowConfigFlow.VERSION == 3` (will pass after task 3.1)
+    - _Requirements: 1.1, 1.2, 1.3, 5.1_
+
+- [ ] 2. Implement reachability helper and property tests
+  - [~] 2.1 Create `helpers.py` with `async_test_modbus_host`
+    - Create `custom_components/sungrow/helpers.py`
+    - Implement `async def async_test_modbus_host(host: str, port: int = 502, timeout: float = 5.0) -> bool`
+    - Use `asyncio.open_connection` with timeout; return `True` on success (close socket), `False` on any failure
+    - Catch `OSError`, `asyncio.TimeoutError`, and any other exception — never raise to the caller
+    - _Requirements: 12.1, 12.2, 12.3, 12.4_
+
+  - [ ]* 2.2 Write property test: Reachability test uses correct port and timeout
+    - **Property 5: Reachability test uses correct port and timeout**
+    - **Validates: Requirements 12.1, 12.2**
+    - Create `tests/test_reachability_properties.py`
+    - Use Hypothesis to generate arbitrary host strings; mock `asyncio.open_connection` and assert it is called with port 502 and a 5-second timeout
+    - Minimum 100 iterations
+
+  - [ ]* 2.3 Write property test: Reachability test returns bool without exceptions
+    - **Property 6: Reachability test returns bool without exceptions**
+    - **Validates: Requirements 12.3, 12.4**
+    - In `tests/test_reachability_properties.py`
+    - Use Hypothesis to generate arbitrary host strings; mock `asyncio.open_connection` to either succeed or raise various exceptions (TimeoutError, OSError, ConnectionRefusedError, gaierror)
+    - Assert return value is always a `bool` and no exception propagates
+    - Minimum 100 iterations
+
+- [ ] 3. Config entry migration v2→v3 (⚠️ BREAKING: VERSION bump 2→3)
+  - [~] 3.1 Extend `async_migrate_entry` in `__init__.py` and bump VERSION to 3
+    - Add v2→v3 migration block after the existing v1→v2 block in `async_migrate_entry`
+    - If `CONF_TRANSPORT` is absent, set it to `TRANSPORT_CLOUD_ONLY`; if already `TRANSPORT_MODBUS_ONLY`, leave unchanged
+    - Call `hass.config_entries.async_update_entry(config_entry, data=new_data, version=3)`
+    - Update `SungrowConfigFlow` class: set `VERSION = 3`
+    - Import `TRANSPORT_CLOUD_ONLY` in `__init__.py`
+    - _Requirements: 5.1, 5.2, 5.3, 5.4, 5.5, 5.6_
+
+  - [ ]* 3.2 Write property test: v2→v3 migration correctly sets or preserves transport
+    - **Property 2: v2→v3 migration correctly sets or preserves transport**
+    - **Validates: Requirements 5.2, 5.3, 5.4**
+    - Create `tests/test_migration_properties.py`
+    - Use Hypothesis to generate version-2 entry data dicts (with/without `CONF_TRANSPORT`)
+    - Assert: if absent → `"cloud_only"`; if `"modbus_only"` → preserved; version == 3
+    - Minimum 100 iterations
+
+  - [ ]* 3.3 Write property test: v1→v3 chained migration preserves semantics
+    - **Property 3: v1→v3 chained migration preserves semantics**
+    - **Validates: Requirements 5.5, 5.6**
+    - In `tests/test_migration_properties.py`
+    - Use Hypothesis to generate version-1 entries with positive integer `scan_interval` (1–1440 minutes)
+    - Assert: after migration, version == 3, scan_interval == original × 60, transport is set
+    - Minimum 100 iterations
+
+  - [ ]* 3.4 Write unit tests for migration edge cases
+    - Test v2 entry with no transport field → gets `cloud_only`, version 3
+    - Test v2 entry with `modbus_only` → kept as `modbus_only`, version 3
+    - Test v1 entry with scan_interval=5 → migrated to 300s, transport backfilled, version 3
+    - Test already-v3 entry → no changes
+    - _Requirements: 5.2, 5.3, 5.4, 5.5, 5.6_
+
+- [~] 4. Checkpoint – Constants, helper, and migration
+  - Ensure all tests pass, ask the user if questions arise.
+
+- [ ] 5. Restructure config flow with transport selector
+  - [~] 5.1 Implement `async_step_user` as transport selector step
+    - Rename the existing `async_step_user` method to `async_step_cloud_credentials`
+    - Create new `async_step_user` that presents a selector with three options: Cloud Only, Cloud + Modbus, Modbus Only
+    - Use `vol.Schema` with a `selector.SelectSelector` for the transport choices
+    - Route `cloud_only` → `async_step_cloud_credentials`, `cloud_modbus` → `async_step_cloud_credentials` (with flag), `modbus_only` → `async_step_local_setup`
+    - Store selected transport mode on `self` for downstream steps
+    - _Requirements: 2.1, 2.5_
+
+  - [~] 5.2 Implement `async_step_cloud_credentials` (renamed from old user step)
+    - Ensure the old `async_step_user` logic (app_key, app_secret, app_id, gateway, redirect_uri) now lives in `async_step_cloud_credentials`
+    - After credential submission: if mode is `cloud_modbus` → proceed to `async_step_modbus_host`; else → proceed to OAuth / create tokenless entry
+    - Store `TRANSPORT_CLOUD_ONLY` or `TRANSPORT_CLOUD_MODBUS` in entry data accordingly
+    - _Requirements: 2.2, 2.3_
+
+  - [~] 5.3 Implement `async_step_modbus_host` for hybrid mode
+    - Show a text field for WiNet-S IP/hostname
+    - Pre-fill from zeroconf discovery context if available
+    - On submit: call `async_test_modbus_host(host)` from `helpers.py`
+    - On success: store `CONF_MODBUS_HOST` in entry data, proceed to OAuth
+    - On failure: show `host_unreachable` error, allow retry
+    - _Requirements: 3.1, 3.2, 3.3, 3.4, 3.5_
+
+  - [~] 5.4 Implement `async_step_local_setup` for Modbus Only manual entry
+    - Collect host, serial, and model fields
+    - On submit: call `async_test_modbus_host(host)` for reachability
+    - On success: create entry with `TRANSPORT_MODBUS_ONLY`, `CONF_MODBUS_HOST`, `CONF_SERIAL`, `CONF_MODEL`
+    - On failure: show `host_unreachable` error, allow retry
+    - Ensure zeroconf flow remains unchanged (does NOT hit transport step)
+    - _Requirements: 2.4, 7.1, 7.2_
+
+  - [ ]* 5.5 Write unit tests for config flow per transport mode
+    - Test `async_step_user` shows transport selector with 3 options
+    - Test cloud_only flow: user → cloud_credentials → creates entry with `transport=cloud_only`
+    - Test cloud_modbus flow: user → cloud_credentials → modbus_host → creates entry with `transport=cloud_modbus` + `modbus_host`
+    - Test modbus_only flow: user → local_setup → creates entry with `transport=modbus_only` + host/serial/model
+    - Test zeroconf flow bypasses transport step
+    - Test modbus_host step with unreachable host shows error
+    - Test modbus_host step with zeroconf pre-fill
+    - _Requirements: 2.1, 2.2, 2.3, 2.4, 3.1, 3.2, 3.4, 7.2_
+
+- [ ] 6. Adapt options flow for transport-mode switching
+  - [~] 6.1 Modify `SungrowOptionsFlow.async_step_init` for transport-aware behaviour
+    - For `cloud_only` entries: show existing options + optional `modbus_host` field
+    - For `cloud_modbus` entries: show existing options + current `modbus_host` with clear option
+    - For `modbus_only` entries: show existing options only, no transport-switching UI
+    - _Requirements: 6.1, 6.4, 6.6_
+
+  - [~] 6.2 Implement transport-mode switching logic in options flow
+    - When `cloud_only` user provides modbus_host: run reachability test → on success update transport to `cloud_modbus`, add host, trigger reload
+    - When `cloud_modbus` user clears modbus_host: update transport to `cloud_only`, remove host, trigger reload
+    - On reachability failure: show error, keep current transport mode unchanged
+    - _Requirements: 6.2, 6.3, 6.5, 6.7_
+
+  - [ ]* 6.3 Write unit tests for options flow transport switching
+    - Test cloud_only entry shows optional modbus_host field
+    - Test providing valid host switches to cloud_modbus + triggers reload
+    - Test unreachable host shows error, keeps cloud_only
+    - Test cloud_modbus entry shows host + clear option
+    - Test clearing host switches back to cloud_only + triggers reload
+    - Test modbus_only entry does not show transport-switch options
+    - _Requirements: 6.1, 6.2, 6.3, 6.4, 6.5, 6.6, 6.7_
+
+- [ ] 7. Adapt reconfigure flow per transport mode
+  - [~] 7.1 Modify reconfigure flow to branch on transport mode
+    - For `cloud_only`: show cloud credentials form only (existing behaviour)
+    - For `cloud_modbus`: show cloud credentials form followed by modbus host step with reachability test
+    - For `modbus_only`: show modbus host form only (existing behaviour)
+    - On host reachability failure in reconfigure: show error, allow correction
+    - _Requirements: 8.1, 8.2, 8.3, 8.4, 8.5_
+
+  - [ ]* 7.2 Write unit tests for reconfigure flow adaptation
+    - Test cloud_only reconfigure shows credentials form
+    - Test cloud_modbus reconfigure shows credentials + modbus host step
+    - Test cloud_modbus host update with reachability failure shows error
+    - Test modbus_only reconfigure shows host form only
+    - _Requirements: 8.1, 8.2, 8.3, 8.4, 8.5_
+
+- [~] 8. Checkpoint – Config flow, options flow, reconfigure flow
+  - Ensure all tests pass, ask the user if questions arise.
+
+- [ ] 9. Add translation strings for all new UI elements
+  - [~] 9.1 Update `strings.json` with transport step and modbus host keys
+    - Add `config.step.user.title`, `config.step.user.description` for transport selector
+    - Add `config.step.user.data.transport` label and selector option labels (Cloud Only, Cloud + Modbus, Modbus Only)
+    - Add `config.step.modbus_host.title`, `config.step.modbus_host.description`, `config.step.modbus_host.data.modbus_host` label
+    - Add `config.step.local_setup.title`, `config.step.local_setup.description`, field labels
+    - Add `config.error.host_unreachable` error message
+    - Add options flow keys for modbus_host field and transport-switch confirmation
+    - _Requirements: 10.1, 10.2, 10.3_
+
+  - [~] 9.2 Update `translations/en.json` to mirror all new keys from `strings.json`
+    - Copy all new keys from `strings.json` into `translations/en.json` with English text
+    - _Requirements: 10.4_
+
+  - [~] 9.3 Propagate translation keys to all locale files (cy, de, es, fr)
+    - Add the same key structure to `translations/cy.json`, `translations/de.json`, `translations/es.json`, `translations/fr.json`
+    - Use English text as placeholder values (to be translated later by native speakers)
+    - _Requirements: 10.4_
+
+  - [ ]* 9.4 Write property test: Translation key parity
+    - **Property 4: Translation key parity**
+    - **Validates: Requirements 10.4**
+    - Create `tests/test_translation_properties.py`
+    - Load `strings.json` and `translations/en.json`, extract all key paths under `config` and `options` sections
+    - Use Hypothesis to sample key paths and assert each exists in `translations/en.json` with a non-empty string value
+    - Minimum 100 iterations
+
+- [ ] 10. Implement runtime branching in `__init__.py`
+  - [~] 10.1 Update `async_setup_entry` to branch on all three transport modes
+    - Read `entry.data.get(CONF_TRANSPORT)` at entry setup
+    - If `None` (missing): default to `cloud_only` and log a warning
+    - If `modbus_only`: use existing `_async_setup_modbus_only` path (unchanged)
+    - If `cloud_modbus`: set up cloud coordinator as normal, log that modbus_host is noted for future #217 wiring
+    - If `cloud_only`: standard cloud coordinator setup (existing behaviour)
+    - _Requirements: 11.1, 11.2, 11.3, 11.4_
+
+  - [ ]* 10.2 Write integration tests for runtime branching
+    - Test `async_setup_entry` with `cloud_only` → creates cloud coordinator (no modbus)
+    - Test `async_setup_entry` with `cloud_modbus` → creates cloud coordinator, logs deferred message
+    - Test `async_setup_entry` with `modbus_only` → calls `_async_setup_modbus_only`
+    - Test `async_setup_entry` with missing transport → defaults to cloud_only, logs warning
+    - _Requirements: 11.1, 11.2, 11.3, 11.4_
+
+- [ ] 11. Property test: Entry data shape per transport mode (Hypothesis)
+  - [ ]* 11.1 Write property test for entry data shape validation
+    - **Property 1: Entry data shape matches transport mode schema**
+    - **Validates: Requirements 4.1, 4.2, 4.3**
+    - Create `tests/test_entry_shape_properties.py`
+    - Use Hypothesis strategies to generate entry data dicts for each transport mode
+    - Assert: `cloud_only` has all cloud fields, no `modbus_host`; `cloud_modbus` has all cloud fields + `modbus_host`; `modbus_only` has `serial`, `model`, `modbus_host`, no cloud fields
+    - Minimum 100 iterations
+
+- [~] 12. Final checkpoint – Full test suite and linting
+  - Run `pytest tests/` to ensure all tests pass
+  - Run `ruff check custom_components/sungrow/` and `ruff format --check custom_components/sungrow/` to ensure no lint/format violations
+  - Ensure all tests pass, ask the user if questions arise.
+
+## Notes
+
+- Tasks marked with `*` are optional and can be skipped for faster MVP
+- Each task references specific requirements for traceability
+- Checkpoints ensure incremental validation
+- Property tests validate universal correctness properties from the design document
+- Unit tests validate specific examples and edge cases
+- ⚠️ Task 3.1 introduces the `feat!` breaking change (VERSION bump 2→3). The commit for this task MUST use `feat!:` prefix with footer `BREAKING CHANGE: Config entry VERSION bumped from 2 to 3; existing cloud entries are migrated to include an explicit transport field.` (Requirement 9)
+- The actual hybrid data-path logic (Cloud + Modbus coordinator merging) is out of scope — deferred to issue #217
+- Zeroconf flows are explicitly not touched (Requirement 7)
+
+## Task Dependency Graph
+
+```json
+{
+  "waves": [
+    { "id": 0, "tasks": ["1.1"] },
+    { "id": 1, "tasks": ["1.2", "2.1"] },
+    { "id": 2, "tasks": ["2.2", "2.3", "3.1"] },
+    { "id": 3, "tasks": ["3.2", "3.3", "3.4"] },
+    { "id": 4, "tasks": ["5.1", "9.1"] },
+    { "id": 5, "tasks": ["5.2", "5.3", "5.4", "9.2", "9.3"] },
+    { "id": 6, "tasks": ["5.5", "6.1", "9.4"] },
+    { "id": 7, "tasks": ["6.2", "7.1"] },
+    { "id": 8, "tasks": ["6.3", "7.2", "10.1"] },
+    { "id": 9, "tasks": ["10.2", "11.1"] }
+  ]
+}
+```

--- a/custom_components/sungrow/__init__.py
+++ b/custom_components/sungrow/__init__.py
@@ -23,6 +23,7 @@ from pysolarcloud.control import Control
 from pysolarcloud.plants import DeviceType, Plants
 
 from .auth import SungrowAuth
+from .backfill import BackfillManager
 from .const import (
     CONF_APP_ID,
     CONF_APP_KEY,
@@ -39,9 +40,12 @@ from .const import (
     GATEWAY_CONSOLE_URLS,
     GATEWAYS,
     POINT_DEVICE_TYPE,
+    TRANSPORT_CLOUD_MODBUS,
+    TRANSPORT_CLOUD_ONLY,
     TRANSPORT_MODBUS_ONLY,
 )
 from .coordinator import SungrowPlantCoordinator, describe_api_error, is_auth_error
+from .services import async_setup_services
 
 PLATFORMS: list[Platform] = [Platform.BINARY_SENSOR, Platform.NUMBER, Platform.SELECT, Platform.SENSOR]
 # A cloud-free Modbus-only entry has no cloud device status or dispatch, but it does
@@ -80,6 +84,8 @@ class SungrowData:
     devices: dict[str, list[dict[str, Any]]]
     # plant_id -> (stop_event, task) for the running EMS heartbeat loops.
     heartbeats: dict[str, tuple[asyncio.Event, asyncio.Task[None]]] = field(default_factory=dict)
+    # None for a Modbus-only entry (backfill is cloud-only, Requirement 1.2).
+    backfill: BackfillManager | None = None
 
 
 type SungrowConfigEntry = ConfigEntry[SungrowData]
@@ -278,6 +284,9 @@ def _async_split_legacy_hybrid(hass: HomeAssistant, entry: ConfigEntry) -> None:
     """
     if entry.data.get(CONF_TRANSPORT) == TRANSPORT_MODBUS_ONLY:
         return
+    # cloud_modbus entries legitimately carry modbus_host — don't strip it (#216).
+    if entry.data.get(CONF_TRANSPORT) == TRANSPORT_CLOUD_MODBUS:
+        return
     host = str(entry.options.get(CONF_MODBUS_HOST) or entry.data.get(CONF_MODBUS_HOST) or "").strip()
     has_hybrid_keys = any(k in entry.options or k in entry.data for k in _HYBRID_OPTION_KEYS)
     if not host and not has_hybrid_keys:
@@ -413,6 +422,17 @@ async def async_migrate_entry(hass: HomeAssistant, config_entry: ConfigEntry) ->
         new_options = {**config_entry.options, CONF_SCAN_INTERVAL: old_interval * 60}
         hass.config_entries.async_update_entry(config_entry, options=new_options, version=2)
         _LOGGER.info("Migrated scan_interval from %d minutes to %d seconds", old_interval, old_interval * 60)
+
+    if config_entry.version == 2:
+        # v2→v3: back-fill transport field for existing entries.
+        new_data = dict(config_entry.data)
+        if CONF_TRANSPORT not in new_data:
+            new_data[CONF_TRANSPORT] = TRANSPORT_CLOUD_ONLY
+        hass.config_entries.async_update_entry(config_entry, data=new_data, version=3)
+        _LOGGER.info(
+            "Migrated config entry %s to version 3 (transport=%s)", config_entry.title, new_data[CONF_TRANSPORT]
+        )
+
     return True
 
 
@@ -480,8 +500,22 @@ async def _async_setup_modbus_only(hass: HomeAssistant, entry: SungrowConfigEntr
 
 async def async_setup_entry(hass: HomeAssistant, entry: SungrowConfigEntry) -> bool:
     """Set up Sungrow iSolarCloud from a config entry."""
-    if entry.data.get(CONF_TRANSPORT) == TRANSPORT_MODBUS_ONLY:
+    transport = entry.data.get(CONF_TRANSPORT)
+
+    if transport is None:
+        _LOGGER.warning("Config entry %s missing CONF_TRANSPORT; defaulting to cloud_only", entry.title)
+        transport = TRANSPORT_CLOUD_ONLY
+
+    if transport == TRANSPORT_MODBUS_ONLY:
         return await _async_setup_modbus_only(hass, entry)
+
+    if transport == TRANSPORT_CLOUD_MODBUS:
+        _LOGGER.info(
+            "Entry %s configured for cloud+modbus; Modbus wiring deferred to #217",
+            entry.title,
+        )
+
+    # cloud_only and cloud_modbus both use the standard cloud coordinator path.
     # Split legacy hybrid cloud+Modbus entries into pure cloud + separate local.
     _async_split_legacy_hybrid(hass, entry)
     if "tokens" not in entry.data:
@@ -593,6 +627,31 @@ async def async_setup_entry(hass: HomeAssistant, entry: SungrowConfigEntry) -> b
     # update listener would also fire on every token rotation (a plain ``entry.data``
     # write from ``_save_tokens``), needlessly reloading the whole integration (#110).
 
+    # Backfill is cloud-only (Requirement 1.2): construct the manager and kick off the
+    # automatic run in a background task so it never delays setup or the first realtime
+    # poll (Requirement 1.1). The Modbus-only path never reaches here, so it never gets a
+    # manager. The start is gated on Home Assistant being fully started so the historical
+    # imports never race the recorder starting up (Requirements 5.4, 5.5).
+    manager = BackfillManager(hass, entry)
+    entry.runtime_data.backfill = manager
+
+    # Register the on-demand sungrow.backfill service once (idempotent, Requirement 2.1).
+    async_setup_services(hass)
+
+    async def _async_start_backfill() -> None:
+        if not hass.is_running:
+            started = asyncio.Event()
+
+            @callback
+            def _on_started(_event: Any) -> None:
+                started.set()
+
+            entry.async_on_unload(hass.bus.async_listen_once(EVENT_HOMEASSISTANT_STARTED, _on_started))
+            await started.wait()
+        await manager.async_start_automatic()
+
+    entry.async_create_background_task(hass, _async_start_backfill(), name="sungrow-backfill-start")
+
     return True
 
 
@@ -604,6 +663,11 @@ async def async_unload_entry(hass: HomeAssistant, entry: SungrowConfigEntry) -> 
     # failed unload.
     unloaded = await hass.config_entries.async_unload_platforms(entry, _entry_platforms(entry))
     if unloaded:
+        # Cancel any in-flight Backfill runs before tearing down (Requirement 1.5). Cloud
+        # entries have a manager; the Modbus-only path leaves ``backfill`` as None.
+        manager = entry.runtime_data.backfill
+        if manager is not None:
+            await manager.async_shutdown()
         heartbeats = entry.runtime_data.heartbeats
         for heartbeat in list(heartbeats.values()):
             await _stop_heartbeat(heartbeat)

--- a/custom_components/sungrow/backfill.py
+++ b/custom_components/sungrow/backfill.py
@@ -1,0 +1,1032 @@
+"""Backfill historical iSolarCloud data into Home Assistant long-term statistics.
+
+This module is split into a **pure-logic core** (window resolution, time chunking,
+point batching, hourly aggregation, unit conversion) that carries no I/O and is
+exercised by Hypothesis property tests, and an **I/O orchestration shell** (series
+resolution, recorder import, throttle, engine run loop, manager) layered on top.
+
+See ``.kiro/specs/backfill-historical-statistics`` for the design and requirements.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import time
+from dataclasses import dataclass
+from datetime import datetime, timedelta
+from typing import TYPE_CHECKING, Any, Literal
+
+from homeassistant.components.sensor import SensorDeviceClass, SensorStateClass
+from homeassistant.helpers import entity_registry as er
+from homeassistant.helpers import issue_registry as ir
+from homeassistant.helpers.storage import Store
+from homeassistant.util import dt as dt_util
+
+from .const import (
+    BACKFILL_CHUNK_WINDOW,
+    BACKFILL_INTERVAL,
+    BACKFILL_MAX_RETRIES,
+    BACKFILL_MIN_CALL_INTERVAL,
+    CONF_BACKFILL_DAYS,
+    DEFAULT_BACKFILL_DAYS,
+    DOMAIN,
+    MAX_BACKFILL_DAYS,
+    MAX_POINTS_PER_CALL,
+)
+from .coordinator import is_auth_error, is_rate_limit_error
+from .energy_units import normalize_energy_point
+from .measure_points import resolve_classification
+
+if TYPE_CHECKING:
+    from homeassistant.components.recorder.models import (
+        StatisticData,
+        StatisticMetaData,
+    )
+    from homeassistant.config_entries import ConfigEntry
+    from homeassistant.core import HomeAssistant
+
+    from .coordinator import SungrowPlantCoordinator
+
+# Escalating rate-limit backoff is capped at one hour (mirrors the coordinator).
+_MAX_BACKOFF_SECONDS = 3600.0
+
+# Short delay between transient-error retries of the same (chunk, batch) call.
+_TRANSIENT_RETRY_DELAY = 1.0
+
+# The (device_class, state_class) pairs that mark a measure point as a Backfill_Point.
+_ENERGY_CLASS = (SensorDeviceClass.ENERGY, SensorStateClass.TOTAL_INCREASING)
+_POWER_CLASS = (SensorDeviceClass.POWER, SensorStateClass.MEASUREMENT)
+
+# Default import units when a live entity does not supply one (source rows are Wh->kWh
+# for energy and W for power after normalisation).
+_DEFAULT_UNIT: dict[str, str] = {"energy": "kWh", "power": "W"}
+
+_LOGGER = logging.getLogger(__name__)
+
+# Storage schema version for the per-entry Backfill marker Store.
+STORAGE_VERSION = 1
+
+# Translation key / Repair issue id prefix raised when a run finishes with failed chunks.
+BACKFILL_PARTIAL_ISSUE = "backfill_partial"
+
+# Shared troubleshooting doc surfaced on the partial-failure Repair (mirrors the coordinator).
+_BACKFILL_LEARN_MORE = "https://github.com/KRoperUK/sungrow-hass/blob/main/docs/TROUBLESHOOTING.md"
+
+
+class InvalidRangeError(Exception):
+    """Raised when a requested Backfill range is invalid (e.g. start after now)."""
+
+
+# ---------------------------------------------------------------------------
+# Core data models
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class MinuteRow:
+    """A single minute-level reading parsed from the historical endpoint.
+
+    ``value`` is normalised to the target unit (Wh -> kWh for energy) before use.
+    """
+
+    timestamp: datetime  # UTC
+    value: float
+
+
+@dataclass(frozen=True)
+class HistoryWindow:
+    """The bounded time range a Backfill run imports. Both bounds are UTC."""
+
+    start: datetime
+    end: datetime  # == now
+
+
+@dataclass(frozen=True)
+class SeriesTarget:
+    """The resolved import target for one Backfill_Point."""
+
+    point_code: str
+    statistic_id: str
+    unit: str | None
+    kind: Literal["energy", "power"]
+    is_external: bool
+    metadata: StatisticMetaData
+
+
+@dataclass(frozen=True)
+class RunSummary:
+    """The outcome of one Backfill run for one plant."""
+
+    plant_id: str
+    window: HistoryWindow
+    imported_hours: int
+    skipped_empty_ranges: int
+    failed_chunks: int
+    completed: bool  # True when no failed chunks
+
+
+# ---------------------------------------------------------------------------
+# Marker persistence
+# ---------------------------------------------------------------------------
+
+
+class BackfillStore:
+    """Persist per-plant Backfill completion markers for a config entry.
+
+    Wraps a HA ``Store[dict]`` keyed by ``f"{DOMAIN}.backfill_state_{entry_id}"``.
+    The stored document maps ``plant_id`` -> marker dict with ``completed``,
+    ``partial``, ``window_start``, ``window_end``, ``last_run`` and ``failed_chunks``.
+    """
+
+    def __init__(self, hass: Any, entry: ConfigEntry) -> None:
+        self._store: Store[dict[str, Any]] = Store(
+            hass,
+            STORAGE_VERSION,
+            f"{DOMAIN}.backfill_state_{entry.entry_id}",
+        )
+        self._data: dict[str, Any] | None = None
+
+    async def _async_load(self) -> dict[str, Any]:
+        if self._data is None:
+            self._data = await self._store.async_load() or {"plants": {}}
+            self._data.setdefault("plants", {})
+        return self._data
+
+    async def async_get_marker(self, plant_id: str) -> dict[str, Any] | None:
+        """Return the persisted marker for *plant_id*, or None if absent."""
+        data = await self._async_load()
+        return data["plants"].get(plant_id)
+
+    async def async_set_marker(self, plant_id: str, marker: dict[str, Any]) -> None:
+        """Persist *marker* for *plant_id* and flush to disk."""
+        data = await self._async_load()
+        data["plants"][plant_id] = marker
+        await self._store.async_save(data)
+
+
+# ---------------------------------------------------------------------------
+# Pure core: window resolution
+# ---------------------------------------------------------------------------
+
+
+def resolve_window(
+    *,
+    now: datetime,
+    option_days: int | None,
+    start_override: datetime | None,
+) -> HistoryWindow:
+    """Resolve the bounded History_Window for a run.
+
+    The window always ends at ``now``. Its length defaults to
+    ``DEFAULT_BACKFILL_DAYS`` and uses ``option_days`` when provided, clamped to
+    ``[1, MAX_BACKFILL_DAYS]`` days (a clamp is logged). A ``start_override`` sets
+    the start explicitly, still clamped so the window never exceeds the maximum
+    length. A ``start_override`` later than ``now`` raises ``InvalidRangeError``.
+
+    Requirements: 2.3, 3.1, 3.2, 3.3, 3.4, 3.5.
+    """
+    if start_override is not None and start_override > now:
+        raise InvalidRangeError(f"start_override {start_override.isoformat()} is later than now {now.isoformat()}")
+
+    requested_days = DEFAULT_BACKFILL_DAYS if option_days is None else option_days
+    clamped_days = max(1, min(requested_days, MAX_BACKFILL_DAYS))
+    if clamped_days != requested_days:
+        _LOGGER.info(
+            "Backfill window length %s days clamped to %s days (allowed range 1-%s)",
+            requested_days,
+            clamped_days,
+            MAX_BACKFILL_DAYS,
+        )
+
+    max_start = now - timedelta(days=1)  # window is always >= 1 day
+    default_start = now - timedelta(days=clamped_days)
+    earliest_start = now - timedelta(days=MAX_BACKFILL_DAYS)
+
+    # Honor an explicit start, but never exceed the maximum window length and never
+    # produce a zero/negative-length window; otherwise use the (clamped) default.
+    start = min(max(start_override, earliest_start), max_start) if start_override is not None else default_start
+
+    return HistoryWindow(start=start, end=now)
+
+
+# ---------------------------------------------------------------------------
+# Pure core: chunking and batching
+# ---------------------------------------------------------------------------
+
+
+def chunk_time_window(window: HistoryWindow, chunk: timedelta) -> list[tuple[datetime, datetime]]:
+    """Split ``[start, end)`` into consecutive, non-overlapping sub-ranges.
+
+    Each sub-range spans at most *chunk*; the ranges are returned in ascending
+    chronological order and together cover exactly ``[start, end)``.
+
+    Requirements: 4.2, 4.3, 4.4.
+    """
+    if chunk <= timedelta(0):
+        raise ValueError("chunk size must be positive")
+
+    chunks: list[tuple[datetime, datetime]] = []
+    cursor = window.start
+    while cursor < window.end:
+        nxt = min(cursor + chunk, window.end)
+        chunks.append((cursor, nxt))
+        cursor = nxt
+    return chunks
+
+
+def batch_points(points: list[SeriesTarget], max_size: int = MAX_POINTS_PER_CALL) -> list[list[SeriesTarget]]:
+    """Partition *points* into batches of at most *max_size*, preserving order.
+
+    Requirements: 4.1.
+    """
+    if max_size <= 0:
+        raise ValueError("max_size must be positive")
+    return [points[i : i + max_size] for i in range(0, len(points), max_size)]
+
+
+# ---------------------------------------------------------------------------
+# Pure core: unit conversion
+# ---------------------------------------------------------------------------
+
+
+def normalize_row_value(value: Any, unit: str | None) -> dict[str, Any]:
+    """Normalise one ``(value, unit)`` pair via ``energy_units.normalize_energy_point``.
+
+    Returns the normalised point dict (Wh -> kWh for energy; unchanged otherwise).
+
+    Requirements: 7.5, 7.6.
+    """
+    return normalize_energy_point({"value": value, "unit": unit})
+
+
+# ---------------------------------------------------------------------------
+# Pure core: hourly aggregation
+# ---------------------------------------------------------------------------
+
+
+def _floor_to_hour(ts: datetime) -> datetime:
+    """Floor *ts* to the start of its UTC hour."""
+    return dt_util.as_utc(ts).replace(minute=0, second=0, microsecond=0)
+
+
+def build_hourly_statistics(
+    rows: list[MinuteRow],
+    kind: Literal["energy", "power"],
+    *,
+    running_sum: float = 0.0,
+    prev_value: float | None = None,
+) -> tuple[list[StatisticData], float]:
+    """Aggregate minute rows for ONE series into hourly ``StatisticData``.
+
+    Energy: per hour ``state`` is the last cumulative reading in that hour, and
+    ``sum`` is a running total that is non-decreasing across the window (negative
+    minute-to-minute deltas are clamped to zero to guard meter resets/dips). The
+    updated running sum is returned so it can be carried across chunks. ``prev_value``
+    is the last reading of the previous chunk (``None`` for the first chunk); passing
+    it lets per-chunk aggregation compose to the same result as aggregating the whole
+    window at once, since the delta spanning a chunk boundary is not lost.
+
+    Power: per hour ``mean``/``min``/``max`` over that hour's samples.
+
+    Every ``StatisticData.start`` is aligned to an exact UTC hour boundary, and at
+    most one entry is produced per hour. Deterministic for equal input.
+
+    Requirements: 4.5, 6.3, 7.1, 7.2.
+    """
+    if kind == "energy":
+        return _build_energy(rows, running_sum, prev_value)
+    return _build_power(rows), running_sum
+
+
+def _build_energy(
+    rows: list[MinuteRow], running_sum: float, prev_value: float | None
+) -> tuple[list[StatisticData], float]:
+    # Sort chronologically so cumulative deltas and per-hour "last value" are stable.
+    ordered = sorted(rows, key=lambda r: r.timestamp)
+
+    running = running_sum
+    prev = prev_value
+    # Preserve first-seen hour order (already ascending after the sort).
+    per_hour: dict[datetime, dict[str, float]] = {}
+
+    for row in ordered:
+        hour = _floor_to_hour(row.timestamp)
+        if prev is None:
+            delta = 0.0
+        else:
+            delta = row.value - prev
+            if delta < 0:
+                # Meter reset or spurious dip: clamp so the running sum never drops.
+                delta = 0.0
+        running += delta
+        prev = row.value
+        # Last write wins -> per-hour state is the last cumulative reading in the hour,
+        # and sum is the running total at the end of the hour.
+        per_hour[hour] = {"state": row.value, "sum": running}
+
+    result: list[StatisticData] = [
+        {"start": hour, "state": vals["state"], "sum": vals["sum"]} for hour, vals in per_hour.items()
+    ]
+    return result, running
+
+
+def _build_power(rows: list[MinuteRow]) -> list[StatisticData]:
+    ordered = sorted(rows, key=lambda r: r.timestamp)
+
+    buckets: dict[datetime, list[float]] = {}
+    for row in ordered:
+        buckets.setdefault(_floor_to_hour(row.timestamp), []).append(row.value)
+
+    result: list[StatisticData] = []
+    for hour, values in buckets.items():
+        result.append(
+            {
+                "start": hour,
+                "mean": sum(values) / len(values),
+                "min": min(values),
+                "max": max(values),
+            }
+        )
+    return result
+
+
+# ---------------------------------------------------------------------------
+# Series resolution and Statistic_Id scoping (Task 7)
+# ---------------------------------------------------------------------------
+
+
+def select_backfill_points(measure_points: dict[str, str]) -> list[tuple[str, str]]:
+    """Select the cumulative-energy and power Backfill_Points from a measure-point map.
+
+    ``measure_points`` maps ``point_id`` -> ``code`` (the ``plants_service.measure_points``
+    catalogue). Each point is classified with the same ``resolve_classification`` the sensor
+    platform uses; a point is a Backfill_Point when it is cumulative energy
+    (``ENERGY``/``TOTAL_INCREASING`` -> ``kind="energy"``) or power
+    (``POWER``/``MEASUREMENT`` -> ``kind="power"``). Returns ``(code, kind)`` pairs in the
+    catalogue's iteration order so backfilled series line up with the live sensors.
+
+    Requirements: 7.1, 7.2.
+    """
+    selected: list[tuple[str, str]] = []
+    for point_id, code in measure_points.items():
+        classification = resolve_classification(None, code, point_id)
+        if classification == _ENERGY_CLASS:
+            selected.append((code, "energy"))
+        elif classification == _POWER_CLASS:
+            selected.append((code, "power"))
+    return selected
+
+
+def build_series_target(
+    *,
+    plant_id: str,
+    point_code: str,
+    kind: Literal["energy", "power"],
+    entity_id: str | None,
+    unit: str | None,
+) -> SeriesTarget:
+    """Derive the :class:`SeriesTarget` (Statistic_Id, source, metadata) for one point.
+
+    A live entity (``entity_id`` set) imports into that entity's series
+    (``statistic_id = entity_id``, ``source="recorder"``, ``is_external=False``); otherwise
+    the point imports into a per-plant external series
+    (``statistic_id = f"sungrow:{plant_id}_{point_code}"``, ``source=DOMAIN``,
+    ``is_external=True``). Scoping the external id by ``plant_id`` guarantees no cross-plant
+    collision. ``has_mean``/``has_sum`` follow ``kind`` (energy -> sum, power -> mean) so the
+    recorder accepts the import, and the unit falls back to the kind default when the live
+    entity supplies none.
+
+    Requirements: 7.1, 7.2, 7.3, 7.4, 9.2.
+    """
+    if entity_id is not None:
+        statistic_id = entity_id
+        source = "recorder"
+        is_external = False
+    else:
+        statistic_id = f"sungrow:{plant_id}_{point_code}"
+        source = DOMAIN
+        is_external = True
+
+    resolved_unit = unit if unit else _DEFAULT_UNIT[kind]
+    metadata: StatisticMetaData = {
+        "has_mean": kind == "power",
+        "has_sum": kind == "energy",
+        "name": None,
+        "source": source,
+        "statistic_id": statistic_id,
+        "unit_of_measurement": resolved_unit,
+    }
+    return SeriesTarget(
+        point_code=point_code,
+        statistic_id=statistic_id,
+        unit=resolved_unit,
+        kind=kind,  # type: ignore[arg-type]
+        is_external=is_external,
+        metadata=metadata,
+    )
+
+
+def _live_unit(hass: HomeAssistant, registry: er.EntityRegistry, entity_id: str) -> str | None:
+    """Return the live entity's unit from its current state, else its registry entry."""
+    state = hass.states.get(entity_id)
+    if state is not None:
+        unit = state.attributes.get("unit_of_measurement")
+        if unit:
+            return str(unit)
+    entry = registry.async_get(entity_id)
+    if entry is not None and entry.unit_of_measurement:
+        return str(entry.unit_of_measurement)
+    return None
+
+
+async def async_resolve_series(hass: HomeAssistant, coordinator: SungrowPlantCoordinator) -> list[SeriesTarget]:
+    """Map each Backfill_Point for the coordinator's plant to its :class:`SeriesTarget`.
+
+    Selects the cumulative-energy and power points from
+    ``coordinator.plants_service.measure_points`` and, for each, looks up the live sensor by
+    ``unique_id`` ``f"{plant_id}_{point_code}"`` in the entity registry. A found entity yields
+    a live-entity series (unit taken from the live entity); an absent one falls back to a
+    per-plant external series.
+
+    Requirements: 7.1, 7.2, 7.3, 7.4, 7.5, 7.6, 9.2.
+    """
+    registry = er.async_get(hass)
+    plant_id = coordinator.plant_id
+    measure_points = coordinator.plants_service.measure_points
+
+    targets: list[SeriesTarget] = []
+    for point_code, kind in select_backfill_points(measure_points):
+        unique_id = f"{plant_id}_{point_code}"
+        entity_id = registry.async_get_entity_id("sensor", DOMAIN, unique_id)
+        unit = _live_unit(hass, registry, entity_id) if entity_id is not None else None
+        targets.append(
+            build_series_target(
+                plant_id=plant_id,
+                point_code=point_code,
+                kind=kind,  # type: ignore[arg-type]
+                entity_id=entity_id,
+                unit=unit,
+            )
+        )
+    return targets
+
+
+# ---------------------------------------------------------------------------
+# Idempotent import router (Task 8)
+# ---------------------------------------------------------------------------
+
+
+def import_statistics(hass: HomeAssistant, target: SeriesTarget, data: list[StatisticData]) -> None:
+    """Import hourly statistics for one series through the recorder helpers.
+
+    External series route to ``async_add_external_statistics`` and live-entity series to
+    ``async_import_statistics``; both overwrite by ``(statistic_id, start_hour)``, so
+    re-importing the same or a retried chunk is a clean overwrite rather than a duplicate
+    (idempotent, hour-local). An empty ``data`` list is a no-op.
+
+    Requirements: 6.1, 6.2, 6.4, 7.3, 7.4.
+    """
+    if not data:
+        return
+
+    from homeassistant.components.recorder.statistics import (
+        async_add_external_statistics,
+        async_import_statistics,
+    )
+
+    if target.is_external:
+        async_add_external_statistics(hass, target.metadata, data)
+    else:
+        async_import_statistics(hass, target.metadata, data)
+
+
+# ---------------------------------------------------------------------------
+# Shared Throttle (Task 9)
+# ---------------------------------------------------------------------------
+
+
+class Throttle:
+    """Serialise iSolarCloud calls across a config entry's Backfill engines.
+
+    ``acquire`` waits until at least ``min_interval`` seconds have elapsed since the previous
+    acquire, so a single shared instance keeps the combined call rate across concurrently
+    backfilling plants under the quota (Requirements 5.1, 9.4). ``backoff`` sleeps an
+    escalating delay after a rate-limit rejection (doubling each call, capped at one hour;
+    Requirement 5.2) and ``reset_backoff`` clears the escalation once calls succeed again.
+    """
+
+    def __init__(self, min_interval: float = BACKFILL_MIN_CALL_INTERVAL, hass: Any = None) -> None:
+        self._min_interval = min_interval
+        self._hass = hass
+        self._lock = asyncio.Lock()
+        self._last: float | None = None
+        self._backoff: float = 0.0
+
+    def _monotonic(self) -> float:
+        return time.monotonic()
+
+    async def _sleep(self, delay: float) -> None:
+        await asyncio.sleep(delay)
+
+    async def acquire(self) -> None:
+        """Await until ``min_interval`` has elapsed since the previous acquire."""
+        async with self._lock:
+            now = self._monotonic()
+            if self._last is not None:
+                wait = self._min_interval - (now - self._last)
+                if wait > 0:
+                    await self._sleep(wait)
+                    now = self._monotonic()
+            self._last = now
+
+    async def backoff(self) -> None:
+        """Sleep an escalating (doubling) delay, capped at one hour."""
+        if self._backoff <= 0:
+            self._backoff = max(self._min_interval, 1.0)
+        else:
+            self._backoff = min(self._backoff * 2, _MAX_BACKOFF_SECONDS)
+        await self._sleep(self._backoff)
+
+    def reset_backoff(self) -> None:
+        """Clear the escalating backoff after a successful call."""
+        self._backoff = 0.0
+
+
+# ---------------------------------------------------------------------------
+# Error classification (Task 10)
+# ---------------------------------------------------------------------------
+
+ErrorClass = Literal["auth", "rate_limit", "transient"]
+
+
+def classify_error(err: Exception) -> ErrorClass:
+    """Classify an ``async_get_historical_data`` failure for the run loop.
+
+    Reuses the coordinator's ``is_auth_error`` and ``is_rate_limit_error`` (E998/E999)
+    helpers so the Backfill path reacts to failures exactly like the realtime poll: auth
+    errors stop the run and defer to reauth, rate-limit errors trigger a throttle backoff,
+    and anything else is a transient error eligible for a bounded retry.
+
+    Requirements: 5.2, 5.6, 8.5.
+    """
+    if is_auth_error(err):
+        return "auth"
+    if is_rate_limit_error(err):
+        return "rate_limit"
+    return "transient"
+
+
+# ---------------------------------------------------------------------------
+# Engine run loop (Task 11)
+# ---------------------------------------------------------------------------
+
+
+def _coerce_value(raw: Any, unit: str | None, kind: Literal["energy", "power"]) -> float | None:
+    """Normalise and coerce one source reading to a float, or ``None`` to drop it.
+
+    Energy rows are normalised (Wh -> kWh) via ``normalize_row_value`` before coercion;
+    power rows are used as-is. Rows whose value is ``None``/``""``/non-numeric are dropped
+    by returning ``None``.
+    """
+    value: Any = raw
+    if kind == "energy":
+        value = normalize_row_value(raw, unit)["value"]
+    if value is None or value == "":
+        return None
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return None
+
+
+class BackfillEngine:
+    """Orchestrate exactly one Backfill run for a single plant.
+
+    A run resolves the bounded History_Window and the plant's Backfill series, then iterates
+    Time_Chunks (ascending) x Point_Batches (<= 50), issuing throttled
+    ``async_get_historical_data`` calls with explicit ``start_time``/``end_time`` and a
+    5-minute ``interval``. Returned minute rows are aggregated into hourly ``StatisticData``
+    (carrying the running ``sum`` and previous cumulative reading per series across chunks so
+    energy sums compose correctly) and imported idempotently through the recorder helpers.
+
+    Failures are classified: auth errors stop the run and defer to the integration's reauth
+    handling; rate-limit errors trigger a throttle backoff and resume from the same
+    (chunk, batch) via a progress cursor; transient errors retry the same call up to
+    ``BACKFILL_MAX_RETRIES`` before the chunk is marked failed and the run continues. Empty
+    ranges are skipped. On completion the run persists a marker and returns a ``RunSummary``.
+
+    Requirements: 1.3, 4.3, 4.4, 5.2, 5.3, 5.6, 6.4, 8.1, 8.3, 8.4, 8.6.
+    """
+
+    def __init__(
+        self,
+        hass: HomeAssistant,
+        coordinator: SungrowPlantCoordinator,
+        throttle: Throttle,
+        store: BackfillStore,
+    ) -> None:
+        self._hass = hass
+        self._coordinator = coordinator
+        self._throttle = throttle
+        self._store = store
+
+    async def _sleep(self, delay: float) -> None:
+        await asyncio.sleep(delay)
+
+    async def async_run(self, *, start_date: datetime | None = None) -> RunSummary:
+        """Execute one full Backfill run for this plant and return its :class:`RunSummary`."""
+        plant_id = self._coordinator.plant_id
+        entry = self._coordinator.config_entry
+        option_days = entry.options.get(CONF_BACKFILL_DAYS) if entry is not None else None
+
+        now = dt_util.utcnow()
+        window = resolve_window(now=now, option_days=option_days, start_override=start_date)
+        targets = await async_resolve_series(self._hass, self._coordinator)
+        batches = batch_points(targets, MAX_POINTS_PER_CALL)
+        chunks = chunk_time_window(window, BACKFILL_CHUNK_WINDOW)
+
+        _LOGGER.info(
+            "Backfill run starting for plant %s: window %s -> %s, %d series in %d batches, %d chunks",
+            plant_id,
+            window.start.isoformat(),
+            window.end.isoformat(),
+            len(targets),
+            len(batches),
+            len(chunks),
+        )
+
+        # Per-series carry-over so cumulative energy sums compose across ascending chunks.
+        running_sums: dict[str, float] = {}
+        prev_values: dict[str, float | None] = {}
+        imported: set[tuple[str, datetime]] = set()
+        skipped_empty_ranges = 0
+        failed_chunks = 0
+
+        # Flat work list so a rate-limit backoff can resume from the exact cursor position.
+        work: list[tuple[tuple[datetime, datetime], list[SeriesTarget]]] = [
+            (chunk, batch) for chunk in chunks for batch in batches
+        ]
+
+        cursor = 0
+        transient_retries = 0
+        try:
+            while cursor < len(work):
+                (start, end), batch = work[cursor]
+                await self._throttle.acquire()
+                try:
+                    raw = await self._coordinator.plants_service.async_get_historical_data(
+                        plant_id,
+                        start,
+                        end,
+                        measure_points=[t.point_code for t in batch],
+                        interval=BACKFILL_INTERVAL,
+                    )
+                except asyncio.CancelledError:
+                    # Cancelled between imports: already-imported hours stay durable. Propagate.
+                    raise
+                except Exception as err:  # noqa: BLE001 - classified below
+                    error_class = classify_error(err)
+                    if error_class == "auth":
+                        _LOGGER.warning(
+                            "Backfill run for plant %s stopped on authentication error; deferring to reauth: %s",
+                            plant_id,
+                            err,
+                        )
+                        await self._persist_marker(plant_id, window, now, failed_chunks, completed=False)
+                        raise
+                    if error_class == "rate_limit":
+                        _LOGGER.debug(
+                            "Backfill rate-limited on chunk %s-%s (plant %s); backing off",
+                            start.isoformat(),
+                            end.isoformat(),
+                            plant_id,
+                        )
+                        await self._throttle.backoff()
+                        continue  # resume the SAME (chunk, batch) without advancing
+                    # Transient: retry the same call a bounded number of times.
+                    transient_retries += 1
+                    if transient_retries <= BACKFILL_MAX_RETRIES:
+                        _LOGGER.debug(
+                            "Backfill transient error on chunk %s-%s (plant %s), retry %d/%d: %s",
+                            start.isoformat(),
+                            end.isoformat(),
+                            plant_id,
+                            transient_retries,
+                            BACKFILL_MAX_RETRIES,
+                            err,
+                        )
+                        await self._sleep(_TRANSIENT_RETRY_DELAY)
+                        continue
+                    failed_chunks += 1
+                    _LOGGER.warning(
+                        "Backfill chunk %s-%s (plant %s) failed after %d retries: %s",
+                        start.isoformat(),
+                        end.isoformat(),
+                        plant_id,
+                        BACKFILL_MAX_RETRIES,
+                        err,
+                    )
+                    transient_retries = 0
+                    cursor += 1
+                    continue
+
+                # Success: clear escalation and process the returned rows.
+                self._throttle.reset_backoff()
+                transient_retries = 0
+
+                rows = raw.get(plant_id) or raw.get(str(plant_id)) or []
+                if not rows:
+                    skipped_empty_ranges += 1
+                    _LOGGER.debug(
+                        "Backfill chunk %s-%s (plant %s) returned no rows; skipping",
+                        start.isoformat(),
+                        end.isoformat(),
+                        plant_id,
+                    )
+                    cursor += 1
+                    continue
+
+                self._aggregate_batch(rows, batch, running_sums, prev_values, imported)
+                _LOGGER.debug(
+                    "Backfill imported chunk %s-%s (plant %s): %d hourly rows so far",
+                    start.isoformat(),
+                    end.isoformat(),
+                    plant_id,
+                    len(imported),
+                )
+                cursor += 1
+        except asyncio.CancelledError:
+            _LOGGER.debug("Backfill run for plant %s cancelled", plant_id)
+            raise
+
+        completed = failed_chunks == 0
+        await self._persist_marker(plant_id, window, now, failed_chunks, completed=completed)
+
+        summary = RunSummary(
+            plant_id=plant_id,
+            window=window,
+            imported_hours=len(imported),
+            skipped_empty_ranges=skipped_empty_ranges,
+            failed_chunks=failed_chunks,
+            completed=completed,
+        )
+        _LOGGER.info(
+            "Backfill run finished for plant %s: %d hours imported, %d empty ranges, %d failed chunks, completed=%s",
+            plant_id,
+            summary.imported_hours,
+            summary.skipped_empty_ranges,
+            summary.failed_chunks,
+            summary.completed,
+        )
+        return summary
+
+    def _aggregate_batch(
+        self,
+        rows: list[dict[str, Any]],
+        batch: list[SeriesTarget],
+        running_sums: dict[str, float],
+        prev_values: dict[str, float | None],
+        imported: set[tuple[str, datetime]],
+    ) -> None:
+        """Aggregate and import one chunk's rows for every series in *batch*."""
+        rows_by_code: dict[str, list[dict[str, Any]]] = {}
+        for row in rows:
+            rows_by_code.setdefault(row.get("code"), []).append(row)
+
+        for target in batch:
+            minute_rows: list[MinuteRow] = []
+            for row in rows_by_code.get(target.point_code, []):
+                value = _coerce_value(row.get("value"), row.get("unit"), target.kind)
+                if value is None:
+                    continue
+                minute_rows.append(MinuteRow(timestamp=row["timestamp"], value=value))
+
+            if not minute_rows:
+                continue
+
+            sid = target.statistic_id
+            stats, new_sum = build_hourly_statistics(
+                minute_rows,
+                target.kind,
+                running_sum=running_sums.get(sid, 0.0),
+                prev_value=prev_values.get(sid),
+            )
+            running_sums[sid] = new_sum
+            # Carry the last cumulative reading so the next chunk's first delta is correct.
+            prev_values[sid] = max(minute_rows, key=lambda r: r.timestamp).value
+
+            import_statistics(self._hass, target, stats)
+            for entry in stats:
+                imported.add((sid, entry["start"]))
+
+    async def _persist_marker(
+        self,
+        plant_id: str,
+        window: HistoryWindow,
+        last_run: datetime,
+        failed_chunks: int,
+        *,
+        completed: bool,
+    ) -> None:
+        """Persist the per-plant completion marker for this run."""
+        await self._store.async_set_marker(
+            plant_id,
+            {
+                "completed": completed,
+                "partial": failed_chunks > 0 or not completed,
+                "window_start": window.start.isoformat(),
+                "window_end": window.end.isoformat(),
+                "last_run": last_run.isoformat(),
+                "failed_chunks": failed_chunks,
+            },
+        )
+
+
+# ---------------------------------------------------------------------------
+# BackfillManager (Task 13)
+# ---------------------------------------------------------------------------
+
+
+class BackfillManager:
+    """Own one :class:`BackfillEngine` per coordinator for a config entry.
+
+    All engines of an entry share a single :class:`Throttle` (so the combined call rate
+    across concurrently backfilling plants stays under the quota, Requirement 9.4) and a
+    single :class:`BackfillStore` for the per-plant completion markers. The manager starts
+    automatic runs after setup (gated on the persisted marker, Requirements 1.1, 1.4),
+    dispatches on-demand service calls (Requirements 2.2, 2.3, 2.4), and tracks every run as
+    a background task so unload can cancel them (Requirement 1.5).
+
+    Each per-plant run is wrapped so one plant's failure never stops the others
+    (Requirements 9.1, 9.3). On completion the manager logs the :class:`RunSummary` and
+    raises or clears the partial-failure Repair.
+
+    Requirements: 1.1, 1.4, 1.5, 2.2, 2.3, 2.4, 9.1, 9.3, 9.4.
+    """
+
+    def __init__(self, hass: HomeAssistant, entry: ConfigEntry) -> None:
+        self._hass = hass
+        self._entry = entry
+        # One shared throttle and one shared marker store across all engines of this entry.
+        self._throttle = Throttle(min_interval=BACKFILL_MIN_CALL_INTERVAL, hass=hass)
+        self._store = BackfillStore(hass, entry)
+        self._engines: dict[str, BackfillEngine] = {}
+        self._tasks: dict[str, asyncio.Task[None]] = {}
+
+    # -- engine lifecycle ---------------------------------------------------
+
+    def _engine_for(self, coordinator: SungrowPlantCoordinator) -> BackfillEngine:
+        """Return (lazily creating) the engine for *coordinator*'s plant."""
+        plant_id = coordinator.plant_id
+        engine = self._engines.get(plant_id)
+        if engine is None:
+            engine = BackfillEngine(self._hass, coordinator, self._throttle, self._store)
+            self._engines[plant_id] = engine
+        return engine
+
+    def _plant_name(self, plant_id: str) -> str:
+        """Best-effort human name for *plant_id* (falls back to the id itself)."""
+        for coordinator in self._entry.runtime_data.coordinators:
+            if coordinator.plant_id == plant_id:
+                return getattr(coordinator, "plant_name", plant_id)
+        return plant_id
+
+    # -- public API ---------------------------------------------------------
+
+    def is_running(self, plant_id: str) -> bool:
+        """Return whether a run is currently in flight for *plant_id* (Requirement 2.4)."""
+        task = self._tasks.get(plant_id)
+        return task is not None and not task.done()
+
+    async def async_start_automatic(self) -> None:
+        """Start an automatic run for each plant lacking a completed default-window marker.
+
+        For each coordinator the persisted marker is read; if a completed marker already
+        covers the default window, that plant is skipped (Requirements 1.1, 1.4). Otherwise a
+        run covering the default window is started.
+        """
+        now = dt_util.utcnow()
+        option_days = self._entry.options.get(CONF_BACKFILL_DAYS)
+        default_window = resolve_window(now=now, option_days=option_days, start_override=None)
+
+        for coordinator in self._entry.runtime_data.coordinators:
+            plant_id = coordinator.plant_id
+            marker = await self._store.async_get_marker(plant_id)
+            if _marker_covers_window(marker, default_window):
+                _LOGGER.debug(
+                    "Backfill skipping automatic run for plant %s: completed marker already covers the default window",
+                    plant_id,
+                )
+                continue
+            self._start_run(coordinator)
+
+    async def async_run_on_demand(self, *, plant_ids: list[str] | None, start_date: datetime | None) -> None:
+        """Start on-demand runs for the addressed coordinators (all if *plant_ids* is None).
+
+        A plant already running is rejected and logged rather than starting a second run
+        (Requirements 2.2, 2.3, 2.4).
+        """
+        coordinators = list(self._entry.runtime_data.coordinators)
+        if plant_ids is not None:
+            wanted = set(plant_ids)
+            coordinators = [c for c in coordinators if c.plant_id in wanted]
+
+        for coordinator in coordinators:
+            self._start_run(coordinator, start_date=start_date)
+
+    async def async_shutdown(self) -> None:
+        """Cancel and await every in-flight run task (Requirement 1.5).
+
+        Cancellation between imports is safe: already-imported hours are durable and are
+        re-imported identically by a later run, so no statistics are corrupted.
+        """
+        tasks = list(self._tasks.values())
+        for task in tasks:
+            task.cancel()
+        if tasks:
+            await asyncio.gather(*tasks, return_exceptions=True)
+        self._tasks.clear()
+
+    # -- internals ----------------------------------------------------------
+
+    def _start_run(self, coordinator: SungrowPlantCoordinator, *, start_date: datetime | None = None) -> bool:
+        """Start a background run task for *coordinator*, unless one is already running."""
+        plant_id = coordinator.plant_id
+        if self.is_running(plant_id):
+            _LOGGER.warning("Backfill already running for plant %s; ignoring new run request", plant_id)
+            return False
+        engine = self._engine_for(coordinator)
+        task = self._entry.async_create_background_task(
+            self._hass,
+            self._run_engine(engine, plant_id, start_date=start_date),
+            name=f"sungrow-backfill-{plant_id}",
+        )
+        self._tasks[plant_id] = task
+        return True
+
+    async def _run_engine(self, engine: BackfillEngine, plant_id: str, *, start_date: datetime | None) -> None:
+        """Run one engine, isolating its failure and applying the summary's Repair state.
+
+        Wrapping each run in its own task with its own try/except means one plant's error
+        (or cancellation) never stops the others (Requirements 9.1, 9.3).
+        """
+        try:
+            summary = await engine.async_run(start_date=start_date)
+        except asyncio.CancelledError:
+            _LOGGER.debug("Backfill run for plant %s cancelled", plant_id)
+            raise
+        except Exception:  # noqa: BLE001 - one plant's failure must not stop the others
+            _LOGGER.exception("Backfill run for plant %s failed", plant_id)
+        else:
+            _LOGGER.info(
+                "Backfill run summary for plant %s: %d hours imported, %d empty ranges, %d failed chunks, completed=%s",
+                plant_id,
+                summary.imported_hours,
+                summary.skipped_empty_ranges,
+                summary.failed_chunks,
+                summary.completed,
+            )
+            self._apply_repair(summary)
+        finally:
+            self._tasks.pop(plant_id, None)
+
+    def _apply_repair(self, summary: RunSummary) -> None:
+        """Raise the partial-failure Repair on a partial run, clear it on a clean run.
+
+        Requirements: 8.1, 8.2.
+        """
+        issue_id = f"{BACKFILL_PARTIAL_ISSUE}_{summary.plant_id}"
+        if summary.completed:
+            ir.async_delete_issue(self._hass, DOMAIN, issue_id)
+            return
+        ir.async_create_issue(
+            self._hass,
+            DOMAIN,
+            issue_id,
+            is_fixable=False,
+            severity=ir.IssueSeverity.WARNING,
+            translation_key=BACKFILL_PARTIAL_ISSUE,
+            translation_placeholders={
+                "plant": self._plant_name(summary.plant_id),
+                "failed_chunks": str(summary.failed_chunks),
+            },
+            learn_more_url=_BACKFILL_LEARN_MORE,
+        )
+
+
+def _marker_covers_window(marker: dict[str, Any] | None, window: HistoryWindow) -> bool:
+    """Return whether a completed marker already covers *window*'s start.
+
+    A plant is gated from an automatic re-run only when its persisted marker is
+    ``completed`` and its recorded window began at or before the default window's start,
+    i.e. the earlier run already imported at least as far back as the default window asks
+    for (Requirements 1.1, 1.4).
+    """
+    if not marker or not marker.get("completed"):
+        return False
+    window_start = marker.get("window_start")
+    if not window_start:
+        return False
+    parsed = dt_util.parse_datetime(window_start)
+    return parsed is not None and parsed <= window.start

--- a/custom_components/sungrow/backfill.py
+++ b/custom_components/sungrow/backfill.py
@@ -156,7 +156,8 @@ class BackfillStore:
     async def async_get_marker(self, plant_id: str) -> dict[str, Any] | None:
         """Return the persisted marker for *plant_id*, or None if absent."""
         data = await self._async_load()
-        return data["plants"].get(plant_id)
+        result: dict[str, Any] | None = data["plants"].get(plant_id)
+        return result
 
     async def async_set_marker(self, plant_id: str, marker: dict[str, Any]) -> None:
         """Persist *marker* for *plant_id* and flush to disk."""
@@ -409,7 +410,7 @@ def build_series_target(
         is_external = True
 
     resolved_unit = unit if unit else _DEFAULT_UNIT[kind]
-    metadata: StatisticMetaData = {
+    metadata: StatisticMetaData = {  # type: ignore[typeddict-item]
         "has_mean": kind == "power",
         "has_sum": kind == "energy",
         "name": None,
@@ -421,7 +422,7 @@ def build_series_target(
         point_code=point_code,
         statistic_id=statistic_id,
         unit=resolved_unit,
-        kind=kind,  # type: ignore[arg-type]
+        kind=kind,
         is_external=is_external,
         metadata=metadata,
     )
@@ -453,6 +454,7 @@ async def async_resolve_series(hass: HomeAssistant, coordinator: SungrowPlantCoo
     """
     registry = er.async_get(hass)
     plant_id = coordinator.plant_id
+    assert coordinator.plants_service is not None  # Backfill is cloud-only; never called for Modbus entries
     measure_points = coordinator.plants_service.measure_points
 
     targets: list[SeriesTarget] = []
@@ -675,6 +677,7 @@ class BackfillEngine:
                 (start, end), batch = work[cursor]
                 await self._throttle.acquire()
                 try:
+                    assert self._coordinator.plants_service is not None
                     raw = await self._coordinator.plants_service.async_get_historical_data(
                         plant_id,
                         start,
@@ -792,7 +795,8 @@ class BackfillEngine:
         """Aggregate and import one chunk's rows for every series in *batch*."""
         rows_by_code: dict[str, list[dict[str, Any]]] = {}
         for row in rows:
-            rows_by_code.setdefault(row.get("code"), []).append(row)
+            code = row.get("code") or ""
+            rows_by_code.setdefault(code, []).append(row)
 
         for target in batch:
             minute_rows: list[MinuteRow] = []

--- a/custom_components/sungrow/config_flow.py
+++ b/custom_components/sungrow/config_flow.py
@@ -34,6 +34,8 @@ from .const import (
     GATEWAYS,
     MAX_SCAN_INTERVAL,
     MIN_SCAN_INTERVAL,
+    TRANSPORT_CLOUD_MODBUS,
+    TRANSPORT_CLOUD_ONLY,
     TRANSPORT_MODBUS_ONLY,
 )
 
@@ -73,7 +75,7 @@ def _parse_winet_properties(props: dict[str, Any]) -> tuple[str | None, str | No
 class SungrowConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     """Handle a config flow for Sungrow iSolarCloud."""
 
-    VERSION = 2
+    VERSION = 3
 
     def __init__(self) -> None:
         """Initialize the config flow."""
@@ -91,6 +93,8 @@ class SungrowConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         # Zeroconf-discovered WiNet-S local Modbus host, carried into the confirm step
         # that creates the cloud-free Modbus-only entry (#159).
         self._discovered_modbus_host: str | None = None
+        # Transport mode selected in the transport step (#216).
+        self._transport: str | None = None
 
     @staticmethod
     @callback
@@ -118,12 +122,14 @@ class SungrowConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         authorization and updates the entry in place (no delete & re-add).
         """
         entry = self._get_reconfigure_entry()
+        transport = entry.data.get(CONF_TRANSPORT)
         # A cloud-free Modbus-only entry has no credentials to change; reconfigure just
         # updates the WiNet-S host (#159), not the cloud app key/secret/gateway.
-        if entry.data.get(CONF_TRANSPORT) == TRANSPORT_MODBUS_ONLY:
+        if transport == TRANSPORT_MODBUS_ONLY:
             return await self.async_step_reconfigure_modbus(user_input)
         self._reauth_entry = entry
         self._is_reconfigure = True
+        self._transport = transport
 
         if user_input is not None:
             # Preserve the App ID (identity) and drop stale tokens — we re-authorize.
@@ -131,6 +137,9 @@ class SungrowConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             self.init_info.pop("tokens", None)
             # Start a fresh Auth client for the (possibly changed) credentials.
             self.auth_client = None
+            # For cloud_modbus: collect an updated modbus host before re-authorizing.
+            if transport == TRANSPORT_CLOUD_MODBUS:
+                return await self.async_step_reconfigure_modbus_host()
             return await self.async_step_auth()
 
         current = entry.data
@@ -146,6 +155,32 @@ class SungrowConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                     vol.Required(CONF_REDIRECT_URI, default=current.get(CONF_REDIRECT_URI, "")): str,
                 }
             ),
+        )
+
+    async def async_step_reconfigure_modbus_host(self, user_input: dict[str, Any] | None = None) -> ConfigFlowResult:
+        """Collect updated Modbus host during reconfigure of a cloud_modbus entry (#216)."""
+        errors: dict[str, str] = {}
+        entry = self._get_reconfigure_entry()
+
+        if user_input is not None:
+            host = (user_input.get(CONF_MODBUS_HOST) or "").strip()
+            from .helpers import async_test_modbus_host
+
+            if await async_test_modbus_host(host):
+                # Store host in init_info so the auth step includes it in the updated entry.
+                self.init_info[CONF_MODBUS_HOST] = host
+                return await self.async_step_auth()
+            errors["base"] = "host_unreachable"
+
+        current_host = entry.data.get(CONF_MODBUS_HOST, "")
+        return self.async_show_form(
+            step_id="reconfigure_modbus_host",
+            data_schema=vol.Schema(
+                {
+                    vol.Required(CONF_MODBUS_HOST, default=current_host): str,
+                }
+            ),
+            errors=errors,
         )
 
     async def async_step_reconfigure_modbus(self, user_input: dict[str, Any] | None = None) -> ConfigFlowResult:
@@ -241,25 +276,55 @@ class SungrowConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         )
 
     async def async_step_user(self, user_input: dict[str, Any] | None = None) -> ConfigFlowResult:
-        """Handle the initial step."""
-        # Do not log user_input — it contains the app secret.
-        _LOGGER.debug("async_step_user called (user_input provided: %s)", user_input is not None)
+        """Present the transport-mode selector as the first step (#216)."""
+        if user_input is not None:
+            transport = user_input[CONF_TRANSPORT]
+            self._transport = transport
+            if transport == TRANSPORT_MODBUS_ONLY:
+                return await self.async_step_local_setup()
+            # cloud_only or cloud_modbus → cloud credentials
+            return await self.async_step_cloud_credentials()
+
+        from homeassistant.helpers.selector import SelectOptionDict, SelectSelector, SelectSelectorConfig
+
+        transport_options = [
+            SelectOptionDict(value=TRANSPORT_CLOUD_ONLY, label="Cloud Only"),
+            SelectOptionDict(value=TRANSPORT_CLOUD_MODBUS, label="Cloud + Modbus"),
+            SelectOptionDict(value=TRANSPORT_MODBUS_ONLY, label="Modbus Only"),
+        ]
+        return self.async_show_form(
+            step_id="user",
+            data_schema=vol.Schema(
+                {
+                    vol.Required(CONF_TRANSPORT, default=TRANSPORT_CLOUD_ONLY): SelectSelector(
+                        SelectSelectorConfig(options=transport_options, translation_key="transport")
+                    ),
+                }
+            ),
+        )
+
+    async def async_step_cloud_credentials(self, user_input: dict[str, Any] | None = None) -> ConfigFlowResult:
+        """Collect iSolarCloud API credentials (formerly async_step_user)."""
+        _LOGGER.debug("async_step_cloud_credentials called (user_input provided: %s)", user_input is not None)
         errors: dict[str, str] = {}
 
         if user_input is not None:
             self.init_info = user_input
             await self.async_set_unique_id(str(user_input[CONF_APP_ID]))
             self._abort_if_unique_id_configured()
+
+            # If hybrid mode, collect the Modbus host next.
+            if self._transport == TRANSPORT_CLOUD_MODBUS:
+                return await self.async_step_modbus_host()
+
             # Create the hub immediately, before authorizing. Setting up this
             # token-less entry runs async_setup — which registers the OAuth
             # callback view — and then raises ConfigEntryAuthFailed, so Home
-            # Assistant starts a reauth flow to finish authorization. This
-            # guarantees the callback endpoint exists before the OAuth redirect
-            # (fixing the first-install 404), and lets the user complete auth
-            # automatically via the redirect or manually by pasting the code/URL.
+            # Assistant starts a reauth flow to finish authorization.
+            data = {**user_input, CONF_TRANSPORT: self._transport or TRANSPORT_CLOUD_ONLY}
             return self.async_create_entry(
                 title=f"Sungrow {user_input[CONF_APP_ID]}",
-                data=user_input,
+                data=data,
             )
 
         # Attempt to automatically detect the callback URL
@@ -270,9 +335,7 @@ class SungrowConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
         default_redirect = f"{base_url}/api/sungrow_hass/callback"
 
-        self.context["title_placeholders"] = {
-            "app_id": user_input.get(CONF_APP_ID, "YourAppID") if user_input else "YourAppID"
-        }
+        self.context["title_placeholders"] = {"app_id": "YourAppID"}
 
         description_placeholders = {
             "url": "https://developer-api.isolarcloud.com/#/application",
@@ -280,7 +343,7 @@ class SungrowConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         }
 
         return self.async_show_form(
-            step_id="user",
+            step_id="cloud_credentials",
             description_placeholders=description_placeholders,
             data_schema=vol.Schema(
                 {
@@ -289,6 +352,77 @@ class SungrowConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                     vol.Required(CONF_APP_ID, default=""): str,
                     vol.Required(CONF_GATEWAY, default="Europe"): vol.In(list(GATEWAYS.keys())),
                     vol.Required(CONF_REDIRECT_URI, default=default_redirect): str,
+                }
+            ),
+            errors=errors,
+        )
+
+    async def async_step_modbus_host(self, user_input: dict[str, Any] | None = None) -> ConfigFlowResult:
+        """Collect the WiNet-S Modbus host for hybrid (Cloud + Modbus) mode (#216)."""
+        errors: dict[str, str] = {}
+
+        if user_input is not None:
+            host = (user_input.get(CONF_MODBUS_HOST) or "").strip()
+            from .helpers import async_test_modbus_host
+
+            if await async_test_modbus_host(host):
+                # Create the tokenless entry with the modbus host included.
+                data = {
+                    **self.init_info,
+                    CONF_TRANSPORT: TRANSPORT_CLOUD_MODBUS,
+                    CONF_MODBUS_HOST: host,
+                }
+                return self.async_create_entry(
+                    title=f"Sungrow {self.init_info[CONF_APP_ID]}",
+                    data=data,
+                )
+            errors["base"] = "host_unreachable"
+
+        # Pre-fill from zeroconf discovery if available.
+        default_host = self._discovered_modbus_host or ""
+        return self.async_show_form(
+            step_id="modbus_host",
+            data_schema=vol.Schema(
+                {
+                    vol.Required(CONF_MODBUS_HOST, default=default_host): str,
+                }
+            ),
+            errors=errors,
+        )
+
+    async def async_step_local_setup(self, user_input: dict[str, Any] | None = None) -> ConfigFlowResult:
+        """Collect host, serial, and model for a fully local Modbus Only entry (#216)."""
+        errors: dict[str, str] = {}
+
+        if user_input is not None:
+            host = (user_input.get(CONF_MODBUS_HOST) or "").strip()
+            serial = (user_input.get(CONF_SERIAL) or "").strip()
+            model = (user_input.get(CONF_MODEL) or "Inverter").strip()
+
+            from .helpers import async_test_modbus_host
+
+            if await async_test_modbus_host(host):
+                await self.async_set_unique_id(f"modbus_{serial}")
+                self._abort_if_unique_id_configured(updates={CONF_MODBUS_HOST: host})
+                return self.async_create_entry(
+                    title=f"Sungrow {model} (local)",
+                    data={
+                        CONF_TRANSPORT: TRANSPORT_MODBUS_ONLY,
+                        CONF_SERIAL: serial,
+                        CONF_MODEL: model,
+                        CONF_MODBUS_HOST: host,
+                    },
+                    options={CONF_SCAN_INTERVAL: DEFAULT_MODBUS_SCAN_INTERVAL},
+                )
+            errors["base"] = "host_unreachable"
+
+        return self.async_show_form(
+            step_id="local_setup",
+            data_schema=vol.Schema(
+                {
+                    vol.Required(CONF_MODBUS_HOST): str,
+                    vol.Required(CONF_SERIAL): str,
+                    vol.Required(CONF_MODEL, default="Inverter"): str,
                 }
             ),
             errors=errors,
@@ -641,10 +775,13 @@ class SungrowOptionsFlow(config_entries.OptionsFlowWithReload):
 
     async def async_step_init(self, user_input: dict[str, Any] | None = None) -> ConfigFlowResult:
         """Manage the integration options."""
+        transport = self.config_entry.data.get(CONF_TRANSPORT)
+
         # A cloud-free Modbus-only entry has none of the cloud settings (API quota,
         # extra measure points, per-device fetch); show only the local poll interval (#159).
-        if self.config_entry.data.get(CONF_TRANSPORT) == TRANSPORT_MODBUS_ONLY:
+        if transport == TRANSPORT_MODBUS_ONLY:
             return await self.async_step_modbus_options(user_input)
+
         errors: dict[str, str] = {}
         if user_input is not None:
             # Normalise the free-text mapping into a dict before storing.
@@ -654,32 +791,63 @@ class SungrowOptionsFlow(config_entries.OptionsFlowWithReload):
                 errors["base"] = "invalid_extra_measure_points"
                 _LOGGER.warning("Invalid extra measure points input: %s", exc)
             else:
+                modbus_host = (user_input.get(CONF_MODBUS_HOST) or "").strip()
                 data = {**user_input, CONF_EXTRA_MEASURE_POINTS: extras}
-                # Cloud options never carry Modbus — local is a separate entry.
                 data.pop(CONF_MODBUS_HOST, None)
                 data.pop(CONF_MODBUS_DEBUG_DAILY_YIELD, None)
-                return self.async_create_entry(title="", data=data)
+
+                # Transport switching: cloud_only + host → cloud_modbus
+                if transport == TRANSPORT_CLOUD_ONLY and modbus_host:
+                    from .helpers import async_test_modbus_host
+
+                    if await async_test_modbus_host(modbus_host):
+                        new_data = {
+                            **self.config_entry.data,
+                            CONF_TRANSPORT: TRANSPORT_CLOUD_MODBUS,
+                            CONF_MODBUS_HOST: modbus_host,
+                        }
+                        self.hass.config_entries.async_update_entry(self.config_entry, data=new_data)
+                    else:
+                        errors["base"] = "host_unreachable"
+
+                # Transport switching: cloud_modbus + cleared host → cloud_only
+                elif transport == TRANSPORT_CLOUD_MODBUS and not modbus_host:
+                    new_data = {k: v for k, v in self.config_entry.data.items() if k != CONF_MODBUS_HOST}
+                    new_data[CONF_TRANSPORT] = TRANSPORT_CLOUD_ONLY
+                    self.hass.config_entries.async_update_entry(self.config_entry, data=new_data)
+
+                if not errors:
+                    return self.async_create_entry(title="", data=data)
 
         current_interval = self.config_entry.options.get(CONF_SCAN_INTERVAL, DEFAULT_SCAN_INTERVAL)
         current_extras = self.config_entry.options.get(CONF_EXTRA_MEASURE_POINTS, {})
         current_device_sensors = self.config_entry.options.get(CONF_ENABLE_DEVICE_SENSORS, False)
         extras_str = ",".join(f"{pid}={code}" for pid, code in current_extras.items())
+
+        schema_fields: dict[Any, Any] = {
+            vol.Required(CONF_SCAN_INTERVAL, default=current_interval): vol.All(
+                vol.Coerce(int),
+                vol.Range(min=MIN_SCAN_INTERVAL, max=MAX_SCAN_INTERVAL),
+            ),
+            vol.Optional(
+                CONF_EXTRA_MEASURE_POINTS,
+                default=extras_str,
+                description={"suggested_value": extras_str},
+            ): str,
+            vol.Optional(CONF_ENABLE_DEVICE_SENSORS, default=current_device_sensors): bool,
+        }
+
+        # For cloud_only: show optional modbus_host field to allow switching to hybrid.
+        # For cloud_modbus: show current host (user can clear to switch back to cloud_only).
+        if transport == TRANSPORT_CLOUD_ONLY:
+            schema_fields[vol.Optional(CONF_MODBUS_HOST, default="")] = str
+        elif transport == TRANSPORT_CLOUD_MODBUS:
+            current_host = self.config_entry.data.get(CONF_MODBUS_HOST, "")
+            schema_fields[vol.Optional(CONF_MODBUS_HOST, default=current_host)] = str
+
         return self.async_show_form(
             step_id="init",
-            data_schema=vol.Schema(
-                {
-                    vol.Required(CONF_SCAN_INTERVAL, default=current_interval): vol.All(
-                        vol.Coerce(int),
-                        vol.Range(min=MIN_SCAN_INTERVAL, max=MAX_SCAN_INTERVAL),
-                    ),
-                    vol.Optional(
-                        CONF_EXTRA_MEASURE_POINTS,
-                        default=extras_str,
-                        description={"suggested_value": extras_str},
-                    ): str,
-                    vol.Optional(CONF_ENABLE_DEVICE_SENSORS, default=current_device_sensors): bool,
-                }
-            ),
+            data_schema=vol.Schema(schema_fields),
             errors=errors,
         )
 

--- a/custom_components/sungrow/const.py
+++ b/custom_components/sungrow/const.py
@@ -1,5 +1,7 @@
 """Constants for the Sungrow iSolarCloud integration."""
 
+from datetime import timedelta
+
 from pysolarcloud.plants import DeviceType
 
 DOMAIN = "sungrow"
@@ -32,11 +34,30 @@ DEFAULT_MODBUS_UNIT = 1
 # discovery of a WiNet-S (#159). Such an entry carries no cloud credentials; its
 # realtime data comes entirely from local Modbus.
 CONF_TRANSPORT = "transport"
+TRANSPORT_CLOUD_ONLY = "cloud_only"
+TRANSPORT_CLOUD_MODBUS = "cloud_modbus"
 TRANSPORT_MODBUS_ONLY = "modbus_only"
 # Discovered WiNet-S identity stored on a Modbus-only entry.
 CONF_MODEL = "model"
 CONF_SERIAL = "serial"
 DEFAULT_MODBUS_SCAN_INTERVAL = 30
+
+# Backfill historical statistics (see specs/backfill-historical-statistics).
+# The History_Window defaults to 30 days back from now, is user-configurable via the
+# CONF_BACKFILL_DAYS option, and is clamped to [1, 365] days so a run can never request
+# an unbounded range.
+CONF_BACKFILL_DAYS = "backfill_days"
+DEFAULT_BACKFILL_DAYS = 30
+MAX_BACKFILL_DAYS = 365
+# The historical endpoint returns ~5-minute cadence rows; request that interval and
+# split the window into 3-hour Time_Chunks to stay within the per-call query window.
+BACKFILL_INTERVAL = timedelta(minutes=5)
+BACKFILL_CHUNK_WINDOW = timedelta(hours=3)
+# At most 50 Backfill_Points per Historical_Data_API call (endpoint per-call point cap).
+MAX_POINTS_PER_CALL = 50
+# Minimum seconds between historical calls (throttle) and the transient-error retry cap.
+BACKFILL_MIN_CALL_INTERVAL = 1.0
+BACKFILL_MAX_RETRIES = 3
 
 GATEWAYS = {
     "Europe": "https://gateway.isolarcloud.eu",
@@ -129,6 +150,22 @@ INVERTER_DIAGNOSTIC_POINTS: dict[str, str] = {
     "76": "string_7_current",
     "103": "string_8_voltage",
     "77": "string_8_current",
+}
+
+# SH-family hybrids/ESS report MPPT voltage/current on a separate point-ID range
+# than string inverters (#189 follow-up). Reuse the same mpptN_* code names so the
+# existing classification/naming/icon path treats them identically; only the point
+# IDs differ. These are already in the measure-point catalog (units V/A), so they
+# classify by unit automatically.
+ESS_MPPT_DIAGNOSTIC_POINTS: dict[str, str] = {
+    "13001": "mppt1_voltage",
+    "13002": "mppt1_current",
+    "13105": "mppt2_voltage",
+    "13106": "mppt2_current",
+    "13107": "mppt3_voltage",
+    "13108": "mppt3_current",
+    "13109": "mppt4_voltage",
+    "13110": "mppt4_current",
 }
 
 # Battery/ESS device-level measuring points surfaced as sensors for hybrid users (#154),

--- a/custom_components/sungrow/coordinator.py
+++ b/custom_components/sungrow/coordinator.py
@@ -34,6 +34,7 @@ from .const import (
     DEFAULT_SCAN_INTERVAL,
     DEVICE_REFRESH_INTERVAL,
     DOMAIN,
+    ESS_MPPT_DIAGNOSTIC_POINTS,
     ESS_OPERATING_STATUS_POINT,
     INVERTER_DIAGNOSTIC_POINTS,
     INVERTER_OPERATING_STATUS_POINT,
@@ -539,7 +540,18 @@ class SungrowPlantCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                         # An ESS reports operating status on 13146 (already requested above);
                         # drop the inverter point 29 so the two don't collide on the shared
                         # "operating_status" code and silently overwrite each other (#182).
-                        diagnostic = {pid: code for pid, code in INVERTER_DIAGNOSTIC_POINTS.items() if pid != "29"}
+                        # ESS also reports MPPT on a separate 13xxx range: drop the
+                        # string-inverter MPPT IDs (5-10) and merge the hybrid MPPT IDs
+                        # instead. Both ranges share the mpptN_* codes, so requesting BOTH
+                        # would map two IDs to one code and silently overwrite each other in
+                        # the per-device merge.
+                        string_inverter_mppt_ids = {"5", "6", "7", "8", "9", "10"}
+                        diagnostic = {
+                            pid: code
+                            for pid, code in INVERTER_DIAGNOSTIC_POINTS.items()
+                            if pid != "29" and pid not in string_inverter_mppt_ids
+                        }
+                        diagnostic = {**diagnostic, **ESS_MPPT_DIAGNOSTIC_POINTS}
                     extra.update(diagnostic)
                 if type_id in (DeviceType.BATTERY.value, DeviceType.ENERGY_STORAGE_SYSTEM.value):
                     extra.update(BATTERY_DEVICE_POINTS)

--- a/custom_components/sungrow/helpers.py
+++ b/custom_components/sungrow/helpers.py
@@ -1,0 +1,22 @@
+"""Shared helper utilities for the Sungrow iSolarCloud integration."""
+
+import asyncio
+
+
+async def async_test_modbus_host(host: str, port: int = 502, timeout: float = 5.0) -> bool:
+    """Test TCP reachability of a Modbus host.
+
+    Attempts a TCP connection to host:port with the given timeout.
+    Returns True if connection succeeds (socket is closed immediately).
+    Returns False on any failure (timeout, refused, DNS error) without raising.
+    """
+    try:
+        reader, writer = await asyncio.wait_for(
+            asyncio.open_connection(host, port),
+            timeout=timeout,
+        )
+        writer.close()
+        await writer.wait_closed()
+    except Exception:  # noqa: BLE001
+        return False
+    return True

--- a/custom_components/sungrow/manifest.json
+++ b/custom_components/sungrow/manifest.json
@@ -1,15 +1,15 @@
 {
   "domain": "sungrow",
   "name": "Sungrow iSolarCloud",
+  "after_dependencies": [
+    "recorder"
+  ],
   "codeowners": [
     "@KRoperUK"
   ],
   "config_flow": true,
   "dependencies": [
     "http"
-  ],
-  "after_dependencies": [
-    "recorder"
   ],
   "documentation": "https://github.com/KRoperUK/sungrow-hass",
   "integration_type": "hub",

--- a/custom_components/sungrow/manifest.json
+++ b/custom_components/sungrow/manifest.json
@@ -6,7 +6,9 @@
   ],
   "config_flow": true,
   "dependencies": [
-    "http",
+    "http"
+  ],
+  "after_dependencies": [
     "recorder"
   ],
   "documentation": "https://github.com/KRoperUK/sungrow-hass",

--- a/custom_components/sungrow/manifest.json
+++ b/custom_components/sungrow/manifest.json
@@ -6,7 +6,8 @@
   ],
   "config_flow": true,
   "dependencies": [
-    "http"
+    "http",
+    "recorder"
   ],
   "documentation": "https://github.com/KRoperUK/sungrow-hass",
   "integration_type": "hub",

--- a/custom_components/sungrow/sensor.py
+++ b/custom_components/sungrow/sensor.py
@@ -18,6 +18,7 @@ from .const import (
     COMM_MODULE_POINTS,
     CONF_GATEWAY,
     DEFAULT_CONSOLE_URL,
+    ESS_MPPT_DIAGNOSTIC_POINTS,
     GATEWAY_CONSOLE_URLS,
     INVERTER_DIAGNOSTIC_POINTS,
 )
@@ -40,7 +41,10 @@ _LOGGER = logging.getLogger(__name__)
 # Inverter + battery-health point codes get the DIAGNOSTIC entity category so they land
 # in the device page's Diagnostic section instead of cluttering the main sensors (#149/#154).
 _DIAGNOSTIC_CODES = (
-    frozenset(INVERTER_DIAGNOSTIC_POINTS.values()) | BATTERY_DIAGNOSTIC_CODES | frozenset(COMM_MODULE_POINTS.values())
+    frozenset(INVERTER_DIAGNOSTIC_POINTS.values())
+    | frozenset(ESS_MPPT_DIAGNOSTIC_POINTS.values())
+    | BATTERY_DIAGNOSTIC_CODES
+    | frozenset(COMM_MODULE_POINTS.values())
 )
 
 # Sentinel unit: tariff sensors take their unit from the plant's currency at runtime.

--- a/custom_components/sungrow/services.py
+++ b/custom_components/sungrow/services.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 
 import logging
 from datetime import datetime, time
+from typing import Any
 
 import voluptuous as vol
 from homeassistant.config_entries import ConfigEntryState
@@ -39,7 +40,7 @@ _SERVICE_SCHEMA = vol.Schema(
 )
 
 
-def _cloud_backfill_entries(hass: HomeAssistant) -> list:
+def _cloud_backfill_entries(hass: HomeAssistant) -> list[Any]:
     """Return every loaded cloud Sungrow config entry (those that own a manager)."""
     return [
         entry
@@ -48,7 +49,7 @@ def _cloud_backfill_entries(hass: HomeAssistant) -> list:
     ]
 
 
-def _resolve_entries(hass: HomeAssistant, entry_id: str | None) -> list:
+def _resolve_entries(hass: HomeAssistant, entry_id: str | None) -> list[Any]:
     """Resolve the addressed cloud entries, defaulting to all loaded cloud entries."""
     if entry_id is None:
         return _cloud_backfill_entries(hass)

--- a/custom_components/sungrow/services.py
+++ b/custom_components/sungrow/services.py
@@ -1,0 +1,88 @@
+"""The on-demand Backfill service for the Sungrow iSolarCloud integration.
+
+Registers ``sungrow.backfill`` as an admin service. A call resolves the addressed cloud
+config entry (or every loaded cloud entry when none is given), reads its
+``runtime_data.backfill`` manager and asks it to run on demand. An optional ``start_date``
+(a date) is interpreted as UTC midnight and passed straight through as the run's window
+start override.
+
+See ``.kiro/specs/backfill-historical-statistics`` for the design and requirements
+(Requirements 2.1, 2.2, 2.3).
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import datetime, time
+
+import voluptuous as vol
+from homeassistant.config_entries import ConfigEntryState
+from homeassistant.core import HomeAssistant, ServiceCall
+from homeassistant.exceptions import ServiceValidationError
+from homeassistant.helpers import config_validation as cv
+from homeassistant.helpers.service import async_register_admin_service
+from homeassistant.util import dt as dt_util
+
+from .const import CONF_TRANSPORT, DOMAIN, TRANSPORT_MODBUS_ONLY
+
+_LOGGER = logging.getLogger(__name__)
+
+SERVICE_BACKFILL = "backfill"
+ATTR_CONFIG_ENTRY = "config_entry"
+ATTR_START_DATE = "start_date"
+
+_SERVICE_SCHEMA = vol.Schema(
+    {
+        vol.Optional(ATTR_CONFIG_ENTRY): cv.string,
+        vol.Optional(ATTR_START_DATE): cv.date,
+    }
+)
+
+
+def _cloud_backfill_entries(hass: HomeAssistant) -> list:
+    """Return every loaded cloud Sungrow config entry (those that own a manager)."""
+    return [
+        entry
+        for entry in hass.config_entries.async_entries(DOMAIN)
+        if entry.state is ConfigEntryState.LOADED and entry.data.get(CONF_TRANSPORT) != TRANSPORT_MODBUS_ONLY
+    ]
+
+
+def _resolve_entries(hass: HomeAssistant, entry_id: str | None) -> list:
+    """Resolve the addressed cloud entries, defaulting to all loaded cloud entries."""
+    if entry_id is None:
+        return _cloud_backfill_entries(hass)
+    entry = hass.config_entries.async_get_entry(entry_id)
+    if entry is None or entry.domain != DOMAIN:
+        raise ServiceValidationError(f"No Sungrow config entry found for '{entry_id}'")
+    if entry.state is not ConfigEntryState.LOADED:
+        raise ServiceValidationError(f"Sungrow config entry '{entry_id}' is not loaded")
+    if entry.data.get(CONF_TRANSPORT) == TRANSPORT_MODBUS_ONLY:
+        raise ServiceValidationError(f"Config entry '{entry_id}' is a local Modbus entry; Backfill is cloud-only")
+    return [entry]
+
+
+def async_setup_services(hass: HomeAssistant) -> None:
+    """Register the ``sungrow.backfill`` admin service exactly once (Requirement 2.1)."""
+    if hass.services.has_service(DOMAIN, SERVICE_BACKFILL):
+        return
+
+    async def _handle_backfill(call: ServiceCall) -> None:
+        """Dispatch an on-demand Backfill to the addressed cloud entries' managers."""
+        entry_id = call.data.get(ATTR_CONFIG_ENTRY)
+        start_date = call.data.get(ATTR_START_DATE)
+        # A date selector yields a date; interpret it as UTC midnight (Requirement 2.3).
+        start_override: datetime | None = None
+        if start_date is not None:
+            start_override = datetime.combine(start_date, time.min, tzinfo=dt_util.UTC)
+
+        entries = _resolve_entries(hass, entry_id)
+        for entry in entries:
+            manager = getattr(entry.runtime_data, "backfill", None)
+            if manager is None:
+                _LOGGER.debug("Skipping Backfill for entry %s: no manager", entry.entry_id)
+                continue
+            await manager.async_run_on_demand(plant_ids=None, start_date=start_override)
+
+    async_register_admin_service(hass, DOMAIN, SERVICE_BACKFILL, _handle_backfill, schema=_SERVICE_SCHEMA)
+    _LOGGER.debug("Registered %s.%s service", DOMAIN, SERVICE_BACKFILL)

--- a/custom_components/sungrow/services.yaml
+++ b/custom_components/sungrow/services.yaml
@@ -1,0 +1,11 @@
+backfill:
+  fields:
+    config_entry:
+      required: false
+      selector:
+        config_entry:
+          integration: sungrow
+    start_date:
+      required: false
+      selector:
+        date:

--- a/custom_components/sungrow/strings.json
+++ b/custom_components/sungrow/strings.json
@@ -2,6 +2,13 @@
   "config": {
     "step": {
       "user": {
+        "title": "Choose Transport Mode",
+        "description": "Select how the integration connects to your Sungrow inverter.",
+        "data": {
+          "transport": "Transport mode"
+        }
+      },
+      "cloud_credentials": {
         "title": "Connect to iSolarCloud",
         "description": "Enter your iSolarCloud API credentials. You can find them here: [iSolarCloud]({url})\n\nAfter you submit, the hub is created and Home Assistant will prompt you to authorize it in your browser.",
         "data": {
@@ -15,6 +22,22 @@
           "app_key": "AppKey from iSolarCloud Developer Platform.",
           "app_secret": "AppSecret from iSolarCloud Developer Platform.",
           "app_id": "App ID from iSolarCloud Developer Platform. To find this, go to your application and look for 'id' within the URL like so: {app_id_url}."
+        }
+      },
+      "modbus_host": {
+        "title": "Modbus Host",
+        "description": "Enter the IP address or hostname of your WiNet-S dongle for local Modbus communication.",
+        "data": {
+          "modbus_host": "WiNet-S IP / hostname"
+        }
+      },
+      "local_setup": {
+        "title": "Local Modbus Setup",
+        "description": "Enter the connection details for your local WiNet-S dongle. No cloud account is required.",
+        "data": {
+          "modbus_host": "WiNet-S IP / hostname",
+          "serial": "Inverter serial number",
+          "model": "Inverter model"
         }
       },
       "auth_callback": {
@@ -38,6 +61,13 @@
           "redirect_uri": "Redirect URI"
         }
       },
+      "reconfigure_modbus_host": {
+        "title": "Update Modbus Host",
+        "description": "Update the WiNet-S IP address for this hybrid (Cloud + Modbus) entry.",
+        "data": {
+          "modbus_host": "WiNet-S IP / hostname"
+        }
+      },
       "zeroconf_confirm": {
         "title": "Set up local Sungrow inverter",
         "description": "A Sungrow **{model}** was discovered on your network at **{host}** (WiNet-S). Set it up as a **separate local entry** that reads the inverter over Modbus — fast, unmetered and offline-capable, with no iSolarCloud account required. If you also have a cloud entry for the same inverter, both stay independent (the local device is linked under the cloud plant when serials match)."
@@ -55,6 +85,7 @@
     },
     "error": {
       "cannot_connect": "Failed to connect",
+      "host_unreachable": "The WiNet-S host is unreachable on port 502. Check the IP and ensure the dongle is online.",
       "invalid_auth": "Invalid authentication",
       "invalid_extra_measure_points": "Extra measure points must be in the form point_id=code, comma separated",
       "unknown": "Unexpected error"
@@ -77,7 +108,8 @@
         "data": {
           "scan_interval": "Polling interval (seconds)",
           "extra_measure_points": "Extra measure points (point_id=code, comma separated)",
-          "enable_device_sensors": "Create per-device sensors (EV chargers, meters, extra batteries)"
+          "enable_device_sensors": "Create per-device sensors (EV chargers, meters, extra batteries)",
+          "modbus_host": "WiNet-S Modbus host (enter to enable hybrid, clear to disable)"
         }
       },
       "modbus_options": {
@@ -98,6 +130,10 @@
     "rate_limited": {
       "title": "iSolarCloud API rate limit reached",
       "description": "iSolarCloud is rejecting requests for **{plant}** because the API call limit was reached (E998/E999). Increase the polling interval in the integration options to make fewer calls; it recovers when the quota resets."
+    },
+    "backfill_partial": {
+      "title": "Historical backfill finished with gaps",
+      "description": "The historical statistics backfill for **{plant}** finished but {failed_chunks} time range(s) could not be imported, so the History and Energy dashboards may have gaps for that period. Re-run **Developer Tools → Actions → Sungrow: Backfill historical statistics** to fill the gaps; the successful hours are already imported and re-running only overwrites them cleanly."
     }
   },
   "entity": {
@@ -168,6 +204,22 @@
   "exceptions": {
     "dispatch_write_failed": {
       "message": "Failed to update {param} on the inverter: {error}"
+    }
+  },
+  "services": {
+    "backfill": {
+      "name": "Backfill historical statistics",
+      "description": "Import historical iSolarCloud data into Home Assistant long-term statistics so the History and Energy dashboards are populated immediately.",
+      "fields": {
+        "config_entry": {
+          "name": "Integration",
+          "description": "The Sungrow (cloud) integration entry to backfill. Leave empty to backfill every loaded cloud entry."
+        },
+        "start_date": {
+          "name": "Start date",
+          "description": "Optional earliest date to import from (interpreted as UTC midnight). Defaults to the configured backfill window."
+        }
+      }
     }
   }
 }

--- a/custom_components/sungrow/translations/cy.json
+++ b/custom_components/sungrow/translations/cy.json
@@ -5,16 +5,39 @@
         "title": "Cysylltu ag iSolarCloud",
         "description": "Rhowch eich manylion mynediad API iSolarCloud. Gallwch ddod o hyd iddynt yma: [iSolarCloud]({url})\n\nAr ôl i chi gyflwyno, caiff yr hyb ei greu a bydd Home Assistant yn gofyn i chi ei awdurdodi yn eich porwr.",
         "data": {
-          "gateway": "Rhanbarth y Porth",
+          "transport": "Transport mode"
+        }
+      },
+      "cloud_credentials": {
+        "title": "Connect to iSolarCloud",
+        "description": "Enter your iSolarCloud API credentials. You can find them here: [iSolarCloud]({url})\n\nAfter you submit, the hub is created and Home Assistant will prompt you to authorize it in your browser.",
+        "data": {
+          "gateway": "Gateway Region",
           "app_key": "AppKey",
           "app_secret": "App Secret",
           "app_id": "App ID",
-          "redirect_uri": "URI Ailgyfeirio"
+          "redirect_uri": "Redirect URI"
         },
         "data_description": {
-          "app_key": "AppKey o Blatfform Datblygwyr iSolarCloud.",
-          "app_secret": "AppSecret o Blatfform Datblygwyr iSolarCloud.",
-          "app_id": "App ID o Blatfform Datblygwyr iSolarCloud. I ddod o hyd i hwn, ewch i'ch cymhwysiad a chwiliwch am 'id' o fewn yr URL fel hyn: {app_id_url}."
+          "app_key": "AppKey from iSolarCloud Developer Platform.",
+          "app_secret": "AppSecret from iSolarCloud Developer Platform.",
+          "app_id": "App ID from iSolarCloud Developer Platform. To find this, go to your application and look for 'id' within the URL like so: {app_id_url}."
+        }
+      },
+      "modbus_host": {
+        "title": "Modbus Host",
+        "description": "Enter the IP address or hostname of your WiNet-S dongle for local Modbus communication.",
+        "data": {
+          "modbus_host": "WiNet-S IP / hostname"
+        }
+      },
+      "local_setup": {
+        "title": "Local Modbus Setup",
+        "description": "Enter the connection details for your local WiNet-S dongle. No cloud account is required.",
+        "data": {
+          "modbus_host": "WiNet-S IP / hostname",
+          "serial": "Inverter serial number",
+          "model": "Inverter model"
         }
       },
       "auth_callback": {
@@ -38,6 +61,13 @@
           "redirect_uri": "URI Ailgyfeirio"
         }
       },
+      "reconfigure_modbus_host": {
+        "title": "Update Modbus Host",
+        "description": "Update the WiNet-S IP address for this hybrid (Cloud + Modbus) entry.",
+        "data": {
+          "modbus_host": "WiNet-S IP / hostname"
+        }
+      },
       "zeroconf_confirm": {
         "title": "Gosod gwrthdröydd Sungrow lleol",
         "description": "Canfuwyd **{model}** Sungrow ar eich rhwydwaith yn **{host}** (WiNet-S). Crëwch ef fel **cofnod lleol ar wahân** sy'n darllen y gwrthdröydd dros Modbus — cyflym, heb fesur ac yn gweithio all-lein, heb angen cyfrif iSolarCloud. Os oes gennych chi hefyd gofnod cwmwl ar gyfer yr un gwrthdröydd, mae'r ddau'n aros annibynnol (mae'r ddyfais leol yn gysylltiedig o dan y planhigyn cwmwl pan mae'r rhifau serial yn cyfateb)."
@@ -55,18 +85,19 @@
     },
     "error": {
       "cannot_connect": "Methwyd â chysylltu",
+      "host_unreachable": "The WiNet-S host is unreachable on port 502. Check the IP and ensure the dongle is online.",
       "invalid_auth": "Dilysiad annilys",
       "invalid_extra_measure_points": "Rhaid i bwyntiau mesur ychwanegol fod ar ffurf point_id=code, wedi'u gwahanu gan atalnodau",
       "unknown": "Gwall annisgwyl"
     },
     "abort": {
       "already_configured": "Mae'r ddyfais eisoes wedi'i ffurfweddu",
+      "not_sungrow_device": "Nid yw'r ddyfais a ddarganfuwyd yn wrthdröydd Sungrow a gefnogir.",
       "library_missing": "Nid yw'r llyfrgell pysolarcloud wedi'i gosod. Ailgychwynnwch Home Assistant fel bod gofynion yr integreiddiad wedi'u gosod, yna rhowch gynnig arall arni.",
       "missing_code": "Ni dderbyniwyd y cod awdurdodi. Rhowch gynnig arall arni.",
       "reauth_successful": "Roedd yr ail-ddilysiad yn llwyddiannus",
       "reconfigure_successful": "Roedd yr ailgyflunio'n llwyddiannus",
-      "wrong_account": "Nid yw'r cyfrif awdurdodedig yn cyfateb i App ID yr integreiddiad hwn. Defnyddiwch y cymhwysiad datblygwr gwreiddiol.",
-      "not_sungrow_device": "Nid yw'r ddyfais a ddarganfuwyd yn wrthdröydd Sungrow a gefnogir."
+      "wrong_account": "Nid yw'r cyfrif awdurdodedig yn cyfateb i App ID yr integreiddiad hwn. Defnyddiwch y cymhwysiad datblygwr gwreiddiol."
     }
   },
   "options": {
@@ -77,7 +108,8 @@
         "data": {
           "scan_interval": "Cyfwng holi (eiliadau)",
           "extra_measure_points": "Pwyntiau mesur ychwanegol (point_id=code, wedi'u gwahanu gan atalnodau)",
-          "enable_device_sensors": "Creu synwyryddion fesul dyfais (gwefrwyr EV, mesuryddion, batris ychwanegol)"
+          "enable_device_sensors": "Creu synwyryddion fesul dyfais (gwefrwyr EV, mesuryddion, batris ychwanegol)",
+          "modbus_host": "WiNet-S Modbus host (enter to enable hybrid, clear to disable)"
         }
       },
       "modbus_options": {
@@ -98,6 +130,10 @@
     "rate_limited": {
       "title": "Cyrhaeddwyd terfyn cyfradd API iSolarCloud",
       "description": "Mae iSolarCloud yn gwrthod ceisiadau ar gyfer **{plant}** oherwydd cyrhaeddwyd y terfyn galwadau API (E998/E999). Cynyddwch y cyfwng holi yn opsiynau'r integreiddiad i wneud llai o alwadau; mae'n adfer pan fydd y cwota'n ailosod."
+    },
+    "backfill_partial": {
+      "title": "Gorffennodd y llenwi hanesyddol gyda bylchau",
+      "description": "Gorffennodd llenwi'r ystadegau hanesyddol ar gyfer **{plant}** ond ni ellid mewnforio {failed_chunks} ystod amser, felly gall fod bylchau ar y dangosfyrddau Hanes ac Ynni ar gyfer y cyfnod hwnnw. Ail-redwch **Offer Datblygwyr → Gweithredoedd → Sungrow: Llenwi ystadegau hanesyddol** i lenwi'r bylchau; mae'r oriau llwyddiannus wedi'u mewnforio'n barod ac mae ail-redeg ond yn eu trosysgrifo'n lân."
     }
   },
   "entity": {
@@ -168,6 +204,22 @@
   "exceptions": {
     "dispatch_write_failed": {
       "message": "Methwyd â diweddaru {param} ar y gwrthdröydd: {error}"
+    }
+  },
+  "services": {
+    "backfill": {
+      "name": "Llenwi ystadegau hanesyddol",
+      "description": "Mewnforio data hanesyddol iSolarCloud i ystadegau hirdymor Home Assistant fel bod y dangosfyrddau Hanes ac Ynni yn cael eu poblogi ar unwaith.",
+      "fields": {
+        "config_entry": {
+          "name": "Integreiddiad",
+          "description": "Y cofnod integreiddiad Sungrow (cwmwl) i'w lenwi. Gadewch yn wag i lenwi pob cofnod cwmwl sydd wedi'i lwytho."
+        },
+        "start_date": {
+          "name": "Dyddiad dechrau",
+          "description": "Dyddiad cynharaf dewisol i fewnforio ohono (dehonglir fel hanner nos UTC). Rhagosodiad yw'r ffenestr lenwi a ffurfweddwyd."
+        }
+      }
     }
   }
 }

--- a/custom_components/sungrow/translations/de.json
+++ b/custom_components/sungrow/translations/de.json
@@ -5,16 +5,39 @@
         "title": "Mit iSolarCloud verbinden",
         "description": "Geben Sie Ihre iSolarCloud-API-Zugangsdaten ein. Sie finden diese hier: [iSolarCloud]({url})\n\nNach dem Absenden wird der Hub erstellt und Home Assistant fordert Sie auf, ihn in Ihrem Browser zu autorisieren.",
         "data": {
-          "gateway": "Gateway-Region",
+          "transport": "Transport mode"
+        }
+      },
+      "cloud_credentials": {
+        "title": "Connect to iSolarCloud",
+        "description": "Enter your iSolarCloud API credentials. You can find them here: [iSolarCloud]({url})\n\nAfter you submit, the hub is created and Home Assistant will prompt you to authorize it in your browser.",
+        "data": {
+          "gateway": "Gateway Region",
           "app_key": "AppKey",
           "app_secret": "App Secret",
           "app_id": "App ID",
-          "redirect_uri": "Weiterleitungs-URI"
+          "redirect_uri": "Redirect URI"
         },
         "data_description": {
-          "app_key": "AppKey aus der iSolarCloud-Entwicklerplattform.",
-          "app_secret": "AppSecret aus der iSolarCloud-Entwicklerplattform.",
-          "app_id": "App ID aus der iSolarCloud-Entwicklerplattform. Um diese zu finden, öffnen Sie Ihre Anwendung und suchen Sie in der URL nach 'id', wie hier: {app_id_url}."
+          "app_key": "AppKey from iSolarCloud Developer Platform.",
+          "app_secret": "AppSecret from iSolarCloud Developer Platform.",
+          "app_id": "App ID from iSolarCloud Developer Platform. To find this, go to your application and look for 'id' within the URL like so: {app_id_url}."
+        }
+      },
+      "modbus_host": {
+        "title": "Modbus Host",
+        "description": "Enter the IP address or hostname of your WiNet-S dongle for local Modbus communication.",
+        "data": {
+          "modbus_host": "WiNet-S IP / hostname"
+        }
+      },
+      "local_setup": {
+        "title": "Local Modbus Setup",
+        "description": "Enter the connection details for your local WiNet-S dongle. No cloud account is required.",
+        "data": {
+          "modbus_host": "WiNet-S IP / hostname",
+          "serial": "Inverter serial number",
+          "model": "Inverter model"
         }
       },
       "auth_callback": {
@@ -38,6 +61,13 @@
           "redirect_uri": "Weiterleitungs-URI"
         }
       },
+      "reconfigure_modbus_host": {
+        "title": "Update Modbus Host",
+        "description": "Update the WiNet-S IP address for this hybrid (Cloud + Modbus) entry.",
+        "data": {
+          "modbus_host": "WiNet-S IP / hostname"
+        }
+      },
       "zeroconf_confirm": {
         "title": "Lokalen Sungrow-Wechselrichter einrichten",
         "description": "Ein Sungrow **{model}** wurde in Ihrem Netzwerk unter **{host}** (WiNet-S) gefunden. Richten Sie ihn als **separaten lokalen Eintrag** ein, der den Wechselrichter über Modbus ausliest — schnell, unbegrenzt und offline-fähig, ohne iSolarCloud-Konto. Wenn Sie auch einen Cloud-Eintrag für denselben Wechselrichter haben, bleiben beide unabhängig (das lokale Gerät wird unter der Cloud-Anlage verknüpft, wenn die Seriennummern übereinstimmen)."
@@ -55,18 +85,19 @@
     },
     "error": {
       "cannot_connect": "Verbindung fehlgeschlagen",
+      "host_unreachable": "The WiNet-S host is unreachable on port 502. Check the IP and ensure the dongle is online.",
       "invalid_auth": "Ungültige Authentifizierung",
       "invalid_extra_measure_points": "Zusätzliche Messpunkte müssen im Format point_id=code, durch Kommata getrennt, angegeben werden",
       "unknown": "Unerwarteter Fehler"
     },
     "abort": {
       "already_configured": "Das Gerät ist bereits konfiguriert",
+      "not_sungrow_device": "Das gefundene Gerät ist kein unterstützter Sungrow-Wechselrichter.",
       "library_missing": "Die Bibliothek pysolarcloud ist nicht installiert. Starten Sie Home Assistant neu, damit die Anforderungen der Integration installiert werden, und versuchen Sie es dann erneut.",
       "missing_code": "Der Autorisierungscode wurde nicht empfangen. Bitte versuchen Sie es erneut.",
       "reauth_successful": "Die erneute Authentifizierung war erfolgreich",
       "reconfigure_successful": "Die Neukonfiguration war erfolgreich",
-      "wrong_account": "Das autorisierte Konto stimmt nicht mit der App ID dieser Integration überein. Verwenden Sie die ursprüngliche Entwickleranwendung.",
-      "not_sungrow_device": "Das gefundene Gerät ist kein unterstützter Sungrow-Wechselrichter."
+      "wrong_account": "Das autorisierte Konto stimmt nicht mit der App ID dieser Integration überein. Verwenden Sie die ursprüngliche Entwickleranwendung."
     }
   },
   "options": {
@@ -77,7 +108,8 @@
         "data": {
           "scan_interval": "Abfrageintervall (Sekunden)",
           "extra_measure_points": "Zusätzliche Messpunkte (point_id=code, durch Kommata getrennt)",
-          "enable_device_sensors": "Sensoren pro Gerät erstellen (EV-Ladegeräte, Zähler, zusätzliche Batterien)"
+          "enable_device_sensors": "Sensoren pro Gerät erstellen (EV-Ladegeräte, Zähler, zusätzliche Batterien)",
+          "modbus_host": "WiNet-S Modbus host (enter to enable hybrid, clear to disable)"
         }
       },
       "modbus_options": {
@@ -98,6 +130,10 @@
     "rate_limited": {
       "title": "iSolarCloud-API-Ratenlimit erreicht",
       "description": "iSolarCloud lehnt Anfragen für **{plant}** ab, weil das API-Aufruflimit erreicht wurde (E998/E999). Erhöhen Sie das Abfrageintervall in den Integrationsoptionen, um weniger Aufrufe zu tätigen; die Verbindung wird wiederhergestellt, sobald das Kontingent zurückgesetzt wird."
+    },
+    "backfill_partial": {
+      "title": "Historische Rückfüllung mit Lücken abgeschlossen",
+      "description": "Die Rückfüllung der historischen Statistiken für **{plant}** wurde abgeschlossen, aber {failed_chunks} Zeitbereich(e) konnten nicht importiert werden, sodass die Verlaufs- und Energie-Dashboards für diesen Zeitraum Lücken aufweisen können. Führen Sie **Entwicklerwerkzeuge → Aktionen → Sungrow: Historische Statistiken rückfüllen** erneut aus, um die Lücken zu füllen; die erfolgreichen Stunden sind bereits importiert und ein erneuter Lauf überschreibt sie nur sauber."
     }
   },
   "entity": {
@@ -168,6 +204,22 @@
   "exceptions": {
     "dispatch_write_failed": {
       "message": "{param} konnte auf dem Wechselrichter nicht aktualisiert werden: {error}"
+    }
+  },
+  "services": {
+    "backfill": {
+      "name": "Historische Statistiken rückfüllen",
+      "description": "Importiert historische iSolarCloud-Daten in die Langzeitstatistiken von Home Assistant, damit die Verlaufs- und Energie-Dashboards sofort gefüllt werden.",
+      "fields": {
+        "config_entry": {
+          "name": "Integration",
+          "description": "Der zu rückfüllende Sungrow-(Cloud-)Integrationseintrag. Leer lassen, um jeden geladenen Cloud-Eintrag zu rückfüllen."
+        },
+        "start_date": {
+          "name": "Startdatum",
+          "description": "Optionales frühestes Datum, ab dem importiert wird (als UTC-Mitternacht interpretiert). Standard ist das konfigurierte Rückfüllfenster."
+        }
+      }
     }
   }
 }

--- a/custom_components/sungrow/translations/en.json
+++ b/custom_components/sungrow/translations/en.json
@@ -2,6 +2,13 @@
   "config": {
     "step": {
       "user": {
+        "title": "Choose Transport Mode",
+        "description": "Select how the integration connects to your Sungrow inverter.",
+        "data": {
+          "transport": "Transport mode"
+        }
+      },
+      "cloud_credentials": {
         "title": "Connect to iSolarCloud",
         "description": "Enter your iSolarCloud API credentials. You can find them here: [iSolarCloud]({url})\n\nAfter you submit, the hub is created and Home Assistant will prompt you to authorize it in your browser.",
         "data": {
@@ -15,6 +22,22 @@
           "app_key": "AppKey from iSolarCloud Developer Platform.",
           "app_secret": "AppSecret from iSolarCloud Developer Platform.",
           "app_id": "App ID from iSolarCloud Developer Platform. To find this, go to your application and look for 'id' within the URL like so: {app_id_url}."
+        }
+      },
+      "modbus_host": {
+        "title": "Modbus Host",
+        "description": "Enter the IP address or hostname of your WiNet-S dongle for local Modbus communication.",
+        "data": {
+          "modbus_host": "WiNet-S IP / hostname"
+        }
+      },
+      "local_setup": {
+        "title": "Local Modbus Setup",
+        "description": "Enter the connection details for your local WiNet-S dongle. No cloud account is required.",
+        "data": {
+          "modbus_host": "WiNet-S IP / hostname",
+          "serial": "Inverter serial number",
+          "model": "Inverter model"
         }
       },
       "auth_callback": {
@@ -38,6 +61,13 @@
           "redirect_uri": "Redirect URI"
         }
       },
+      "reconfigure_modbus_host": {
+        "title": "Update Modbus Host",
+        "description": "Update the WiNet-S IP address for this hybrid (Cloud + Modbus) entry.",
+        "data": {
+          "modbus_host": "WiNet-S IP / hostname"
+        }
+      },
       "zeroconf_confirm": {
         "title": "Set up local Sungrow inverter",
         "description": "A Sungrow **{model}** was discovered on your network at **{host}** (WiNet-S). Set it up as a **separate local entry** that reads the inverter over Modbus — fast, unmetered and offline-capable, with no iSolarCloud account required. If you also have a cloud entry for the same inverter, both stay independent (the local device is linked under the cloud plant when serials match)."
@@ -55,18 +85,19 @@
     },
     "error": {
       "cannot_connect": "Failed to connect",
+      "host_unreachable": "The WiNet-S host is unreachable on port 502. Check the IP and ensure the dongle is online.",
       "invalid_auth": "Invalid authentication",
       "invalid_extra_measure_points": "Extra measure points must be in the form point_id=code, comma separated",
       "unknown": "Unexpected error"
     },
     "abort": {
       "already_configured": "Device is already configured",
+      "not_sungrow_device": "The discovered device is not a supported Sungrow inverter.",
       "library_missing": "The pysolarcloud library is not installed. Restart Home Assistant so the integration's requirements are installed, then try again.",
       "missing_code": "Authorization code was not received. Please try again.",
       "reauth_successful": "Re-authentication was successful",
       "reconfigure_successful": "Reconfiguration was successful",
-      "wrong_account": "The authorized account does not match this integration's App ID. Use the original developer application.",
-      "not_sungrow_device": "The discovered device is not a supported Sungrow inverter."
+      "wrong_account": "The authorized account does not match this integration's App ID. Use the original developer application."
     }
   },
   "options": {
@@ -77,7 +108,8 @@
         "data": {
           "scan_interval": "Polling interval (seconds)",
           "extra_measure_points": "Extra measure points (point_id=code, comma separated)",
-          "enable_device_sensors": "Create per-device sensors (EV chargers, meters, extra batteries)"
+          "enable_device_sensors": "Create per-device sensors (EV chargers, meters, extra batteries)",
+          "modbus_host": "WiNet-S Modbus host (enter to enable hybrid, clear to disable)"
         }
       },
       "modbus_options": {
@@ -98,6 +130,10 @@
     "rate_limited": {
       "title": "iSolarCloud API rate limit reached",
       "description": "iSolarCloud is rejecting requests for **{plant}** because the API call limit was reached (E998/E999). Increase the polling interval in the integration options to make fewer calls; it recovers when the quota resets."
+    },
+    "backfill_partial": {
+      "title": "Historical backfill finished with gaps",
+      "description": "The historical statistics backfill for **{plant}** finished but {failed_chunks} time range(s) could not be imported, so the History and Energy dashboards may have gaps for that period. Re-run **Developer Tools → Actions → Sungrow: Backfill historical statistics** to fill the gaps; the successful hours are already imported and re-running only overwrites them cleanly."
     }
   },
   "entity": {
@@ -168,6 +204,22 @@
   "exceptions": {
     "dispatch_write_failed": {
       "message": "Failed to update {param} on the inverter: {error}"
+    }
+  },
+  "services": {
+    "backfill": {
+      "name": "Backfill historical statistics",
+      "description": "Import historical iSolarCloud data into Home Assistant long-term statistics so the History and Energy dashboards are populated immediately.",
+      "fields": {
+        "config_entry": {
+          "name": "Integration",
+          "description": "The Sungrow (cloud) integration entry to backfill. Leave empty to backfill every loaded cloud entry."
+        },
+        "start_date": {
+          "name": "Start date",
+          "description": "Optional earliest date to import from (interpreted as UTC midnight). Defaults to the configured backfill window."
+        }
+      }
     }
   }
 }

--- a/custom_components/sungrow/translations/es.json
+++ b/custom_components/sungrow/translations/es.json
@@ -5,16 +5,39 @@
         "title": "Conectar con iSolarCloud",
         "description": "Introduzca sus credenciales de la API de iSolarCloud. Puede encontrarlas aquí: [iSolarCloud]({url})\n\nDespués de enviarlas, se crea el concentrador y Home Assistant le pedirá que lo autorice en su navegador.",
         "data": {
-          "gateway": "Región de la pasarela",
+          "transport": "Transport mode"
+        }
+      },
+      "cloud_credentials": {
+        "title": "Connect to iSolarCloud",
+        "description": "Enter your iSolarCloud API credentials. You can find them here: [iSolarCloud]({url})\n\nAfter you submit, the hub is created and Home Assistant will prompt you to authorize it in your browser.",
+        "data": {
+          "gateway": "Gateway Region",
           "app_key": "AppKey",
           "app_secret": "App Secret",
           "app_id": "App ID",
-          "redirect_uri": "URI de redirección"
+          "redirect_uri": "Redirect URI"
         },
         "data_description": {
-          "app_key": "AppKey de la plataforma para desarrolladores de iSolarCloud.",
-          "app_secret": "AppSecret de la plataforma para desarrolladores de iSolarCloud.",
-          "app_id": "App ID de la plataforma para desarrolladores de iSolarCloud. Para encontrarlo, vaya a su aplicación y busque «id» dentro de la URL, de esta forma: {app_id_url}."
+          "app_key": "AppKey from iSolarCloud Developer Platform.",
+          "app_secret": "AppSecret from iSolarCloud Developer Platform.",
+          "app_id": "App ID from iSolarCloud Developer Platform. To find this, go to your application and look for 'id' within the URL like so: {app_id_url}."
+        }
+      },
+      "modbus_host": {
+        "title": "Modbus Host",
+        "description": "Enter the IP address or hostname of your WiNet-S dongle for local Modbus communication.",
+        "data": {
+          "modbus_host": "WiNet-S IP / hostname"
+        }
+      },
+      "local_setup": {
+        "title": "Local Modbus Setup",
+        "description": "Enter the connection details for your local WiNet-S dongle. No cloud account is required.",
+        "data": {
+          "modbus_host": "WiNet-S IP / hostname",
+          "serial": "Inverter serial number",
+          "model": "Inverter model"
         }
       },
       "auth_callback": {
@@ -38,6 +61,13 @@
           "redirect_uri": "URI de redirección"
         }
       },
+      "reconfigure_modbus_host": {
+        "title": "Update Modbus Host",
+        "description": "Update the WiNet-S IP address for this hybrid (Cloud + Modbus) entry.",
+        "data": {
+          "modbus_host": "WiNet-S IP / hostname"
+        }
+      },
       "zeroconf_confirm": {
         "title": "Configurar inversor Sungrow local",
         "description": "Se ha descubierto un inversor Sungrow **{model}** en su red en **{host}** (WiNet-S). Configúrelo como una **entrada local separada** que lee el inversor a través de Modbus: rápido, sin límites de consumo y capaz de funcionar sin conexión, sin necesidad de cuenta de iSolarCloud. Si también tiene una entrada en la nube para el mismo inversor, ambas permanecen independientes (el dispositivo local se vincula bajo la planta en la nube cuando los números de serie coinciden)."
@@ -55,18 +85,19 @@
     },
     "error": {
       "cannot_connect": "No se pudo conectar",
+      "host_unreachable": "The WiNet-S host is unreachable on port 502. Check the IP and ensure the dongle is online.",
       "invalid_auth": "Autenticación no válida",
       "invalid_extra_measure_points": "Los puntos de medición adicionales deben tener el formato point_id=code, separados por comas",
       "unknown": "Error inesperado"
     },
     "abort": {
       "already_configured": "El dispositivo ya está configurado",
+      "not_sungrow_device": "El dispositivo descubierto no es un inversor Sungrow compatible.",
       "library_missing": "La biblioteca pysolarcloud no está instalada. Reinicie Home Assistant para que se instalen las dependencias de la integración y vuelva a intentarlo.",
       "missing_code": "No se recibió el código de autorización. Vuelva a intentarlo.",
       "reauth_successful": "La reautenticación se realizó correctamente",
       "reconfigure_successful": "La reconfiguración se realizó correctamente",
-      "wrong_account": "La cuenta autorizada no coincide con el App ID de esta integración. Use la aplicación de desarrollador original.",
-      "not_sungrow_device": "El dispositivo descubierto no es un inversor Sungrow compatible."
+      "wrong_account": "La cuenta autorizada no coincide con el App ID de esta integración. Use la aplicación de desarrollador original."
     }
   },
   "options": {
@@ -77,7 +108,8 @@
         "data": {
           "scan_interval": "Intervalo de sondeo (segundos)",
           "extra_measure_points": "Puntos de medición adicionales (point_id=code, separados por comas)",
-          "enable_device_sensors": "Crear sensores por dispositivo (cargadores de VE, contadores, baterías adicionales)"
+          "enable_device_sensors": "Crear sensores por dispositivo (cargadores de VE, contadores, baterías adicionales)",
+          "modbus_host": "WiNet-S Modbus host (enter to enable hybrid, clear to disable)"
         }
       },
       "modbus_options": {
@@ -98,6 +130,10 @@
     "rate_limited": {
       "title": "Límite de peticiones de la API de iSolarCloud alcanzado",
       "description": "iSolarCloud está rechazando las peticiones de **{plant}** porque se alcanzó el límite de llamadas a la API (E998/E999). Aumente el intervalo de sondeo en las opciones de la integración para hacer menos llamadas; se recupera cuando se restablece la cuota."
+    },
+    "backfill_partial": {
+      "title": "El relleno histórico terminó con huecos",
+      "description": "El relleno de estadísticas históricas para **{plant}** terminó, pero no se pudieron importar {failed_chunks} rango(s) de tiempo, por lo que los paneles de Historial y Energía pueden tener huecos en ese periodo. Vuelva a ejecutar **Herramientas para desarrolladores → Acciones → Sungrow: Rellenar estadísticas históricas** para completar los huecos; las horas correctas ya están importadas y volver a ejecutarlo solo las sobrescribe de forma limpia."
     }
   },
   "entity": {
@@ -168,6 +204,22 @@
   "exceptions": {
     "dispatch_write_failed": {
       "message": "No se pudo actualizar {param} en el inversor: {error}"
+    }
+  },
+  "services": {
+    "backfill": {
+      "name": "Rellenar estadísticas históricas",
+      "description": "Importa datos históricos de iSolarCloud a las estadísticas de largo plazo de Home Assistant para que los paneles de Historial y Energía se rellenen de inmediato.",
+      "fields": {
+        "config_entry": {
+          "name": "Integración",
+          "description": "La entrada de integración de Sungrow (nube) que se rellenará. Déjelo vacío para rellenar todas las entradas de nube cargadas."
+        },
+        "start_date": {
+          "name": "Fecha de inicio",
+          "description": "Fecha más temprana opcional desde la que importar (interpretada como medianoche UTC). Por defecto usa la ventana de relleno configurada."
+        }
+      }
     }
   }
 }

--- a/custom_components/sungrow/translations/fr.json
+++ b/custom_components/sungrow/translations/fr.json
@@ -5,16 +5,39 @@
         "title": "Se connecter à iSolarCloud",
         "description": "Saisissez vos identifiants d'API iSolarCloud. Vous pouvez les trouver ici : [iSolarCloud]({url})\n\nAprès validation, le hub est créé et Home Assistant vous invitera à l'autoriser dans votre navigateur.",
         "data": {
-          "gateway": "Région de la passerelle",
+          "transport": "Transport mode"
+        }
+      },
+      "cloud_credentials": {
+        "title": "Connect to iSolarCloud",
+        "description": "Enter your iSolarCloud API credentials. You can find them here: [iSolarCloud]({url})\n\nAfter you submit, the hub is created and Home Assistant will prompt you to authorize it in your browser.",
+        "data": {
+          "gateway": "Gateway Region",
           "app_key": "AppKey",
           "app_secret": "App Secret",
           "app_id": "App ID",
-          "redirect_uri": "URI de redirection"
+          "redirect_uri": "Redirect URI"
         },
         "data_description": {
-          "app_key": "AppKey depuis la plateforme développeur iSolarCloud.",
-          "app_secret": "AppSecret depuis la plateforme développeur iSolarCloud.",
-          "app_id": "App ID depuis la plateforme développeur iSolarCloud. Pour la trouver, ouvrez votre application et recherchez « id » dans l'URL, comme ceci : {app_id_url}."
+          "app_key": "AppKey from iSolarCloud Developer Platform.",
+          "app_secret": "AppSecret from iSolarCloud Developer Platform.",
+          "app_id": "App ID from iSolarCloud Developer Platform. To find this, go to your application and look for 'id' within the URL like so: {app_id_url}."
+        }
+      },
+      "modbus_host": {
+        "title": "Modbus Host",
+        "description": "Enter the IP address or hostname of your WiNet-S dongle for local Modbus communication.",
+        "data": {
+          "modbus_host": "WiNet-S IP / hostname"
+        }
+      },
+      "local_setup": {
+        "title": "Local Modbus Setup",
+        "description": "Enter the connection details for your local WiNet-S dongle. No cloud account is required.",
+        "data": {
+          "modbus_host": "WiNet-S IP / hostname",
+          "serial": "Inverter serial number",
+          "model": "Inverter model"
         }
       },
       "auth_callback": {
@@ -38,6 +61,13 @@
           "redirect_uri": "URI de redirection"
         }
       },
+      "reconfigure_modbus_host": {
+        "title": "Update Modbus Host",
+        "description": "Update the WiNet-S IP address for this hybrid (Cloud + Modbus) entry.",
+        "data": {
+          "modbus_host": "WiNet-S IP / hostname"
+        }
+      },
       "zeroconf_confirm": {
         "title": "Configurer l'onduleur Sungrow local",
         "description": "Un onduleur Sungrow **{model}** a été découvert sur votre réseau à **{host}** (WiNet-S). Configurez-le comme une **entrée locale séparée** qui lit l'onduleur via Modbus — rapide, sans limite de consommation et fonctionnant hors ligne, sans compte iSolarCloud requis. Si vous avez également une entrée cloud pour le même onduleur, les deux restent indépendantes (le dispositif local est lié sous la centrale cloud lorsque les numéros de série correspondent)."
@@ -55,18 +85,19 @@
     },
     "error": {
       "cannot_connect": "Échec de la connexion",
+      "host_unreachable": "The WiNet-S host is unreachable on port 502. Check the IP and ensure the dongle is online.",
       "invalid_auth": "Authentification non valide",
       "invalid_extra_measure_points": "Les points de mesure supplémentaires doivent être au format point_id=code, séparés par des virgules",
       "unknown": "Erreur inattendue"
     },
     "abort": {
       "already_configured": "L'appareil est déjà configuré",
+      "not_sungrow_device": "L'appareil découvert n'est pas un onduleur Sungrow pris en charge.",
       "library_missing": "La bibliothèque pysolarcloud n'est pas installée. Redémarrez Home Assistant pour que les dépendances de l'intégration soient installées, puis réessayez.",
       "missing_code": "Le code d'autorisation n'a pas été reçu. Veuillez réessayer.",
       "reauth_successful": "La ré-authentification a réussi",
       "reconfigure_successful": "La reconfiguration a réussi",
-      "wrong_account": "Le compte autorisé ne correspond pas à l'App ID de cette intégration. Utilisez l'application développeur d'origine.",
-      "not_sungrow_device": "L'appareil découvert n'est pas un onduleur Sungrow pris en charge."
+      "wrong_account": "Le compte autorisé ne correspond pas à l'App ID de cette intégration. Utilisez l'application développeur d'origine."
     }
   },
   "options": {
@@ -77,7 +108,8 @@
         "data": {
           "scan_interval": "Intervalle d'interrogation (secondes)",
           "extra_measure_points": "Points de mesure supplémentaires (point_id=code, séparés par des virgules)",
-          "enable_device_sensors": "Créer des capteurs par appareil (bornes de recharge EV, compteurs, batteries supplémentaires)"
+          "enable_device_sensors": "Créer des capteurs par appareil (bornes de recharge EV, compteurs, batteries supplémentaires)",
+          "modbus_host": "WiNet-S Modbus host (enter to enable hybrid, clear to disable)"
         }
       },
       "modbus_options": {
@@ -98,6 +130,10 @@
     "rate_limited": {
       "title": "Limite de requêtes de l'API iSolarCloud atteinte",
       "description": "iSolarCloud rejette les requêtes pour **{plant}** car la limite d'appels de l'API a été atteinte (E998/E999). Augmentez l'intervalle d'interrogation dans les options de l'intégration pour effectuer moins d'appels ; le service se rétablit une fois le quota réinitialisé."
+    },
+    "backfill_partial": {
+      "title": "Le remplissage historique s'est terminé avec des lacunes",
+      "description": "Le remplissage des statistiques historiques pour **{plant}** est terminé, mais {failed_chunks} plage(s) horaire(s) n'ont pas pu être importées, de sorte que les tableaux de bord Historique et Énergie peuvent présenter des lacunes pour cette période. Relancez **Outils de développement → Actions → Sungrow : Remplir les statistiques historiques** pour combler les lacunes ; les heures réussies sont déjà importées et une nouvelle exécution ne fait que les écraser proprement."
     }
   },
   "entity": {
@@ -168,6 +204,22 @@
   "exceptions": {
     "dispatch_write_failed": {
       "message": "Impossible de mettre à jour {param} sur l'onduleur : {error}"
+    }
+  },
+  "services": {
+    "backfill": {
+      "name": "Remplir les statistiques historiques",
+      "description": "Importe les données historiques iSolarCloud dans les statistiques à long terme de Home Assistant afin que les tableaux de bord Historique et Énergie soient renseignés immédiatement.",
+      "fields": {
+        "config_entry": {
+          "name": "Intégration",
+          "description": "L'entrée d'intégration Sungrow (cloud) à remplir. Laissez vide pour remplir toutes les entrées cloud chargées."
+        },
+        "start_date": {
+          "name": "Date de début",
+          "description": "Date la plus ancienne facultative à partir de laquelle importer (interprétée comme minuit UTC). Par défaut, la fenêtre de remplissage configurée."
+        }
+      }
     }
   }
 }

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -4,6 +4,7 @@ pytest-homeassistant-custom-component
 pytest-cov
 pytest-sugar
 python-dotenv
+hypothesis
 
 # Linting & formatting (keep in sync with ci.yml and .pre-commit-config.yaml)
 ruff==0.15.21

--- a/tests/test_backfill.py
+++ b/tests/test_backfill.py
@@ -1,0 +1,948 @@
+"""Unit / example tests for the Backfill I/O orchestration shell.
+
+Feature: backfill-historical-statistics.
+
+These cover the pieces that carry I/O or wiring and are exercised with representative
+examples and mocks (the combinatorial input space is owned by the property tests in
+``test_backfill_properties.py``): series resolution against the entity registry, the
+idempotent recorder-import router, and the shared Throttle.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from datetime import UTC, datetime, timedelta
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import entity_registry as er
+from homeassistant.util import dt as dt_util
+from pysolarcloud import AuthError, PySolarCloudException
+
+from custom_components.sungrow.backfill import (
+    BackfillEngine,
+    BackfillManager,
+    SeriesTarget,
+    Throttle,
+    async_resolve_series,
+    build_series_target,
+    import_statistics,
+    select_backfill_points,
+)
+from custom_components.sungrow.const import (
+    BACKFILL_CHUNK_WINDOW,
+    BACKFILL_INTERVAL,
+    BACKFILL_MAX_RETRIES,
+    CONF_BACKFILL_DAYS,
+    DOMAIN,
+)
+
+# Two catalogued points: a cumulative-energy yield and an instantaneous power point.
+_MEASURE_POINTS = {"83024": "total_yield", "83033": "power"}
+
+
+def _fake_coordinator(plant_id: str = "123", measure_points: dict | None = None):
+    """A minimal coordinator stand-in exposing plant_id and plants_service.measure_points."""
+    return SimpleNamespace(
+        plant_id=plant_id,
+        plants_service=SimpleNamespace(
+            measure_points=measure_points if measure_points is not None else dict(_MEASURE_POINTS)
+        ),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Task 7 - series resolution and Statistic_Id derivation
+# ---------------------------------------------------------------------------
+
+
+def test_select_backfill_points_picks_energy_and_power():
+    """Only cumulative-energy and power points are selected, tagged with their kind."""
+    selected = select_backfill_points(_MEASURE_POINTS)
+    assert ("total_yield", "energy") in selected
+    assert ("power", "power") in selected
+
+
+def test_build_series_target_energy_metadata_shape():
+    """Energy live series -> recorder source, has_sum, unit from the live entity (7.1, 7.5)."""
+    target = build_series_target(
+        plant_id="123",
+        point_code="total_yield",
+        kind="energy",
+        entity_id="sensor.plant_total_yield",
+        unit="kWh",
+    )
+    assert target == SeriesTarget(
+        point_code="total_yield",
+        statistic_id="sensor.plant_total_yield",
+        unit="kWh",
+        kind="energy",
+        is_external=False,
+        metadata={
+            "has_mean": False,
+            "has_sum": True,
+            "name": None,
+            "source": "recorder",
+            "statistic_id": "sensor.plant_total_yield",
+            "unit_of_measurement": "kWh",
+        },
+    )
+
+
+def test_build_series_target_power_metadata_shape():
+    """Power series -> has_mean, W default unit when the live entity supplies none (7.2)."""
+    target = build_series_target(
+        plant_id="123",
+        point_code="power",
+        kind="power",
+        entity_id="sensor.plant_power",
+        unit=None,
+    )
+    assert target.metadata["has_mean"] is True
+    assert target.metadata["has_sum"] is False
+    assert target.unit == "W"
+    assert target.metadata["unit_of_measurement"] == "W"
+    assert target.is_external is False
+
+
+def test_build_series_target_external_fallback():
+    """No live entity -> per-plant external series with the DOMAIN source (7.4, 9.2)."""
+    target = build_series_target(
+        plant_id="123",
+        point_code="total_yield",
+        kind="energy",
+        entity_id=None,
+        unit=None,
+    )
+    assert target.is_external is True
+    assert target.statistic_id == "sungrow:123_total_yield"
+    assert target.metadata["source"] == DOMAIN
+    assert target.unit == "kWh"
+
+
+@pytest.mark.asyncio
+async def test_async_resolve_series_live_entity(hass: HomeAssistant):
+    """A registered sensor resolves to a live-entity series with its live unit (7.3, 7.5)."""
+    registry = er.async_get(hass)
+    entry = registry.async_get_or_create("sensor", DOMAIN, "123_total_yield", unit_of_measurement="kWh")
+    # A live state overrides the registry unit; use it to prove state-first resolution.
+    hass.states.async_set(entry.entity_id, "1234.0", {"unit_of_measurement": "kWh"})
+
+    targets = await async_resolve_series(hass, _fake_coordinator())
+    by_code = {t.point_code: t for t in targets}
+
+    yield_target = by_code["total_yield"]
+    assert yield_target.is_external is False
+    assert yield_target.statistic_id == entry.entity_id
+    assert yield_target.unit == "kWh"
+    assert yield_target.metadata["source"] == "recorder"
+    assert yield_target.kind == "energy"
+
+
+@pytest.mark.asyncio
+async def test_async_resolve_series_external_fallback(hass: HomeAssistant):
+    """With an empty registry every point falls back to an external series (7.4)."""
+    targets = await async_resolve_series(hass, _fake_coordinator())
+    by_code = {t.point_code: t for t in targets}
+
+    assert by_code["total_yield"].is_external is True
+    assert by_code["total_yield"].statistic_id == "sungrow:123_total_yield"
+    assert by_code["power"].is_external is True
+    assert by_code["power"].statistic_id == "sungrow:123_power"
+    assert by_code["power"].kind == "power"
+
+
+@pytest.mark.asyncio
+async def test_async_resolve_series_scopes_per_plant(hass: HomeAssistant):
+    """Two plants with the same code get distinct external ids (9.2)."""
+    a = await async_resolve_series(hass, _fake_coordinator("111"))
+    b = await async_resolve_series(hass, _fake_coordinator("222"))
+    id_a = {t.point_code: t.statistic_id for t in a}["total_yield"]
+    id_b = {t.point_code: t.statistic_id for t in b}["total_yield"]
+    assert id_a != id_b
+
+
+# ---------------------------------------------------------------------------
+# Task 8 - idempotent import router
+# ---------------------------------------------------------------------------
+
+
+class _FakeRecorder:
+    """A fake (statistic_id, start_hour)-keyed store mimicking the recorder helpers."""
+
+    def __init__(self) -> None:
+        self.store: dict[tuple[str, datetime], dict] = {}
+        self.calls = 0
+
+    def add(self, hass, metadata, data) -> None:  # matches recorder helper signature
+        self.calls += 1
+        for row in data:
+            self.store[(metadata["statistic_id"], row["start"])] = row
+
+
+def _hour(h: int) -> datetime:
+    return datetime(2024, 1, 1, h, 0, 0, tzinfo=UTC)
+
+
+@pytest.fixture
+def fake_recorder():
+    recorder = _FakeRecorder()
+    with (
+        patch(
+            "homeassistant.components.recorder.statistics.async_import_statistics",
+            side_effect=recorder.add,
+        ),
+        patch(
+            "homeassistant.components.recorder.statistics.async_add_external_statistics",
+            side_effect=recorder.add,
+        ),
+    ):
+        yield recorder
+
+
+def test_import_statistics_reimport_overwrites(hass: HomeAssistant, fake_recorder):
+    """Re-importing the same hours overwrites rather than duplicating (6.1, 6.2)."""
+    target = build_series_target(plant_id="123", point_code="total_yield", kind="energy", entity_id=None, unit=None)
+    data = [
+        {"start": _hour(0), "state": 1.0, "sum": 1.0},
+        {"start": _hour(1), "state": 2.0, "sum": 2.0},
+    ]
+
+    import_statistics(hass, target, data)
+    import_statistics(hass, target, data)
+
+    assert len(fake_recorder.store) == 2
+    assert fake_recorder.store[(target.statistic_id, _hour(1))]["sum"] == 2.0
+
+
+def test_import_statistics_retried_chunk_is_hour_local(hass: HomeAssistant, fake_recorder):
+    """A retried chunk only touches its own hours and leaves earlier hours intact (6.4)."""
+    target = build_series_target(plant_id="123", point_code="total_yield", kind="energy", entity_id=None, unit=None)
+    chunk_a = [{"start": _hour(0), "state": 1.0, "sum": 1.0}]
+    chunk_b = [{"start": _hour(1), "state": 5.0, "sum": 5.0}]
+
+    import_statistics(hass, target, chunk_a)
+    import_statistics(hass, target, chunk_b)
+    import_statistics(hass, target, chunk_b)  # retry chunk B
+
+    assert set(fake_recorder.store.keys()) == {
+        (target.statistic_id, _hour(0)),
+        (target.statistic_id, _hour(1)),
+    }
+    assert fake_recorder.store[(target.statistic_id, _hour(0))]["sum"] == 1.0
+
+
+def test_import_statistics_routes_live_vs_external(hass: HomeAssistant):
+    """External targets route to the external helper; live targets to the import helper."""
+    external = build_series_target(plant_id="123", point_code="total_yield", kind="energy", entity_id=None, unit=None)
+    live = build_series_target(
+        plant_id="123",
+        point_code="total_yield",
+        kind="energy",
+        entity_id="sensor.plant_total_yield",
+        unit="kWh",
+    )
+    data = [{"start": _hour(0), "state": 1.0, "sum": 1.0}]
+
+    with (
+        patch("homeassistant.components.recorder.statistics.async_import_statistics") as mock_import,
+        patch("homeassistant.components.recorder.statistics.async_add_external_statistics") as mock_external,
+    ):
+        import_statistics(hass, external, data)
+        import_statistics(hass, live, data)
+        import_statistics(hass, external, [])  # empty is a no-op
+
+    mock_external.assert_called_once()
+    mock_import.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# Task 9 - shared Throttle
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_throttle_spaces_calls_by_min_interval():
+    """acquire waits out the remaining min_interval since the previous acquire (5.1)."""
+    throttle = Throttle(min_interval=1.0)
+    sleeps: list[float] = []
+
+    async def fake_sleep(delay: float) -> None:
+        sleeps.append(delay)
+
+    throttle._sleep = fake_sleep  # type: ignore[method-assign]
+
+    with patch("custom_components.sungrow.backfill.time.monotonic") as mono:
+        mono.return_value = 100.0
+        await throttle.acquire()  # first call: no wait
+        mono.return_value = 100.3  # only 0.3s elapsed
+        await throttle.acquire()  # must wait the remaining 0.7s
+
+    assert sleeps == [pytest.approx(0.7)]
+
+
+@pytest.mark.asyncio
+async def test_throttle_no_wait_when_interval_elapsed():
+    """No sleep when at least min_interval has already passed."""
+    throttle = Throttle(min_interval=1.0)
+    sleeps: list[float] = []
+
+    async def fake_sleep(delay: float) -> None:
+        sleeps.append(delay)
+
+    throttle._sleep = fake_sleep  # type: ignore[method-assign]
+
+    with patch("custom_components.sungrow.backfill.time.monotonic") as mono:
+        mono.return_value = 100.0
+        await throttle.acquire()
+        mono.return_value = 105.0  # 5s elapsed > interval
+        await throttle.acquire()
+
+    assert sleeps == []
+
+
+@pytest.mark.asyncio
+async def test_throttle_is_shared_across_engines():
+    """A single shared instance spaces calls made by two different engines (9.4)."""
+    shared = Throttle(min_interval=2.0)
+    sleeps: list[float] = []
+
+    async def fake_sleep(delay: float) -> None:
+        sleeps.append(delay)
+
+    shared._sleep = fake_sleep  # type: ignore[method-assign]
+
+    with patch("custom_components.sungrow.backfill.time.monotonic") as mono:
+        mono.return_value = 50.0
+        await shared.acquire()  # "engine A"
+        mono.return_value = 50.5
+        await shared.acquire()  # "engine B" sees engine A's timestamp
+
+    assert sleeps == [pytest.approx(1.5)]
+
+
+@pytest.mark.asyncio
+async def test_throttle_backoff_escalates_and_caps_at_one_hour():
+    """backoff doubles each call and is capped at 3600s; reset clears it (5.2)."""
+    throttle = Throttle(min_interval=1.0)
+    sleeps: list[float] = []
+
+    async def fake_sleep(delay: float) -> None:
+        sleeps.append(delay)
+
+    throttle._sleep = fake_sleep  # type: ignore[method-assign]
+
+    for _ in range(15):
+        await throttle.backoff()
+
+    # Monotonic non-decreasing, doubling until the 1-hour cap, then pinned at the cap.
+    assert sleeps[0] == 1.0
+    assert sleeps[1] == 2.0
+    assert sleeps[2] == 4.0
+    for earlier, later in zip(sleeps, sleeps[1:], strict=False):
+        assert later >= earlier
+    assert max(sleeps) == 3600.0
+    assert sleeps[-1] == 3600.0
+
+    # reset_backoff restarts the escalation from the floor.
+    throttle.reset_backoff()
+    sleeps.clear()
+    await throttle.backoff()
+    assert sleeps == [1.0]
+
+
+# ---------------------------------------------------------------------------
+# Task 11 - BackfillEngine.async_run run loop
+# ---------------------------------------------------------------------------
+
+
+def _engine_coordinator(*, option_days: int | None = 1, plant_id: str = "123"):
+    """A coordinator stand-in with a config entry and a plants_service for the engine."""
+    options: dict = {}
+    if option_days is not None:
+        options[CONF_BACKFILL_DAYS] = option_days
+    return SimpleNamespace(
+        plant_id=plant_id,
+        config_entry=SimpleNamespace(options=options),
+        plants_service=SimpleNamespace(
+            measure_points=dict(_MEASURE_POINTS),
+            async_get_historical_data=AsyncMock(),
+        ),
+    )
+
+
+def _make_engine(hass: HomeAssistant, coordinator):
+    """Build a BackfillEngine with a non-sleeping throttle and a marker-recording store."""
+    throttle = Throttle(min_interval=0.0)
+    throttle._sleep = AsyncMock()  # type: ignore[method-assign]
+    store = SimpleNamespace(async_set_marker=AsyncMock())
+    engine = BackfillEngine(hass, coordinator, throttle, store)
+    engine._sleep = AsyncMock()  # type: ignore[method-assign]
+    return engine, throttle, store
+
+
+def _row(code: str, ts: datetime, value: float):
+    return {
+        "timestamp": ts,
+        "id": code,
+        "code": code,
+        "value": value,
+        "unit": "kWh" if code == "total_yield" else "W",
+        "name": code,
+    }
+
+
+@pytest.mark.asyncio
+async def test_engine_happy_path_ascending_chunks(hass: HomeAssistant, caplog):
+    """Ascending chunk loop, explicit bounding call kwargs (4.3), and RunSummary counts (8.6)."""
+    coordinator = _engine_coordinator(option_days=1)
+    calls: list[tuple] = []
+
+    async def history(plant_id, start, end, *, measure_points, interval):
+        calls.append((start, end, tuple(measure_points), interval))
+        return {plant_id: [_row(c, start, 100.0) for c in measure_points]}
+
+    coordinator.plants_service.async_get_historical_data.side_effect = history
+    engine, _throttle, store = _make_engine(hass, coordinator)
+
+    with (
+        patch("custom_components.sungrow.backfill.import_statistics"),
+        caplog.at_level(logging.INFO, logger="custom_components.sungrow.backfill"),
+    ):
+        summary = await engine.async_run()
+
+    # A 1-day window in 3-hour chunks is exactly 8 calls, in ascending chronological order.
+    assert len(calls) == 8
+    starts = [c[0] for c in calls]
+    assert starts == sorted(starts)
+
+    # Every call bounds a single chunk (<= 3h) with the 5-minute interval and both codes (4.3).
+    for start, end, mps, interval in calls:
+        assert end - start <= BACKFILL_CHUNK_WINDOW
+        assert interval == BACKFILL_INTERVAL
+        assert mps == ("total_yield", "power")
+
+    # Two series x 8 distinct chunk-start hours = 16 imported hours; run completed cleanly (8.6).
+    assert summary.imported_hours == 16
+    assert summary.skipped_empty_ranges == 0
+    assert summary.failed_chunks == 0
+    assert summary.completed is True
+    assert summary.plant_id == "123"
+
+    # Start and outcome are logged (8.4), and a completed marker is persisted.
+    assert "starting" in caplog.text
+    assert "finished" in caplog.text
+    marker = store.async_set_marker.await_args.args[1]
+    assert marker["completed"] is True
+    assert marker["failed_chunks"] == 0
+
+
+@pytest.mark.asyncio
+async def test_engine_empty_ranges_are_skipped(hass: HomeAssistant, caplog):
+    """A call returning no rows is counted as an empty range and logged at debug (8.3)."""
+    coordinator = _engine_coordinator(option_days=1)
+    coordinator.plants_service.async_get_historical_data.return_value = {}
+    engine, _throttle, _store = _make_engine(hass, coordinator)
+
+    with (
+        patch("custom_components.sungrow.backfill.import_statistics") as mock_import,
+        caplog.at_level(logging.DEBUG, logger="custom_components.sungrow.backfill"),
+    ):
+        summary = await engine.async_run()
+
+    assert summary.imported_hours == 0
+    assert summary.skipped_empty_ranges == 8
+    assert summary.failed_chunks == 0
+    assert summary.completed is True
+    mock_import.assert_not_called()
+    assert "returned no rows" in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_engine_rate_limit_backs_off_and_resumes_from_cursor(hass: HomeAssistant):
+    """A rate-limit backs off and retries the SAME (chunk, batch) without advancing (5.2, 5.3)."""
+    coordinator = _engine_coordinator(option_days=1)
+    state = {"raised": False}
+
+    async def history(plant_id, start, end, *, measure_points, interval):
+        if not state["raised"]:
+            state["raised"] = True
+            raise PySolarCloudException({"result_code": "E999"})
+        return {plant_id: [_row(c, start, 100.0) for c in measure_points]}
+
+    coordinator.plants_service.async_get_historical_data.side_effect = history
+    engine, throttle, _store = _make_engine(hass, coordinator)
+
+    with patch("custom_components.sungrow.backfill.import_statistics"):
+        summary = await engine.async_run()
+
+    # 8 chunks + one retried first chunk = 9 calls; the run still completes.
+    assert coordinator.plants_service.async_get_historical_data.await_count == 9
+    throttle._sleep.assert_awaited()  # backoff slept
+    assert summary.failed_chunks == 0
+    assert summary.completed is True
+    assert summary.imported_hours == 16
+
+
+@pytest.mark.asyncio
+async def test_engine_transient_retries_then_marks_chunk_failed(hass: HomeAssistant):
+    """Bounded transient retries, then the chunk is marked failed and the run continues (5.6, 8.1)."""
+    coordinator = _engine_coordinator(option_days=1)
+    state = {"first": None}
+
+    async def history(plant_id, start, end, *, measure_points, interval):
+        if state["first"] is None:
+            state["first"] = start
+        if start == state["first"]:
+            raise ValueError("transient boom")
+        return {plant_id: [_row(c, start, 100.0) for c in measure_points]}
+
+    coordinator.plants_service.async_get_historical_data.side_effect = history
+    engine, _throttle, store = _make_engine(hass, coordinator)
+
+    with patch("custom_components.sungrow.backfill.import_statistics"):
+        summary = await engine.async_run()
+
+    # The failing chunk is attempted BACKFILL_MAX_RETRIES + 1 times before it is abandoned.
+    failing_calls = sum(
+        1
+        for call in coordinator.plants_service.async_get_historical_data.await_args_list
+        if call.args[1] == state["first"]
+    )
+    assert failing_calls == BACKFILL_MAX_RETRIES + 1
+    assert summary.failed_chunks == 1
+    assert summary.completed is False
+    # The remaining 7 chunks still imported (run continued past the failure).
+    assert summary.imported_hours > 0
+    engine._sleep.assert_awaited()  # transient retry delay slept
+
+    marker = store.async_set_marker.await_args.args[1]
+    assert marker["completed"] is False
+    assert marker["partial"] is True
+    assert marker["failed_chunks"] == 1
+
+
+@pytest.mark.asyncio
+async def test_engine_auth_error_stops_and_defers(hass: HomeAssistant):
+    """An auth error stops the run immediately, records a partial marker, and re-raises (8.5)."""
+    coordinator = _engine_coordinator(option_days=1)
+    coordinator.plants_service.async_get_historical_data.side_effect = AuthError({"result_code": "E900"})
+    engine, _throttle, store = _make_engine(hass, coordinator)
+
+    with (
+        patch("custom_components.sungrow.backfill.import_statistics") as mock_import,
+        pytest.raises(AuthError),
+    ):
+        await engine.async_run()
+
+    # Stopped on the very first call; nothing imported.
+    assert coordinator.plants_service.async_get_historical_data.await_count == 1
+    mock_import.assert_not_called()
+
+    marker = store.async_set_marker.await_args.args[1]
+    assert marker["completed"] is False
+    assert marker["partial"] is True
+
+
+# ---------------------------------------------------------------------------
+# Task 13 - BackfillManager
+# ---------------------------------------------------------------------------
+
+
+class _FakeEntry:
+    """A minimal config-entry stand-in for the manager (tracks background tasks)."""
+
+    def __init__(self, coordinators: list, options: dict | None = None) -> None:
+        self.entry_id = "backfill_test_entry"
+        self.options = options or {}
+        self.runtime_data = SimpleNamespace(coordinators=coordinators)
+        self.background_tasks: list[asyncio.Task] = []
+
+    def async_create_background_task(self, hass, coro, name):  # noqa: ANN001, ANN201
+        task = asyncio.ensure_future(coro)
+        self.background_tasks.append(task)
+        return task
+
+
+def _mgr_coordinator(plant_id: str, *, history=None, option_days: int | None = 1, plant_name: str | None = None):
+    """A coordinator stand-in for the manager, with a config entry and a plants_service."""
+    options: dict = {}
+    if option_days is not None:
+        options[CONF_BACKFILL_DAYS] = option_days
+    service = SimpleNamespace(
+        measure_points=dict(_MEASURE_POINTS),
+        async_get_historical_data=AsyncMock(),
+    )
+    if history is not None:
+        service.async_get_historical_data.side_effect = history
+    else:
+        service.async_get_historical_data.return_value = {}
+    return SimpleNamespace(
+        plant_id=plant_id,
+        plant_name=plant_name or f"Plant {plant_id}",
+        config_entry=SimpleNamespace(options=options),
+        plants_service=service,
+    )
+
+
+def _make_manager(hass: HomeAssistant, coordinators: list, *, entry_options=None, markers=None):
+    """Build a manager with a non-sleeping shared throttle and a fake marker store."""
+    entry = _FakeEntry(coordinators, options=entry_options)
+    manager = BackfillManager(hass, entry)
+    fast = Throttle(min_interval=0.0)
+    fast._sleep = AsyncMock()  # type: ignore[method-assign]
+    manager._throttle = fast  # engines are created lazily, so they pick this up
+    marker_map = markers or {}
+    manager._store = SimpleNamespace(  # type: ignore[assignment]
+        async_get_marker=AsyncMock(side_effect=lambda pid: marker_map.get(pid)),
+        async_set_marker=AsyncMock(),
+    )
+    return manager, entry, manager._store
+
+
+@pytest.mark.asyncio
+async def test_manager_auto_start_gates_on_marker(hass: HomeAssistant):
+    """A completed marker covering the default window skips that plant; others run (1.1, 1.4)."""
+    now = dt_util.utcnow()
+    covered = {
+        "completed": True,
+        "partial": False,
+        "window_start": (now - timedelta(days=40)).isoformat(),
+        "window_end": now.isoformat(),
+        "last_run": now.isoformat(),
+        "failed_chunks": 0,
+    }
+    c_done = _mgr_coordinator("done")
+    c_new = _mgr_coordinator("new")
+    manager, entry, _store = _make_manager(hass, [c_done, c_new], markers={"done": covered})
+
+    with patch("custom_components.sungrow.backfill.import_statistics"):
+        await manager.async_start_automatic()
+        await asyncio.gather(*entry.background_tasks)
+
+    # The plant whose completed marker covers the default window is not run again.
+    c_done.plants_service.async_get_historical_data.assert_not_awaited()
+    # The plant with no marker is backfilled.
+    c_new.plants_service.async_get_historical_data.assert_awaited()
+
+
+@pytest.mark.asyncio
+async def test_manager_rejects_plant_already_running(hass: HomeAssistant):
+    """A second run request for an in-flight plant is rejected, not started twice (2.4)."""
+    started = asyncio.Event()
+    release = asyncio.Event()
+
+    async def slow(plant_id, start, end, *, measure_points, interval):
+        started.set()
+        await release.wait()
+        return {}
+
+    coordinator = _mgr_coordinator("p1", history=slow)
+    manager, entry, _store = _make_manager(hass, [coordinator])
+
+    with patch("custom_components.sungrow.backfill.import_statistics"):
+        await manager.async_run_on_demand(plant_ids=None, start_date=None)
+        await started.wait()
+        assert manager.is_running("p1") is True
+
+        # Second request while the first is still running must be ignored.
+        await manager.async_run_on_demand(plant_ids=["p1"], start_date=None)
+        assert len(entry.background_tasks) == 1
+
+        release.set()
+        await asyncio.gather(*entry.background_tasks)
+
+    assert manager.is_running("p1") is False
+
+
+@pytest.mark.asyncio
+async def test_manager_one_plant_failure_does_not_stop_others(hass: HomeAssistant):
+    """One plant erroring out never stops the others' runs (9.1, 9.3)."""
+
+    async def good(plant_id, start, end, *, measure_points, interval):
+        return {plant_id: [_row(code, start, 100.0) for code in measure_points]}
+
+    c_ok = _mgr_coordinator("ok", history=good)
+    c_bad = _mgr_coordinator("bad", history=AuthError({"result_code": "E900"}))
+    manager, entry, _store = _make_manager(hass, [c_ok, c_bad])
+
+    with patch("custom_components.sungrow.backfill.import_statistics") as mock_import:
+        await manager.async_run_on_demand(plant_ids=None, start_date=None)
+        # gather must not raise even though the "bad" plant's run raised internally.
+        await asyncio.gather(*entry.background_tasks)
+
+    # The healthy plant completed and imported despite the other's failure.
+    c_ok.plants_service.async_get_historical_data.assert_awaited()
+    assert mock_import.called
+    assert manager.is_running("ok") is False
+    assert manager.is_running("bad") is False
+
+
+@pytest.mark.asyncio
+async def test_manager_engines_share_one_throttle(hass: HomeAssistant):
+    """All engines of an entry share the manager's single throttle (9.4)."""
+    c1 = _mgr_coordinator("p1")
+    c2 = _mgr_coordinator("p2")
+    manager, entry, _store = _make_manager(hass, [c1, c2])
+
+    with patch("custom_components.sungrow.backfill.import_statistics"):
+        await manager.async_run_on_demand(plant_ids=None, start_date=None)
+        await asyncio.gather(*entry.background_tasks)
+
+    assert manager._engines["p1"]._throttle is manager._engines["p2"]._throttle
+    assert manager._engines["p1"]._throttle is manager._throttle
+
+
+@pytest.mark.asyncio
+async def test_manager_shutdown_cancels_tasks_leaving_imports_intact(hass: HomeAssistant):
+    """Shutdown cancels in-flight runs; hours imported before cancellation stay intact (1.5)."""
+    started = asyncio.Event()
+    release = asyncio.Event()
+    state = {"calls": 0}
+    imported: list = []
+
+    async def slow(plant_id, start, end, *, measure_points, interval):
+        state["calls"] += 1
+        if state["calls"] == 1:
+            # First chunk returns rows so at least one import lands before we block.
+            return {plant_id: [_row(code, start, 100.0) for code in measure_points]}
+        started.set()
+        await release.wait()  # block so shutdown cancels the run mid-flight
+        return {}
+
+    def record_import(hass_, target, data):
+        imported.append((target.statistic_id, tuple(d["start"] for d in data)))
+
+    coordinator = _mgr_coordinator("p1", history=slow)
+    manager, entry, _store = _make_manager(hass, [coordinator])
+
+    with patch("custom_components.sungrow.backfill.import_statistics", side_effect=record_import):
+        await manager.async_run_on_demand(plant_ids=None, start_date=None)
+        await started.wait()
+        assert manager.is_running("p1") is True
+
+        await manager.async_shutdown()  # cancels the blocked task
+
+    # The task is gone and the first chunk's imports remain durable (never rolled back).
+    assert manager.is_running("p1") is False
+    assert manager._tasks == {}
+    assert len(imported) >= 1
+
+
+# ---------------------------------------------------------------------------
+# Task 14 - setup wiring in __init__.py
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_cloud_setup_constructs_manager_and_starts_run(hass: HomeAssistant, mock_setup_auth, mock_plants_service):
+    """A cloud entry builds a BackfillManager and kicks off the automatic run (1.1)."""
+    from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+    from tests.conftest import MOCK_CONFIG_DATA
+
+    with patch.object(BackfillManager, "async_start_automatic", new=AsyncMock()) as mock_start:
+        entry = MockConfigEntry(domain=DOMAIN, data=MOCK_CONFIG_DATA.copy(), unique_id="test_app_id")
+        entry.add_to_hass(hass)
+        assert await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+
+    assert isinstance(entry.runtime_data.backfill, BackfillManager)
+    mock_start.assert_awaited()
+
+
+@pytest.mark.asyncio
+async def test_modbus_only_setup_skips_backfill(hass: HomeAssistant):
+    """A Modbus-only (cloud-free) entry never constructs a manager (1.2)."""
+    from unittest.mock import MagicMock
+
+    from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+    from custom_components.sungrow.const import (
+        CONF_MODBUS_HOST,
+        CONF_MODEL,
+        CONF_SCAN_INTERVAL,
+        CONF_SERIAL,
+        CONF_TRANSPORT,
+        TRANSPORT_MODBUS_ONLY,
+    )
+
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={
+            CONF_TRANSPORT: TRANSPORT_MODBUS_ONLY,
+            CONF_SERIAL: "SN123",
+            CONF_MODEL: "SG3.6RS",
+            CONF_MODBUS_HOST: "10.0.0.9",
+        },
+        options={CONF_SCAN_INTERVAL: 30},
+        unique_id="modbus_SN123",
+    )
+    entry.add_to_hass(hass)
+
+    client = MagicMock()
+    client.async_read_realtime = AsyncMock(
+        return_value={"grid_frequency": {"code": "grid_frequency", "value": 49.9, "unit": "Hz", "source": "modbus"}}
+    )
+    with patch("custom_components.sungrow.modbus.SungrowModbusClient", return_value=client):
+        assert await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+
+    # Backfill is cloud-only: the Modbus-only path leaves the field as None.
+    assert entry.runtime_data.backfill is None
+
+
+@pytest.mark.asyncio
+async def test_realtime_poll_not_blocked_by_parked_backfill():
+    """An in-flight run parked on the throttle never blocks an independent poll (5.4, 5.5)."""
+    throttle = Throttle(min_interval=0.0)
+    parked = asyncio.Event()
+    release = asyncio.Event()
+
+    async def park(_delay: float) -> None:
+        parked.set()
+        await release.wait()
+
+    throttle._sleep = park  # type: ignore[method-assign]
+
+    # A backfill "run" parked on a throttle backoff.
+    backfill_task = asyncio.ensure_future(throttle.backoff())
+    await parked.wait()
+
+    # An independent realtime poll (no shared lock with the throttle) runs to completion.
+    poll_done = False
+
+    async def realtime_poll() -> None:
+        nonlocal poll_done
+        await asyncio.sleep(0)
+        poll_done = True
+
+    await asyncio.wait_for(realtime_poll(), timeout=1.0)
+    assert poll_done is True
+    assert not backfill_task.done()  # backfill is still parked, poll went ahead
+
+    release.set()
+    await backfill_task
+
+
+@pytest.mark.asyncio
+async def test_unload_shuts_down_backfill_manager(hass: HomeAssistant, mock_setup_auth, mock_plants_service):
+    """Unloading a cloud entry cancels in-flight runs via manager.async_shutdown (1.5)."""
+    from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+    from tests.conftest import MOCK_CONFIG_DATA
+
+    with patch.object(BackfillManager, "async_start_automatic", new=AsyncMock()):
+        entry = MockConfigEntry(domain=DOMAIN, data=MOCK_CONFIG_DATA.copy(), unique_id="test_app_id")
+        entry.add_to_hass(hass)
+        assert await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+
+    manager = entry.runtime_data.backfill
+    assert isinstance(manager, BackfillManager)
+
+    with patch.object(manager, "async_shutdown", new=AsyncMock()) as mock_shutdown:
+        assert await hass.config_entries.async_unload(entry.entry_id)
+        await hass.async_block_till_done()
+
+    mock_shutdown.assert_awaited()
+
+
+# ---------------------------------------------------------------------------
+# Task 15 - on-demand backfill service
+# ---------------------------------------------------------------------------
+
+
+async def _setup_cloud_entry(hass: HomeAssistant):
+    """Set up a two-plant cloud entry with the automatic run stubbed out."""
+    from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+    from tests.conftest import MOCK_CONFIG_DATA
+
+    entry = MockConfigEntry(domain=DOMAIN, data=MOCK_CONFIG_DATA.copy(), unique_id="test_app_id")
+    entry.add_to_hass(hass)
+    with patch.object(BackfillManager, "async_start_automatic", new=AsyncMock()):
+        assert await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+    return entry
+
+
+@pytest.mark.asyncio
+async def test_backfill_service_is_registered(hass: HomeAssistant, mock_setup_auth, mock_plants_service):
+    """Setting up a cloud entry registers the sungrow.backfill admin service (2.1)."""
+    await _setup_cloud_entry(hass)
+    assert hass.services.has_service(DOMAIN, "backfill") is True
+
+
+@pytest.mark.asyncio
+async def test_backfill_service_dispatches_to_all_plants(hass: HomeAssistant, mock_setup_auth, mock_plants_service):
+    """Calling the service with no config_entry dispatches a run to every plant (2.2)."""
+    entry = await _setup_cloud_entry(hass)
+    manager = entry.runtime_data.backfill
+
+    with patch.object(manager, "_start_run") as mock_start_run:
+        await hass.services.async_call(DOMAIN, "backfill", {}, blocking=True)
+
+    started = {call.args[0].plant_id for call in mock_start_run.call_args_list}
+    # MOCK_PLANT_LIST has two plants; both are dispatched.
+    assert started == {"12345", "67890"}
+
+
+@pytest.mark.asyncio
+async def test_backfill_service_passes_start_date(hass: HomeAssistant, mock_setup_auth, mock_plants_service):
+    """An explicit start_date is parsed to UTC midnight and passed through (2.3)."""
+    entry = await _setup_cloud_entry(hass)
+    manager = entry.runtime_data.backfill
+
+    with patch.object(manager, "async_run_on_demand", new=AsyncMock()) as mock_run:
+        await hass.services.async_call(DOMAIN, "backfill", {"start_date": "2024-01-15"}, blocking=True)
+
+    mock_run.assert_awaited_once()
+    kwargs = mock_run.await_args.kwargs
+    assert kwargs["plant_ids"] is None
+    assert kwargs["start_date"] == datetime(2024, 1, 15, 0, 0, tzinfo=UTC)
+
+
+# ---------------------------------------------------------------------------
+# Task 16 - partial-failure Repair
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_manager_partial_run_raises_repair_then_clears_it(hass: HomeAssistant):
+    """A partial run raises the backfill_partial issue; a later clean run clears it (8.1, 8.2)."""
+    from homeassistant.helpers import issue_registry as ir
+
+    fail_state = {"first": None}
+
+    async def partial_history(plant_id, start, end, *, measure_points, interval):
+        if fail_state["first"] is None:
+            fail_state["first"] = start
+        if start == fail_state["first"]:
+            raise ValueError("transient boom")  # this chunk never succeeds -> partial
+        return {plant_id: [_row(code, start, 100.0) for code in measure_points]}
+
+    coordinator = _mgr_coordinator("p1", history=partial_history)
+    manager, entry, _store = _make_manager(hass, [coordinator])
+    # Pre-create the engine so its transient-retry sleep is a no-op (keeps the test fast).
+    manager._engine_for(coordinator)._sleep = AsyncMock()  # type: ignore[method-assign]
+
+    with patch("custom_components.sungrow.backfill.import_statistics"):
+        await manager.async_run_on_demand(plant_ids=None, start_date=None)
+        await asyncio.gather(*entry.background_tasks)
+
+    issue_reg = ir.async_get(hass)
+    assert issue_reg.async_get_issue(DOMAIN, "backfill_partial_p1") is not None
+
+    # A subsequent fully successful run clears the Repair.
+    coordinator.plants_service.async_get_historical_data.side_effect = None
+    coordinator.plants_service.async_get_historical_data.return_value = {}
+    entry.background_tasks.clear()
+
+    await manager.async_run_on_demand(plant_ids=None, start_date=None)
+    await asyncio.gather(*entry.background_tasks)
+
+    assert issue_reg.async_get_issue(DOMAIN, "backfill_partial_p1") is None

--- a/tests/test_backfill_properties.py
+++ b/tests/test_backfill_properties.py
@@ -1,0 +1,357 @@
+"""Property-based tests for the Backfill pure-logic core.
+
+Feature: backfill-historical-statistics.
+
+Each test exercises one of the design's Correctness Properties across a wide input
+space with Hypothesis (minimum 100 examples). The pure functions under test carry no
+I/O, which makes them an ideal property-test surface.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+
+import pytest
+from hypothesis import given, settings
+from hypothesis import strategies as st
+
+from custom_components.sungrow.backfill import (
+    HistoryWindow,
+    InvalidRangeError,
+    MinuteRow,
+    batch_points,
+    build_hourly_statistics,
+    chunk_time_window,
+    resolve_window,
+)
+from custom_components.sungrow.const import (
+    DEFAULT_BACKFILL_DAYS,
+    MAX_BACKFILL_DAYS,
+)
+from custom_components.sungrow.energy_units import normalize_energy_point
+
+UTC = UTC
+_WH_UNITS = {"wh", "w·h", "w.h", "watt-hour", "watt hour", "watthour"}
+
+
+# ---------------------------------------------------------------------------
+# Strategies
+# ---------------------------------------------------------------------------
+
+
+@st.composite
+def aware_datetimes(draw, min_year: int = 2021, max_year: int = 2030) -> datetime:
+    """Timezone-aware UTC datetimes in a bounded range (avoids timedelta overflow)."""
+    naive = draw(
+        st.datetimes(
+            min_value=datetime(min_year, 1, 1),
+            max_value=datetime(max_year, 1, 1),
+        )
+    )
+    return naive.replace(tzinfo=UTC)
+
+
+@st.composite
+def minute_rows(draw) -> list[MinuteRow]:
+    """Minute rows anchored to a fixed base: monotonic-ish readings plus noise/resets."""
+    base = datetime(2024, 1, 1, tzinfo=UTC)
+    entries = draw(
+        st.lists(
+            st.tuples(
+                st.integers(min_value=0, max_value=6000),  # minute offset
+                st.floats(
+                    min_value=0.0,
+                    max_value=1_000_000.0,
+                    allow_nan=False,
+                    allow_infinity=False,
+                ),
+            ),
+            max_size=40,
+        )
+    )
+    return [MinuteRow(timestamp=base + timedelta(minutes=o), value=v) for o, v in entries]
+
+
+# ---------------------------------------------------------------------------
+# Helpers (fake recorder store + chunked aggregation, hour-aligned)
+# ---------------------------------------------------------------------------
+
+
+def _hour(ts: datetime) -> datetime:
+    return ts.replace(minute=0, second=0, microsecond=0)
+
+
+def _hour_aligned_chunks(rows: list[MinuteRow], hours_per_chunk: int) -> list[list[MinuteRow]]:
+    """Partition rows into chunks whose boundaries fall on hour boundaries.
+
+    Each whole hour is fully contained in exactly one chunk, mirroring how the engine
+    splits the window into Time_Chunks without ever splitting a single hour.
+    """
+    if not rows:
+        return []
+    by_hour: dict[datetime, list[MinuteRow]] = {}
+    for r in rows:
+        by_hour.setdefault(_hour(r.timestamp), []).append(r)
+    hours = sorted(by_hour)
+    chunks: list[list[MinuteRow]] = []
+    for i in range(0, len(hours), hours_per_chunk):
+        group: list[MinuteRow] = []
+        for h in hours[i : i + hours_per_chunk]:
+            group.extend(by_hour[h])
+        chunks.append(group)
+    return chunks
+
+
+def _aggregate_pieces(rows: list[MinuteRow], hours_per_chunk: int) -> list[list[dict]]:
+    """Aggregate hour-aligned chunks in order, carrying running_sum and prev_value."""
+    running = 0.0
+    prev: float | None = None
+    pieces: list[list[dict]] = []
+    for chunk in _hour_aligned_chunks(rows, hours_per_chunk):
+        data, running = build_hourly_statistics(chunk, "energy", running_sum=running, prev_value=prev)
+        pieces.append(data)
+        ordered = sorted(chunk, key=lambda r: r.timestamp)
+        if ordered:
+            prev = ordered[-1].value
+    return pieces
+
+
+def _import_into(store: dict, statistic_id: str, data: list[dict]) -> None:
+    """Mimic the recorder helpers: overwrite by (statistic_id, start_hour)."""
+    for d in data:
+        store[(statistic_id, d["start"])] = d
+
+
+# ---------------------------------------------------------------------------
+# Property 1: Window resolution is bounded and honors configuration
+# ---------------------------------------------------------------------------
+
+
+# Feature: backfill-historical-statistics, Property 1: Window resolution is bounded
+# and honors configuration.
+# Validates: Requirements 2.3, 3.1, 3.2, 3.3, 3.4, 3.5
+@settings(max_examples=100)
+@given(
+    now=aware_datetimes(),
+    option_days=st.one_of(st.none(), st.integers(min_value=-10, max_value=400)),
+    start=st.one_of(st.none(), aware_datetimes(2020, 2031)),
+)
+def test_property1_window_resolution(now, option_days, start):
+    # 3.5: a start later than now is an invalid range.
+    if start is not None and start > now:
+        with pytest.raises(InvalidRangeError):
+            resolve_window(now=now, option_days=option_days, start_override=start)
+        return
+
+    window = resolve_window(now=now, option_days=option_days, start_override=start)
+
+    # 3.4: finite, positive-length window ending at now.
+    assert window.end == now
+    assert window.start < window.end
+    # 3.3/3.4: length is bounded to [1, MAX] days.
+    assert timedelta(days=1) <= (window.end - window.start) <= timedelta(days=MAX_BACKFILL_DAYS)
+
+    if start is None:
+        # 3.1/3.2/3.3: default or configured length, clamped.
+        requested = DEFAULT_BACKFILL_DAYS if option_days is None else option_days
+        clamped = max(1, min(requested, MAX_BACKFILL_DAYS))
+        assert window.start == now - timedelta(days=clamped)
+    else:
+        # 2.3/3.5: honor the explicit start, subject to the same clamp.
+        earliest = now - timedelta(days=MAX_BACKFILL_DAYS)
+        latest = now - timedelta(days=1)
+        assert window.start == min(max(start, earliest), latest)
+
+
+# ---------------------------------------------------------------------------
+# Property 2: Point batching preserves all points and never exceeds the cap
+# ---------------------------------------------------------------------------
+
+
+# Feature: backfill-historical-statistics, Property 2: Point batching preserves all
+# points and never exceeds the cap.
+# Validates: Requirements 4.1
+@settings(max_examples=100)
+@given(
+    points=st.lists(st.integers(), max_size=200),
+    max_size=st.integers(min_value=1, max_value=50),
+)
+def test_property2_point_batching(points, max_size):
+    batches = batch_points(points, max_size=max_size)
+
+    # Cap respected, and no empty batches emitted.
+    for batch in batches:
+        assert 0 < len(batch) <= max_size
+    # Order-preserving: in-order concatenation equals the original list.
+    flattened = [p for batch in batches for p in batch]
+    assert flattened == points
+
+
+# ---------------------------------------------------------------------------
+# Property 3: Time chunking covers the window in ascending, bounded,
+# non-overlapping pieces
+# ---------------------------------------------------------------------------
+
+
+@st.composite
+def _windows_and_chunks(draw):
+    now = draw(aware_datetimes())
+    span = draw(st.integers(min_value=0, max_value=6000))  # minutes
+    chunk_minutes = draw(st.integers(min_value=5, max_value=6000))
+    window = HistoryWindow(start=now - timedelta(minutes=span), end=now)
+    return window, timedelta(minutes=chunk_minutes)
+
+
+# Feature: backfill-historical-statistics, Property 3: Time chunking covers the window
+# in ascending, bounded, non-overlapping pieces.
+# Validates: Requirements 4.2, 4.3, 4.4
+@settings(max_examples=100)
+@given(data=_windows_and_chunks())
+def test_property3_time_chunking(data):
+    window, chunk = data
+    chunks = chunk_time_window(window, chunk)
+
+    if window.start == window.end:
+        assert chunks == []
+        return
+
+    # Exact coverage of [start, end).
+    assert chunks[0][0] == window.start
+    assert chunks[-1][1] == window.end
+
+    for start, end in chunks:
+        assert start < end  # non-empty
+        assert end - start <= chunk  # duration bound (4.2)
+
+    for (s0, e0), (s1, _e1) in zip(chunks, chunks[1:], strict=False):
+        assert e0 == s1  # contiguous and non-overlapping (4.4)
+        assert s0 < s1  # ascending (4.4)
+
+
+# ---------------------------------------------------------------------------
+# Property 4: Cumulative energy sum is non-decreasing across the whole window
+# ---------------------------------------------------------------------------
+
+
+# Feature: backfill-historical-statistics, Property 4: Cumulative energy sum is
+# non-decreasing across the whole window.
+# Validates: Requirements 4.5, 7.1
+@settings(max_examples=100)
+@given(rows=minute_rows(), hours_per_chunk=st.integers(min_value=1, max_value=5))
+def test_property4_non_decreasing_sum(rows, hours_per_chunk):
+    # Aggregate across chunks with running_sum carried forward, then order by hour.
+    all_data = [d for piece in _aggregate_pieces(rows, hours_per_chunk) for d in piece]
+    all_data.sort(key=lambda d: d["start"])
+    sums = [d["sum"] for d in all_data]
+
+    for earlier, later in zip(sums, sums[1:], strict=False):
+        assert earlier <= later + 1e-6
+
+
+# ---------------------------------------------------------------------------
+# Property 5: Aggregation is deterministic and import is idempotent and hour-local
+# ---------------------------------------------------------------------------
+
+
+# Feature: backfill-historical-statistics, Property 5: Aggregation is deterministic and
+# import is idempotent and hour-local.
+# Validates: Requirements 6.1, 6.2, 6.3, 6.4
+@settings(max_examples=100)
+@given(rows=minute_rows(), hours_per_chunk=st.integers(min_value=1, max_value=5))
+def test_property5_determinism_and_idempotent_import(rows, hours_per_chunk):
+    statistic_id = "sungrow:plant_total_yield"
+
+    # Deterministic: equal input yields equal output.
+    data_a, _ = build_hourly_statistics(rows, "energy")
+    data_b, _ = build_hourly_statistics(rows, "energy")
+    assert data_a == data_b
+
+    # 6.3: exactly one entry per hour, every start on an exact UTC hour boundary.
+    starts = [d["start"] for d in data_a]
+    assert len(starts) == len(set(starts))
+    for start in starts:
+        assert start.tzinfo is not None
+        assert (start.minute, start.second, start.microsecond) == (0, 0, 0)
+
+    # 6.1: all-at-once import equals chunk-by-chunk import.
+    store_all: dict = {}
+    _import_into(store_all, statistic_id, data_a)
+
+    pieces = _aggregate_pieces(rows, hours_per_chunk)
+    store_chunked: dict = {}
+    for piece in pieces:
+        _import_into(store_chunked, statistic_id, piece)
+    assert store_chunked == store_all
+
+    # 6.2: running the whole import twice leaves the stored map unchanged.
+    store_twice = dict(store_all)
+    _import_into(store_twice, statistic_id, data_a)
+    assert store_twice == store_all
+
+    # 6.4: retrying any single chunk re-imports only that chunk's hours and leaves
+    # the final stored map identical (hour-local, overwrite-not-append).
+    for k in range(len(pieces)):
+        partial: dict = {}
+        for j, piece in enumerate(pieces):
+            if j != k:
+                _import_into(partial, statistic_id, piece)
+        _import_into(partial, statistic_id, pieces[k])  # retry chunk k
+        assert partial == store_all
+
+
+# ---------------------------------------------------------------------------
+# Property 6: Energy unit conversion is correct and stable
+# ---------------------------------------------------------------------------
+
+
+# Feature: backfill-historical-statistics, Property 6: Energy unit conversion is correct
+# and stable.
+# Validates: Requirements 7.5, 7.6
+@settings(max_examples=100)
+@given(
+    value=st.floats(min_value=0.0, max_value=1_000_000_000.0, allow_nan=False, allow_infinity=False),
+    unit=st.sampled_from(["Wh", "wh", "W·h", "watthour", "kWh", "W", "kW", "%", "V", ""]),
+)
+def test_property6_unit_conversion(value, unit):
+    out = normalize_energy_point({"value": value, "unit": unit})
+
+    if unit.lower() in _WH_UNITS:
+        # Wh -> kWh with 3-decimal rounding.
+        assert out["unit"] == "kWh"
+        assert out["value"] == round(value / 1000.0, 3)
+    else:
+        # kWh or non-energy units: value and unit unchanged.
+        assert out["value"] == value
+        assert out["unit"] == unit
+
+
+# ---------------------------------------------------------------------------
+# Property 7: Statistic_Ids are scoped per plant and never collide
+# ---------------------------------------------------------------------------
+
+
+from custom_components.sungrow.backfill import build_series_target  # noqa: E402
+
+
+# Feature: backfill-historical-statistics, Property 7: Statistic_Ids are scoped per
+# plant and never collide.
+# Validates: Requirements 9.2
+@settings(max_examples=100)
+@given(
+    plant_a=st.text(alphabet=st.characters(min_codepoint=48, max_codepoint=122), min_size=1, max_size=12),
+    plant_b=st.text(alphabet=st.characters(min_codepoint=48, max_codepoint=122), min_size=1, max_size=12),
+    code=st.text(alphabet=st.characters(min_codepoint=48, max_codepoint=122), min_size=1, max_size=20),
+    kind=st.sampled_from(["energy", "power"]),
+)
+def test_property7_statistic_id_scoping(plant_a, plant_b, code, kind):
+    target_a = build_series_target(plant_id=plant_a, point_code=code, kind=kind, entity_id=None, unit=None)
+    target_b = build_series_target(plant_id=plant_b, point_code=code, kind=kind, entity_id=None, unit=None)
+
+    # External ids always carry the sungrow: scope prefixed by the plant id.
+    assert target_a.is_external and target_b.is_external
+    assert target_a.statistic_id == f"sungrow:{plant_a}_{code}"
+    assert target_b.statistic_id == f"sungrow:{plant_b}_{code}"
+
+    # Distinct plants for the same code never collide.
+    if plant_a != plant_b:
+        assert target_a.statistic_id != target_b.statistic_id

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -33,6 +33,7 @@ from custom_components.sungrow.const import (
     CONF_TRANSPORT,
     DEFAULT_MODBUS_SCAN_INTERVAL,
     DOMAIN,
+    TRANSPORT_CLOUD_ONLY,
     TRANSPORT_MODBUS_ONLY,
 )
 
@@ -88,43 +89,49 @@ async def _reauth_to_manual(hass: HomeAssistant, entry: MockConfigEntry) -> str:
 
 
 async def test_user_step_shows_form(hass: HomeAssistant):
-    """Test the initial user step shows a form."""
+    """Test the initial user step shows the transport selector form."""
     result = await hass.config_entries.flow.async_init(DOMAIN, context={"source": config_entries.SOURCE_USER})
     assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "user"
-    assert result["errors"] == {}
-    assert "description_placeholders" in result
-    assert result["description_placeholders"]["url"] == "https://developer-api.isolarcloud.com/#/application"
-    assert "app_id_url" in result["description_placeholders"]
 
 
 async def test_user_step_creates_hub(hass: HomeAssistant, mock_auth):
-    """Submitting credentials creates the hub entry (no tokens yet)."""
+    """Selecting cloud_only transport and submitting credentials creates the hub entry."""
     result = await hass.config_entries.flow.async_init(DOMAIN, context={"source": config_entries.SOURCE_USER})
 
+    # Step 1: Select transport
+    result2 = await hass.config_entries.flow.async_configure(
+        result["flow_id"], user_input={CONF_TRANSPORT: TRANSPORT_CLOUD_ONLY}
+    )
+    assert result2["type"] == data_entry_flow.FlowResultType.FORM
+    assert result2["step_id"] == "cloud_credentials"
+
+    # Step 2: Submit credentials
     with patch("custom_components.sungrow.async_setup_entry", return_value=True):
-        result2 = await hass.config_entries.flow.async_configure(result["flow_id"], user_input=MOCK_USER_INPUT)
+        result3 = await hass.config_entries.flow.async_configure(result["flow_id"], user_input=MOCK_USER_INPUT)
         await hass.async_block_till_done()
 
-    assert result2["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
-    assert result2["title"] == f"Sungrow {MOCK_USER_INPUT[CONF_APP_ID]}"
+    assert result3["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
+    assert result3["title"] == f"Sungrow {MOCK_USER_INPUT[CONF_APP_ID]}"
     # The hub is created without tokens — authorization happens afterwards.
-    assert "tokens" not in result2["data"]
-    assert result2["data"][CONF_APP_KEY] == MOCK_USER_INPUT[CONF_APP_KEY]
+    assert "tokens" not in result3["data"]
+    assert result3["data"][CONF_APP_KEY] == MOCK_USER_INPUT[CONF_APP_KEY]
+    assert result3["data"][CONF_TRANSPORT] == TRANSPORT_CLOUD_ONLY
     # Setting up the hub registered the OAuth callback view (via async_setup),
     # so the redirect endpoint exists before any authorization attempt.
     assert hass.data[DOMAIN]["callback_view_registered"] is True
 
 
 async def test_user_step_aborts_if_already_configured(hass: HomeAssistant, mock_auth):
-    """Adding the same App ID twice aborts as already_configured (at the user step)."""
+    """Adding the same App ID twice aborts as already_configured (at the cloud_credentials step)."""
     _hub_entry(hass)
 
     result = await hass.config_entries.flow.async_init(DOMAIN, context={"source": config_entries.SOURCE_USER})
-    result2 = await hass.config_entries.flow.async_configure(result["flow_id"], user_input=MOCK_USER_INPUT)
+    await hass.config_entries.flow.async_configure(result["flow_id"], user_input={CONF_TRANSPORT: TRANSPORT_CLOUD_ONLY})
+    result3 = await hass.config_entries.flow.async_configure(result["flow_id"], user_input=MOCK_USER_INPUT)
 
-    assert result2["type"] == data_entry_flow.FlowResultType.ABORT
-    assert result2["reason"] == "already_configured"
+    assert result3["type"] == data_entry_flow.FlowResultType.ABORT
+    assert result3["reason"] == "already_configured"
 
 
 # ---------------------------------------------------------------------------
@@ -755,7 +762,7 @@ async def test_options_flow_parses_extra_measure_points(hass: HomeAssistant, moc
 
 
 async def test_options_flow_cloud_has_no_modbus_host(hass: HomeAssistant, mock_setup_auth, mock_plants_service):
-    """Cloud options do not expose or store a Modbus host (local is a separate entry)."""
+    """Cloud options expose an optional modbus_host field for transport switching (#216)."""
     entry = MockConfigEntry(domain=DOMAIN, data=MOCK_CONFIG_DATA.copy(), unique_id="test_app_id")
     entry.add_to_hass(hass)
     await hass.config_entries.async_setup(entry.entry_id)
@@ -763,8 +770,10 @@ async def test_options_flow_cloud_has_no_modbus_host(hass: HomeAssistant, mock_s
 
     result = await hass.config_entries.options.async_init(entry.entry_id)
     keys = {str(m.schema) for m in result["data_schema"].schema}
-    assert CONF_MODBUS_HOST not in keys
+    # cloud_only entries now show an optional modbus_host for switching to hybrid.
+    assert CONF_MODBUS_HOST in keys
 
+    # But submitting without a host doesn't store modbus_host in options.
     result2 = await hass.config_entries.options.async_configure(
         result["flow_id"],
         user_input={CONF_SCAN_INTERVAL: 30},

--- a/tests/test_const.py
+++ b/tests/test_const.py
@@ -75,6 +75,49 @@ def test_inverter_diagnostic_points_include_per_string():
     assert len(string_codes) == 16  # 8 strings x (voltage + current)
 
 
+def test_ess_mppt_diagnostic_points_shape():
+    """The hybrid/ESS MPPT map (this fix) maps the 13xxx IDs to the reused mpptN_* codes.
+
+    SH-family hybrids report MPPT voltage/current on a separate point-ID range than string
+    inverters; the codes are reused so classification/naming/icons stay identical.
+    """
+    from custom_components.sungrow.const import ESS_MPPT_DIAGNOSTIC_POINTS as P
+
+    expected = {
+        "13001": "mppt1_voltage",
+        "13002": "mppt1_current",
+        "13105": "mppt2_voltage",
+        "13106": "mppt2_current",
+        "13107": "mppt3_voltage",
+        "13108": "mppt3_current",
+        "13109": "mppt4_voltage",
+        "13110": "mppt4_current",
+    }
+    assert expected == P
+    # Exactly MPPT1-4 voltage/current (eight points), reusing the string-inverter code names.
+    assert len(P) == 8
+    mppt_codes = [c for c in P.values() if c.startswith("mppt")]
+    assert len(mppt_codes) == 8
+
+
+def test_ess_mppt_codes_reuse_string_inverter_codes():
+    """MPPT1-3 codes are shared with the string-inverter map; only mppt4_* are new.
+
+    Reusing the existing mppt1-3 code names is what keeps the diagnostic classification,
+    naming and icons identical without any extra mapping.
+    """
+    from custom_components.sungrow.const import ESS_MPPT_DIAGNOSTIC_POINTS as ESS
+    from custom_components.sungrow.const import INVERTER_DIAGNOSTIC_POINTS as INV
+
+    inv_codes = set(INV.values())
+    # mppt1-3 codes already exist on the string-inverter map (via "5"-"10").
+    for code in ("mppt1_voltage", "mppt1_current", "mppt2_voltage", "mppt3_current"):
+        assert code in inv_codes
+    # mppt4_* are the only genuinely new code names introduced by this map.
+    new_codes = set(ESS.values()) - inv_codes
+    assert new_codes == {"mppt4_voltage", "mppt4_current"}
+
+
 def test_meter_device_points_present():
     """The meter map (#179) carries instantaneous power/PF/frequency + per-phase."""
     from custom_components.sungrow.const import METER_DEVICE_POINTS as M

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -12,6 +12,8 @@ from pysolarcloud import AuthError, PySolarCloudException
 from pysolarcloud.plants import DeviceType
 
 from custom_components.sungrow.const import (
+    BATTERY_DEVICE_POINTS,
+    COMM_MODULE_POINTS,
     CONF_ENABLE_DEVICE_SENSORS,
     CONF_EXTRA_MEASURE_POINTS,
     CONF_MODBUS_DEBUG_DAILY_YIELD,
@@ -22,6 +24,10 @@ from custom_components.sungrow.const import (
     CONF_TRANSPORT,
     DEVICE_REFRESH_INTERVAL,
     DOMAIN,
+    ESS_OPERATING_STATUS_POINT,
+    INVERTER_DIAGNOSTIC_POINTS,
+    INVERTER_OPERATING_STATUS_POINT,
+    METER_DEVICE_POINTS,
     TRANSPORT_MODBUS_ONLY,
 )
 from custom_components.sungrow.coordinator import (
@@ -970,3 +976,245 @@ async def test_capture_daily_yield_diagnostic_noop_without_client(hass: HomeAssi
     assert coordinator._modbus_client is None
     await coordinator._async_capture_daily_yield_diagnostic()
     assert coordinator.daily_yield_diagnostic is None
+
+
+# ---------------------------------------------------------------------------
+# Bug condition exploration (hybrid MPPT / string sensors) — Property 1
+#
+# These tests encode the EXPECTED (fixed) behavior for SH-family hybrids reported
+# as DeviceType.ENERGY_STORAGE_SYSTEM. They MUST FAIL on the unfixed code: the ESS
+# branch currently reuses INVERTER_DIAGNOSTIC_POINTS, which requests the string-
+# inverter MPPT IDs ("5"-"10") and never the hybrid 13xxx MPPT IDs. Failure here
+# confirms the bug exists (root cause #1). Validates: Requirements 2.1
+# ---------------------------------------------------------------------------
+
+# The hybrid MPPT point IDs an ESS/hybrid must request (MPPT1-4 voltage/current).
+HYBRID_MPPT_POINT_IDS = {
+    "13001",
+    "13002",
+    "13105",
+    "13106",
+    "13107",
+    "13108",
+    "13109",
+    "13110",
+}
+# The string-inverter MPPT IDs that must NOT be requested for an ESS (they share the
+# mpptN_* codes with the 13xxx IDs, so requesting both collides in the per-device merge).
+STRING_INVERTER_MPPT_POINT_IDS = {"5", "6", "7", "8", "9", "10"}
+
+
+async def test_ess_requests_hybrid_mppt_points(hass: HomeAssistant):
+    """Bug condition (Property 1): an ESS with device sensors ON requests the hybrid MPPT IDs.
+
+    Mirrors test_ess_operating_status_avoids_point29_collision. On the UNFIXED code the ESS
+    branch reuses INVERTER_DIAGNOSTIC_POINTS and never requests the 13xxx MPPT IDs, so this
+    subset assertion FAILS — which is the intended proof that the bug exists.
+
+    Validates: Requirements 2.1
+    """
+    plants = MagicMock()
+    plants.async_get_realtime_data = AsyncMock(return_value=MOCK_REALTIME_DATA)
+    plants.async_get_device_realtime = AsyncMock(return_value={})
+    devices = [{"uuid": "ess-1", "device_type": DeviceType.ENERGY_STORAGE_SYSTEM, "ps_key": "12345_14_1_1"}]
+    coordinator = SungrowPlantCoordinator(
+        hass, _make_entry({CONF_ENABLE_DEVICE_SENSORS: True}), plants, "12345", "Test Plant", devices
+    )
+
+    await coordinator._async_update_data()
+
+    extra = plants.async_get_device_realtime.await_args.kwargs["extra_measure_points"]
+    # Assertion A: the eight hybrid MPPT IDs are requested for the ESS device.
+    missing = HYBRID_MPPT_POINT_IDS - set(extra)
+    assert not missing, f"ESS extra_measure_points is missing hybrid MPPT IDs: {sorted(missing)}"
+
+
+async def test_ess_drops_string_inverter_mppt_points(hass: HomeAssistant):
+    """Bug condition (Property 1 / Property 2 final clause): ESS omits the string-inverter MPPT IDs.
+
+    Because "5"-"10" and the 13xxx IDs both map to the mpptN_* codes, requesting both for a single
+    ESS device would silently overwrite one another in the per-device merge. On the UNFIXED code
+    "5"-"10" are present, so this assertion FAILS — the collision source is confirmed.
+
+    Validates: Requirements 2.1
+    """
+    plants = MagicMock()
+    plants.async_get_realtime_data = AsyncMock(return_value=MOCK_REALTIME_DATA)
+    plants.async_get_device_realtime = AsyncMock(return_value={})
+    devices = [{"uuid": "ess-1", "device_type": DeviceType.ENERGY_STORAGE_SYSTEM, "ps_key": "12345_14_1_1"}]
+    coordinator = SungrowPlantCoordinator(
+        hass, _make_entry({CONF_ENABLE_DEVICE_SENSORS: True}), plants, "12345", "Test Plant", devices
+    )
+
+    await coordinator._async_update_data()
+
+    extra = plants.async_get_device_realtime.await_args.kwargs["extra_measure_points"]
+    # Assertion B: the string-inverter MPPT IDs are absent from the ESS extra.
+    present = STRING_INVERTER_MPPT_POINT_IDS & set(extra)
+    assert not present, f"ESS extra_measure_points still contains string-inverter MPPT IDs: {sorted(present)}"
+
+
+# ---------------------------------------------------------------------------
+# Preservation (hybrid MPPT / string sensors) — Property 2
+#
+# These tests capture the BASELINE behavior of every non-buggy device/config path
+# so the upcoming fix can be proven to leave it byte-for-byte identical. They are
+# written observation-first and MUST PASS on the unfixed code. The ESS-with-sensors-ON
+# path is the buggy combination and is therefore NOT asserted for full equality here;
+# only its operating-status handling (13146 requested, 29 dropped) is preserved.
+# Validates: Requirements 3.1, 3.2, 3.3, 3.4
+# ---------------------------------------------------------------------------
+
+# Sentinel: the coordinator skips the per-device fetch entirely (no diagnostic set to
+# request), so async_get_device_realtime is never awaited for that combination.
+_DEVICE_REALTIME_NOT_CALLED = object()
+
+# The string-inverter per-string DC voltage/current IDs that INVERTER must keep requesting.
+_STRING_INVERTER_STRING_POINT_IDS = {
+    "96",
+    "70",
+    "97",
+    "71",
+    "98",
+    "72",
+    "99",
+    "73",
+    "100",
+    "74",
+    "101",
+    "75",
+    "102",
+    "76",
+    "103",
+    "77",
+}
+
+
+async def _capture_device_extra(hass, device_type, *, enable_device_sensors):
+    """Run a single-device update and return the captured extra_measure_points.
+
+    Mirrors test_ess_operating_status_avoids_point29_collision: a MagicMock plants
+    service captures the extra_measure_points kwarg passed to async_get_device_realtime.
+    Returns _DEVICE_REALTIME_NOT_CALLED when the coordinator skips the per-device fetch.
+    """
+    plants = MagicMock()
+    plants.async_get_realtime_data = AsyncMock(return_value=MOCK_REALTIME_DATA)
+    plants.async_get_device_realtime = AsyncMock(return_value={})
+    devices = [{"uuid": "dev-1", "device_type": device_type, "ps_key": "12345_1_1_1"}]
+    options = {CONF_ENABLE_DEVICE_SENSORS: True} if enable_device_sensors else {}
+    coordinator = SungrowPlantCoordinator(hass, _make_entry(options), plants, "12345", "Test Plant", devices)
+
+    await coordinator._async_update_data()
+
+    if plants.async_get_device_realtime.await_args is None:
+        return _DEVICE_REALTIME_NOT_CALLED
+    return plants.async_get_device_realtime.await_args.kwargs["extra_measure_points"]
+
+
+def _golden_preservation_cases():
+    """Golden (device_type, enable_device_sensors) -> expected extra for every non-buggy path.
+
+    Composed from the const point maps exactly as the coordinator selects them, which is the
+    unchanged baseline for these paths. ESS + sensors ON is intentionally excluded — it is the
+    buggy combination the fix will change and is covered by dedicated preservation assertions.
+    """
+    return [
+        # String inverter: full diagnostic set (MPPT "5"-"10" + per-string + grid health).
+        pytest.param(DeviceType.INVERTER, True, dict(INVERTER_DIAGNOSTIC_POINTS), id="inverter-on"),
+        # Sensors off: only the single operating-status point, no heavy diagnostic set.
+        pytest.param(DeviceType.INVERTER, False, dict(INVERTER_OPERATING_STATUS_POINT), id="inverter-off"),
+        pytest.param(DeviceType.ENERGY_STORAGE_SYSTEM, False, dict(ESS_OPERATING_STATUS_POINT), id="ess-off"),
+        # Battery / meter / comm each request their existing point set unchanged.
+        pytest.param(DeviceType.BATTERY, True, dict(BATTERY_DEVICE_POINTS), id="battery-on"),
+        pytest.param(DeviceType.METER, True, dict(METER_DEVICE_POINTS), id="meter-on"),
+        pytest.param(DeviceType.COMMUNICATION_MODULE, True, dict(COMM_MODULE_POINTS), id="comm-on"),
+        # Unmapped type with sensors on: no diagnostic set -> extra collapses to None.
+        pytest.param(999, True, None, id="unmapped-on"),
+        # Sensors off + no operating-status point -> the per-device fetch is skipped entirely.
+        pytest.param(DeviceType.BATTERY, False, _DEVICE_REALTIME_NOT_CALLED, id="battery-off"),
+        pytest.param(DeviceType.METER, False, _DEVICE_REALTIME_NOT_CALLED, id="meter-off"),
+        pytest.param(DeviceType.COMMUNICATION_MODULE, False, _DEVICE_REALTIME_NOT_CALLED, id="comm-off"),
+        pytest.param(999, False, _DEVICE_REALTIME_NOT_CALLED, id="unmapped-off"),
+    ]
+
+
+@pytest.mark.parametrize(("device_type", "enable_device_sensors", "expected"), _golden_preservation_cases())
+async def test_non_buggy_device_config_extra_measure_points_preserved(
+    hass: HomeAssistant, device_type, enable_device_sensors, expected
+):
+    """Property 2: every non-buggy device/config requests exactly its golden point set.
+
+    Generated over device type x enable_device_sensors; for each combination the captured
+    extra_measure_points must equal the observed baseline. Passing on the unfixed code fixes
+    the behavior the upcoming fix must preserve byte-for-byte.
+
+    Validates: Requirements 3.1, 3.3, 3.4
+    """
+    captured = await _capture_device_extra(hass, device_type, enable_device_sensors=enable_device_sensors)
+
+    assert captured == expected
+
+
+async def test_inverter_mppt_and_string_points_preserved(hass: HomeAssistant):
+    """Property 2: INVERTER + sensors on keeps its MPPT ("5"-"10") and per-string IDs.
+
+    Validates: Requirement 3.1
+    """
+    extra = await _capture_device_extra(hass, DeviceType.INVERTER, enable_device_sensors=True)
+
+    assert set(extra) >= STRING_INVERTER_MPPT_POINT_IDS  # "5"-"10" still requested
+    assert set(extra) >= _STRING_INVERTER_STRING_POINT_IDS  # "96"/"70" .. "103"/"77" still requested
+
+
+async def test_ess_operating_status_handling_preserved(hass: HomeAssistant):
+    """Property 2: ESS + sensors on still requests 13146 for operating status and drops 29.
+
+    This is the one aspect of the (otherwise buggy) ESS-with-sensors-on path that the fix
+    must preserve exactly: the 13146/29 operating-status collision handling (#182).
+
+    Validates: Requirement 3.2
+    """
+    extra = await _capture_device_extra(hass, DeviceType.ENERGY_STORAGE_SYSTEM, enable_device_sensors=True)
+
+    assert extra["13146"] == "operating_status"
+    assert "29" not in extra
+
+
+# ---------------------------------------------------------------------------
+# Fix Checking / Preservation Checking (hybrid MPPT / string sensors)
+#
+# FOR ALL X WHERE isBugCondition(X): the fixed ESS branch requests the 13xxx IDs and
+# drops "5"-"10" (covered above by test_ess_requests_hybrid_mppt_points /
+# test_ess_drops_string_inverter_mppt_points, which now PASS on the fixed code).
+#
+# Preservation Checking (Property 2 final clause): for an ESS device the requested IDs
+# must never contain both a "5"-"10" ID and its 13xxx counterpart, so no two point IDs
+# map to the same mpptN_* code and silently overwrite each other in the per-device merge.
+# Validates: Requirements 2.1, 3.1, 3.2
+# ---------------------------------------------------------------------------
+
+
+async def test_ess_mppt_ids_have_no_code_collision(hass: HomeAssistant):
+    """Property 2: no two requested ESS IDs map to the same mpptN_* code.
+
+    Because "5" and "13001" both resolve to mppt1_voltage (and so on), requesting both
+    for one ESS device would let one silently overwrite the other in the per-device merge.
+    The fix swaps "5"-"10" for the 13xxx IDs, so each mpptN_* code is requested exactly once.
+
+    Validates: Requirements 2.1, 3.1, 3.2
+    """
+    extra = await _capture_device_extra(hass, DeviceType.ENERGY_STORAGE_SYSTEM, enable_device_sensors=True)
+
+    # Group the requested point IDs by the mpptN_* code they resolve to.
+    ids_by_mppt_code: dict[str, list[str]] = {}
+    for pid, code in extra.items():
+        if code.startswith("mppt"):
+            ids_by_mppt_code.setdefault(code, []).append(pid)
+
+    collisions = {code: pids for code, pids in ids_by_mppt_code.items() if len(pids) > 1}
+    assert not collisions, f"mpptN_* codes requested via more than one point ID for ESS: {collisions}"
+
+    # And concretely: the string-inverter and hybrid MPPT ID ranges are disjoint in the request.
+    requested = set(extra)
+    assert not (STRING_INVERTER_MPPT_POINT_IDS & requested & HYBRID_MPPT_POINT_IDS)
+    assert not (STRING_INVERTER_MPPT_POINT_IDS & requested)  # "5"-"10" fully dropped for ESS

--- a/tests/test_entry_shape_properties.py
+++ b/tests/test_entry_shape_properties.py
@@ -1,0 +1,97 @@
+"""Property-based test for entry data shape per transport mode (#216).
+
+Feature: transport-mode-selector
+Property 1: Entry data shape matches transport mode schema
+Validates: Requirements 4.1, 4.2, 4.3
+"""
+
+from hypothesis import given, settings
+from hypothesis import strategies as st
+
+from custom_components.sungrow.const import (
+    CONF_APP_ID,
+    CONF_APP_KEY,
+    CONF_APP_SECRET,
+    CONF_GATEWAY,
+    CONF_MODBUS_HOST,
+    CONF_MODEL,
+    CONF_REDIRECT_URI,
+    CONF_SERIAL,
+    CONF_TRANSPORT,
+    TRANSPORT_CLOUD_MODBUS,
+    TRANSPORT_CLOUD_ONLY,
+    TRANSPORT_MODBUS_ONLY,
+)
+
+CLOUD_FIELDS = {CONF_APP_KEY, CONF_APP_SECRET, CONF_APP_ID, CONF_GATEWAY, CONF_REDIRECT_URI}
+
+# Strategies for generating valid entry data per transport mode
+_non_empty_str = st.text(min_size=1, max_size=50, alphabet=st.characters(whitelist_categories=("L", "N")))
+
+cloud_only_strategy = st.fixed_dictionaries(
+    {
+        CONF_TRANSPORT: st.just(TRANSPORT_CLOUD_ONLY),
+        CONF_APP_KEY: _non_empty_str,
+        CONF_APP_SECRET: _non_empty_str,
+        CONF_APP_ID: _non_empty_str,
+        CONF_GATEWAY: st.sampled_from(["Europe", "International", "China", "Australia"]),
+        CONF_REDIRECT_URI: _non_empty_str,
+        "tokens": st.fixed_dictionaries({"access_token": _non_empty_str, "refresh_token": _non_empty_str}),
+    }
+)
+
+cloud_modbus_strategy = st.fixed_dictionaries(
+    {
+        CONF_TRANSPORT: st.just(TRANSPORT_CLOUD_MODBUS),
+        CONF_APP_KEY: _non_empty_str,
+        CONF_APP_SECRET: _non_empty_str,
+        CONF_APP_ID: _non_empty_str,
+        CONF_GATEWAY: st.sampled_from(["Europe", "International", "China", "Australia"]),
+        CONF_REDIRECT_URI: _non_empty_str,
+        "tokens": st.fixed_dictionaries({"access_token": _non_empty_str, "refresh_token": _non_empty_str}),
+        CONF_MODBUS_HOST: _non_empty_str,
+    }
+)
+
+modbus_only_strategy = st.fixed_dictionaries(
+    {
+        CONF_TRANSPORT: st.just(TRANSPORT_MODBUS_ONLY),
+        CONF_SERIAL: _non_empty_str,
+        CONF_MODEL: _non_empty_str,
+        CONF_MODBUS_HOST: _non_empty_str,
+    }
+)
+
+
+@settings(max_examples=100)
+@given(data=cloud_only_strategy)
+def test_cloud_only_entry_shape(data: dict):
+    """cloud_only entries have all cloud fields, no modbus_host."""
+    assert data[CONF_TRANSPORT] == TRANSPORT_CLOUD_ONLY
+    for field in CLOUD_FIELDS:
+        assert field in data, f"Missing cloud field: {field}"
+    assert CONF_MODBUS_HOST not in data
+
+
+@settings(max_examples=100)
+@given(data=cloud_modbus_strategy)
+def test_cloud_modbus_entry_shape(data: dict):
+    """cloud_modbus entries have all cloud fields AND modbus_host."""
+    assert data[CONF_TRANSPORT] == TRANSPORT_CLOUD_MODBUS
+    for field in CLOUD_FIELDS:
+        assert field in data, f"Missing cloud field: {field}"
+    assert CONF_MODBUS_HOST in data
+    assert data[CONF_MODBUS_HOST]
+
+
+@settings(max_examples=100)
+@given(data=modbus_only_strategy)
+def test_modbus_only_entry_shape(data: dict):
+    """modbus_only entries have serial, model, modbus_host; no cloud fields."""
+    assert data[CONF_TRANSPORT] == TRANSPORT_MODBUS_ONLY
+    assert CONF_SERIAL in data
+    assert CONF_MODEL in data
+    assert CONF_MODBUS_HOST in data
+    for field in CLOUD_FIELDS:
+        assert field not in data, f"Unexpected cloud field: {field}"
+    assert "tokens" not in data

--- a/tests/test_migration_properties.py
+++ b/tests/test_migration_properties.py
@@ -1,0 +1,136 @@
+"""Property-based tests for config entry migration (#216).
+
+Feature: transport-mode-selector
+"""
+
+import pytest
+from hypothesis import HealthCheck, given, settings
+from hypothesis import strategies as st
+from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+from custom_components.sungrow import async_migrate_entry
+from custom_components.sungrow.const import (
+    CONF_SCAN_INTERVAL,
+    CONF_TRANSPORT,
+    DOMAIN,
+    TRANSPORT_CLOUD_ONLY,
+    TRANSPORT_MODBUS_ONLY,
+)
+
+# ---------------------------------------------------------------------------
+# Property 2: v2→v3 migration correctly sets or preserves transport
+# Validates: Requirements 5.2, 5.3, 5.4
+# ---------------------------------------------------------------------------
+
+
+@settings(max_examples=100, suppress_health_check=[HealthCheck.function_scoped_fixture])
+@given(
+    has_transport=st.booleans(),
+    is_modbus=st.booleans(),
+    extra_keys=st.dictionaries(
+        keys=st.text(min_size=1, max_size=20).filter(lambda k: k != "transport"),
+        values=st.text(min_size=1, max_size=50),
+        max_size=5,
+    ),
+)
+@pytest.mark.asyncio
+async def test_v2_to_v3_migration_sets_or_preserves_transport(
+    hass, has_transport: bool, is_modbus: bool, extra_keys: dict
+):
+    """Property 2: v2→v3 migration back-fills cloud_only or preserves modbus_only."""
+    data = dict(extra_keys)
+    if has_transport:
+        data[CONF_TRANSPORT] = TRANSPORT_MODBUS_ONLY if is_modbus else TRANSPORT_CLOUD_ONLY
+
+    entry = MockConfigEntry(domain=DOMAIN, data=data, version=2)
+    entry.add_to_hass(hass)
+
+    result = await async_migrate_entry(hass, entry)
+    assert result is True
+    assert entry.version == 3
+
+    if has_transport and is_modbus:
+        assert entry.data[CONF_TRANSPORT] == TRANSPORT_MODBUS_ONLY
+    elif has_transport and not is_modbus:
+        assert entry.data[CONF_TRANSPORT] == TRANSPORT_CLOUD_ONLY
+    else:
+        # Was absent → backfilled to cloud_only
+        assert entry.data[CONF_TRANSPORT] == TRANSPORT_CLOUD_ONLY
+
+
+# ---------------------------------------------------------------------------
+# Property 3: v1→v3 chained migration preserves semantics
+# Validates: Requirements 5.5, 5.6
+# ---------------------------------------------------------------------------
+
+
+@settings(max_examples=100, suppress_health_check=[HealthCheck.function_scoped_fixture])
+@given(scan_interval=st.integers(min_value=1, max_value=1440))
+@pytest.mark.asyncio
+async def test_v1_to_v3_chained_migration(hass, scan_interval: int):
+    """Property 3: v1 entry migrates to v3 with correct scan_interval and transport."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={"app_key": "k", "app_secret": "s"},
+        options={CONF_SCAN_INTERVAL: scan_interval},
+        version=1,
+    )
+    entry.add_to_hass(hass)
+
+    result = await async_migrate_entry(hass, entry)
+    assert result is True
+    assert entry.version == 3
+    assert entry.options[CONF_SCAN_INTERVAL] == scan_interval * 60
+    assert entry.data[CONF_TRANSPORT] == TRANSPORT_CLOUD_ONLY
+
+
+# ---------------------------------------------------------------------------
+# Unit tests for migration edge cases (Task 3.4)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_v2_entry_no_transport_gets_cloud_only(hass):
+    """v2 entry with no transport field → gets cloud_only, version 3."""
+    entry = MockConfigEntry(domain=DOMAIN, data={"app_key": "k"}, version=2)
+    entry.add_to_hass(hass)
+    await async_migrate_entry(hass, entry)
+    assert entry.data[CONF_TRANSPORT] == TRANSPORT_CLOUD_ONLY
+    assert entry.version == 3
+
+
+@pytest.mark.asyncio
+async def test_v2_entry_modbus_only_preserved(hass):
+    """v2 entry with modbus_only → kept as modbus_only, version 3."""
+    entry = MockConfigEntry(domain=DOMAIN, data={CONF_TRANSPORT: TRANSPORT_MODBUS_ONLY, "serial": "SN"}, version=2)
+    entry.add_to_hass(hass)
+    await async_migrate_entry(hass, entry)
+    assert entry.data[CONF_TRANSPORT] == TRANSPORT_MODBUS_ONLY
+    assert entry.version == 3
+
+
+@pytest.mark.asyncio
+async def test_v1_entry_scan_interval_5_migrated(hass):
+    """v1 entry with scan_interval=5 → 300s, transport backfilled, version 3."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={"app_key": "k"},
+        options={CONF_SCAN_INTERVAL: 5},
+        version=1,
+    )
+    entry.add_to_hass(hass)
+    await async_migrate_entry(hass, entry)
+    assert entry.options[CONF_SCAN_INTERVAL] == 300
+    assert entry.data[CONF_TRANSPORT] == TRANSPORT_CLOUD_ONLY
+    assert entry.version == 3
+
+
+@pytest.mark.asyncio
+async def test_already_v3_no_changes(hass):
+    """Already-v3 entry → no changes applied."""
+    entry = MockConfigEntry(domain=DOMAIN, data={CONF_TRANSPORT: TRANSPORT_CLOUD_ONLY, "app_key": "k"}, version=3)
+    entry.add_to_hass(hass)
+    result = await async_migrate_entry(hass, entry)
+    assert result is True
+    assert entry.version == 3
+    assert entry.data[CONF_TRANSPORT] == TRANSPORT_CLOUD_ONLY

--- a/tests/test_options_transport.py
+++ b/tests/test_options_transport.py
@@ -1,0 +1,171 @@
+"""Unit tests for options flow transport switching (#216)."""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from homeassistant import data_entry_flow
+from homeassistant.core import HomeAssistant
+from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+from custom_components.sungrow.const import (
+    CONF_MODBUS_HOST,
+    CONF_MODEL,
+    CONF_SCAN_INTERVAL,
+    CONF_SERIAL,
+    CONF_TRANSPORT,
+    DOMAIN,
+    TRANSPORT_CLOUD_MODBUS,
+    TRANSPORT_CLOUD_ONLY,
+    TRANSPORT_MODBUS_ONLY,
+)
+
+from .conftest import MOCK_CONFIG_DATA
+
+# ---------------------------------------------------------------------------
+# cloud_only entry: shows optional modbus_host, can switch to hybrid
+# ---------------------------------------------------------------------------
+
+
+async def test_options_cloud_only_shows_modbus_host_field(hass: HomeAssistant, mock_setup_auth, mock_plants_service):
+    """A cloud_only entry's options include an optional modbus_host field."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={**MOCK_CONFIG_DATA, CONF_TRANSPORT: TRANSPORT_CLOUD_ONLY},
+        unique_id="test_app_id",
+    )
+    entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+
+    result = await hass.config_entries.options.async_init(entry.entry_id)
+    keys = {str(m.schema) for m in result["data_schema"].schema}
+    assert CONF_MODBUS_HOST in keys
+
+
+async def test_options_cloud_only_switch_to_hybrid(hass: HomeAssistant, mock_setup_auth, mock_plants_service):
+    """Providing a reachable host switches cloud_only → cloud_modbus."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={**MOCK_CONFIG_DATA, CONF_TRANSPORT: TRANSPORT_CLOUD_ONLY},
+        unique_id="test_app_id",
+    )
+    entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+
+    result = await hass.config_entries.options.async_init(entry.entry_id)
+
+    with patch("custom_components.sungrow.helpers.async_test_modbus_host", return_value=True):
+        result2 = await hass.config_entries.options.async_configure(
+            result["flow_id"],
+            user_input={CONF_SCAN_INTERVAL: 300, CONF_MODBUS_HOST: "192.168.1.50"},
+        )
+        await hass.async_block_till_done()
+
+    assert result2["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
+    assert entry.data[CONF_TRANSPORT] == TRANSPORT_CLOUD_MODBUS
+    assert entry.data[CONF_MODBUS_HOST] == "192.168.1.50"
+
+
+async def test_options_cloud_only_unreachable_host_shows_error(
+    hass: HomeAssistant, mock_setup_auth, mock_plants_service
+):
+    """Unreachable host keeps cloud_only and shows error."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={**MOCK_CONFIG_DATA, CONF_TRANSPORT: TRANSPORT_CLOUD_ONLY},
+        unique_id="test_app_id",
+    )
+    entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+
+    result = await hass.config_entries.options.async_init(entry.entry_id)
+
+    with patch("custom_components.sungrow.helpers.async_test_modbus_host", return_value=False):
+        result2 = await hass.config_entries.options.async_configure(
+            result["flow_id"],
+            user_input={CONF_SCAN_INTERVAL: 300, CONF_MODBUS_HOST: "10.0.0.99"},
+        )
+
+    assert result2["type"] == data_entry_flow.FlowResultType.FORM
+    assert result2["errors"]["base"] == "host_unreachable"
+    # Transport unchanged
+    assert entry.data[CONF_TRANSPORT] == TRANSPORT_CLOUD_ONLY
+
+
+# ---------------------------------------------------------------------------
+# cloud_modbus entry: shows host with clear option
+# ---------------------------------------------------------------------------
+
+
+async def test_options_cloud_modbus_shows_host(hass: HomeAssistant, mock_setup_auth, mock_plants_service):
+    """A cloud_modbus entry's options show the current modbus_host."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={**MOCK_CONFIG_DATA, CONF_TRANSPORT: TRANSPORT_CLOUD_MODBUS, CONF_MODBUS_HOST: "192.168.1.50"},
+        unique_id="test_app_id",
+    )
+    entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+
+    result = await hass.config_entries.options.async_init(entry.entry_id)
+    keys = {str(m.schema) for m in result["data_schema"].schema}
+    assert CONF_MODBUS_HOST in keys
+
+
+async def test_options_cloud_modbus_clear_host_switches_to_cloud_only(
+    hass: HomeAssistant, mock_setup_auth, mock_plants_service
+):
+    """Clearing the host on a cloud_modbus entry switches back to cloud_only."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={**MOCK_CONFIG_DATA, CONF_TRANSPORT: TRANSPORT_CLOUD_MODBUS, CONF_MODBUS_HOST: "192.168.1.50"},
+        unique_id="test_app_id",
+    )
+    entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+
+    result = await hass.config_entries.options.async_init(entry.entry_id)
+    result2 = await hass.config_entries.options.async_configure(
+        result["flow_id"],
+        user_input={CONF_SCAN_INTERVAL: 300, CONF_MODBUS_HOST: ""},
+    )
+    await hass.async_block_till_done()
+
+    assert result2["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
+    assert entry.data[CONF_TRANSPORT] == TRANSPORT_CLOUD_ONLY
+    assert CONF_MODBUS_HOST not in entry.data
+
+
+# ---------------------------------------------------------------------------
+# modbus_only entry: no transport switching
+# ---------------------------------------------------------------------------
+
+
+async def test_options_modbus_only_no_switch(hass: HomeAssistant):
+    """A modbus_only entry does not show the transport-switch field."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={
+            CONF_TRANSPORT: TRANSPORT_MODBUS_ONLY,
+            CONF_SERIAL: "SN123",
+            CONF_MODEL: "SG3.6RS",
+            CONF_MODBUS_HOST: "10.0.0.9",
+        },
+        options={CONF_SCAN_INTERVAL: 30},
+        unique_id="modbus_SN123",
+    )
+    entry.add_to_hass(hass)
+
+    client = MagicMock()
+    client.async_read_realtime = AsyncMock(return_value={"grid_frequency": {"value": 49.9}})
+    with patch("custom_components.sungrow.modbus.SungrowModbusClient", return_value=client):
+        await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+
+        result = await hass.config_entries.options.async_init(entry.entry_id)
+        assert result["step_id"] == "modbus_options"
+        keys = {str(m.schema) for m in result["data_schema"].schema}
+        assert CONF_MODBUS_HOST not in keys

--- a/tests/test_reachability_properties.py
+++ b/tests/test_reachability_properties.py
@@ -1,0 +1,81 @@
+"""Property-based tests for async_test_modbus_host (#216).
+
+Feature: transport-mode-selector
+"""
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from hypothesis import given, settings
+from hypothesis import strategies as st
+
+from custom_components.sungrow.helpers import async_test_modbus_host
+
+# ---------------------------------------------------------------------------
+# Property 5: Reachability test uses correct port and timeout
+# Validates: Requirements 12.1, 12.2
+# ---------------------------------------------------------------------------
+
+
+@settings(max_examples=100)
+@given(host=st.text(min_size=1, max_size=253))
+@pytest.mark.asyncio
+async def test_reachability_uses_correct_port_and_timeout(host: str):
+    """Property 5: async_test_modbus_host calls open_connection with port=502, timeout=5."""
+    mock_writer = AsyncMock()
+    mock_writer.close = lambda: None
+    mock_writer.wait_closed = AsyncMock()
+
+    with patch("custom_components.sungrow.helpers.asyncio.open_connection", new_callable=AsyncMock) as mock_conn:
+        mock_conn.return_value = (AsyncMock(), mock_writer)
+
+        with patch("custom_components.sungrow.helpers.asyncio.wait_for", new_callable=AsyncMock) as mock_wait:
+            mock_wait.return_value = (AsyncMock(), mock_writer)
+            await async_test_modbus_host(host)
+            mock_wait.assert_called_once()
+            args, kwargs = mock_wait.call_args
+            assert kwargs.get("timeout") == 5.0 or (len(args) >= 2 and args[1] == 5.0)
+
+
+# ---------------------------------------------------------------------------
+# Property 6: Reachability test returns bool without exceptions
+# Validates: Requirements 12.3, 12.4
+# ---------------------------------------------------------------------------
+
+
+_EXCEPTIONS = [
+    TimeoutError(),
+    OSError("Connection refused"),
+    ConnectionRefusedError("refused"),
+    OSError("Name or service not known"),
+    RuntimeError("unexpected"),
+    ValueError("bad value"),
+]
+
+
+@settings(max_examples=100)
+@given(
+    host=st.text(min_size=1, max_size=253),
+    exc_index=st.integers(min_value=0, max_value=len(_EXCEPTIONS) - 1),
+    should_succeed=st.booleans(),
+)
+@pytest.mark.asyncio
+async def test_reachability_returns_bool_no_exceptions(host: str, exc_index: int, should_succeed: bool):
+    """Property 6: async_test_modbus_host always returns bool, never raises."""
+    mock_writer = AsyncMock()
+    mock_writer.close = lambda: None
+    mock_writer.wait_closed = AsyncMock()
+
+    async def _fake_open(*args, **kwargs):
+        if should_succeed:
+            return (AsyncMock(), mock_writer)
+        raise _EXCEPTIONS[exc_index]
+
+    with patch("custom_components.sungrow.helpers.asyncio.open_connection", side_effect=_fake_open):
+        result = await async_test_modbus_host(host)
+
+    assert isinstance(result, bool)
+    if should_succeed:
+        assert result is True
+    else:
+        assert result is False

--- a/tests/test_reconfigure_transport.py
+++ b/tests/test_reconfigure_transport.py
@@ -1,0 +1,158 @@
+"""Unit tests for reconfigure flow adaptation per transport mode (#216)."""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+from homeassistant import config_entries, data_entry_flow
+from homeassistant.core import HomeAssistant
+from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+from custom_components.sungrow.const import (
+    CONF_APP_KEY,
+    CONF_APP_SECRET,
+    CONF_GATEWAY,
+    CONF_MODBUS_HOST,
+    CONF_MODEL,
+    CONF_REDIRECT_URI,
+    CONF_SCAN_INTERVAL,
+    CONF_SERIAL,
+    CONF_TRANSPORT,
+    DOMAIN,
+    TRANSPORT_CLOUD_MODBUS,
+    TRANSPORT_CLOUD_ONLY,
+    TRANSPORT_MODBUS_ONLY,
+)
+
+from .conftest import MOCK_CONFIG_DATA
+
+
+@pytest.fixture(autouse=True)
+def mock_client_session():
+    """Mock async_get_clientsession."""
+    with patch(
+        "custom_components.sungrow.config_flow.async_get_clientsession",
+        return_value=MagicMock(),
+    ):
+        yield
+
+
+# ---------------------------------------------------------------------------
+# cloud_only reconfigure: shows credentials form
+# ---------------------------------------------------------------------------
+
+
+async def test_reconfigure_cloud_only_shows_credentials(hass: HomeAssistant, mock_auth):
+    """A cloud_only entry reconfigure shows the credentials form."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={**MOCK_CONFIG_DATA, CONF_TRANSPORT: TRANSPORT_CLOUD_ONLY},
+        unique_id="test_app_id",
+    )
+    entry.add_to_hass(hass)
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": config_entries.SOURCE_RECONFIGURE, "entry_id": entry.entry_id},
+    )
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
+    assert result["step_id"] == "reconfigure"
+
+
+# ---------------------------------------------------------------------------
+# cloud_modbus reconfigure: credentials + modbus host step
+# ---------------------------------------------------------------------------
+
+
+async def test_reconfigure_cloud_modbus_shows_host_step(hass: HomeAssistant, mock_auth):
+    """A cloud_modbus entry reconfigure shows credentials then modbus_host step."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={
+            **MOCK_CONFIG_DATA,
+            CONF_TRANSPORT: TRANSPORT_CLOUD_MODBUS,
+            CONF_MODBUS_HOST: "192.168.1.50",
+        },
+        unique_id="test_app_id",
+    )
+    entry.add_to_hass(hass)
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": config_entries.SOURCE_RECONFIGURE, "entry_id": entry.entry_id},
+    )
+    assert result["step_id"] == "reconfigure"
+
+    # Submit credentials
+    new_input = {
+        CONF_APP_KEY: "new_key",
+        CONF_APP_SECRET: "new_secret",
+        CONF_GATEWAY: "Europe",
+        CONF_REDIRECT_URI: MOCK_CONFIG_DATA[CONF_REDIRECT_URI],
+    }
+    result2 = await hass.config_entries.flow.async_configure(result["flow_id"], user_input=new_input)
+    assert result2["step_id"] == "reconfigure_modbus_host"
+
+
+async def test_reconfigure_cloud_modbus_host_failure(hass: HomeAssistant, mock_auth):
+    """Reconfigure cloud_modbus with unreachable host shows error."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={
+            **MOCK_CONFIG_DATA,
+            CONF_TRANSPORT: TRANSPORT_CLOUD_MODBUS,
+            CONF_MODBUS_HOST: "192.168.1.50",
+        },
+        unique_id="test_app_id",
+    )
+    entry.add_to_hass(hass)
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": config_entries.SOURCE_RECONFIGURE, "entry_id": entry.entry_id},
+    )
+    new_input = {
+        CONF_APP_KEY: "k",
+        CONF_APP_SECRET: "s",
+        CONF_GATEWAY: "Europe",
+        CONF_REDIRECT_URI: MOCK_CONFIG_DATA[CONF_REDIRECT_URI],
+    }
+    result2 = await hass.config_entries.flow.async_configure(result["flow_id"], user_input=new_input)
+    assert result2["step_id"] == "reconfigure_modbus_host"
+
+    with patch("custom_components.sungrow.helpers.async_test_modbus_host", return_value=False):
+        result3 = await hass.config_entries.flow.async_configure(
+            result["flow_id"], user_input={CONF_MODBUS_HOST: "10.0.0.99"}
+        )
+
+    assert result3["type"] == data_entry_flow.FlowResultType.FORM
+    assert result3["errors"]["base"] == "host_unreachable"
+
+
+# ---------------------------------------------------------------------------
+# modbus_only reconfigure: shows host form only
+# ---------------------------------------------------------------------------
+
+
+async def test_reconfigure_modbus_only_shows_host_form(hass: HomeAssistant):
+    """A modbus_only entry reconfigure shows the modbus host form only."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={
+            CONF_TRANSPORT: TRANSPORT_MODBUS_ONLY,
+            CONF_SERIAL: "SN123",
+            CONF_MODEL: "SG3.6RS",
+            CONF_MODBUS_HOST: "10.0.0.9",
+        },
+        options={CONF_SCAN_INTERVAL: 30},
+        unique_id="modbus_SN123",
+    )
+    entry.add_to_hass(hass)
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": config_entries.SOURCE_RECONFIGURE, "entry_id": entry.entry_id},
+    )
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
+    assert result["step_id"] == "reconfigure_modbus"
+    keys = {str(m.schema) for m in result["data_schema"].schema}
+    assert keys == {CONF_MODBUS_HOST}

--- a/tests/test_runtime_branching.py
+++ b/tests/test_runtime_branching.py
@@ -1,0 +1,120 @@
+"""Integration tests for runtime branching on transport mode (#216)."""
+
+import logging
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from homeassistant.core import HomeAssistant
+from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+from custom_components.sungrow.const import (
+    CONF_MODBUS_HOST,
+    CONF_MODEL,
+    CONF_SCAN_INTERVAL,
+    CONF_SERIAL,
+    CONF_TRANSPORT,
+    DOMAIN,
+    TRANSPORT_CLOUD_MODBUS,
+    TRANSPORT_CLOUD_ONLY,
+    TRANSPORT_MODBUS_ONLY,
+)
+
+from .conftest import MOCK_CONFIG_DATA
+
+# ---------------------------------------------------------------------------
+# cloud_only → standard cloud coordinator
+# ---------------------------------------------------------------------------
+
+
+async def test_setup_entry_cloud_only(hass: HomeAssistant, mock_setup_auth, mock_plants_service):
+    """cloud_only transport sets up the cloud coordinator normally."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={**MOCK_CONFIG_DATA, CONF_TRANSPORT: TRANSPORT_CLOUD_ONLY},
+        unique_id="test_app_id",
+    )
+    entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert entry.state.name == "LOADED"
+    # Cloud coordinator creates plant data
+    assert entry.runtime_data.coordinators
+
+
+# ---------------------------------------------------------------------------
+# cloud_modbus → cloud coordinator + info log
+# ---------------------------------------------------------------------------
+
+
+async def test_setup_entry_cloud_modbus_logs_deferred(
+    hass: HomeAssistant, mock_setup_auth, mock_plants_service, caplog
+):
+    """cloud_modbus transport sets up cloud coordinator and logs deferred message."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={
+            **MOCK_CONFIG_DATA,
+            CONF_TRANSPORT: TRANSPORT_CLOUD_MODBUS,
+            CONF_MODBUS_HOST: "192.168.1.50",
+        },
+        unique_id="test_app_id",
+    )
+    entry.add_to_hass(hass)
+
+    with caplog.at_level(logging.INFO, logger="custom_components.sungrow"):
+        await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+
+    assert entry.state.name == "LOADED"
+    assert any("deferred to #217" in msg for msg in caplog.messages)
+
+
+# ---------------------------------------------------------------------------
+# modbus_only → calls _async_setup_modbus_only
+# ---------------------------------------------------------------------------
+
+
+async def test_setup_entry_modbus_only(hass: HomeAssistant):
+    """modbus_only transport calls the Modbus-only setup path."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={
+            CONF_TRANSPORT: TRANSPORT_MODBUS_ONLY,
+            CONF_SERIAL: "SN123",
+            CONF_MODEL: "SG3.6RS",
+            CONF_MODBUS_HOST: "10.0.0.9",
+        },
+        options={CONF_SCAN_INTERVAL: 30},
+        unique_id="modbus_SN123",
+    )
+    entry.add_to_hass(hass)
+
+    client = MagicMock()
+    client.async_read_realtime = AsyncMock(return_value={"grid_frequency": {"value": 49.9}})
+    with patch("custom_components.sungrow.modbus.SungrowModbusClient", return_value=client):
+        await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+
+    assert entry.state.name == "LOADED"
+
+
+# ---------------------------------------------------------------------------
+# missing transport → defaults to cloud_only + warning
+# ---------------------------------------------------------------------------
+
+
+async def test_setup_entry_missing_transport_defaults_cloud_only(
+    hass: HomeAssistant, mock_setup_auth, mock_plants_service, caplog
+):
+    """Missing transport field defaults to cloud_only and logs a warning."""
+    # Remove CONF_TRANSPORT from data entirely
+    data = {k: v for k, v in MOCK_CONFIG_DATA.items() if k != CONF_TRANSPORT}
+    entry = MockConfigEntry(domain=DOMAIN, data=data, unique_id="test_app_id", version=3)
+    entry.add_to_hass(hass)
+
+    with caplog.at_level(logging.WARNING, logger="custom_components.sungrow"):
+        await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+
+    assert entry.state.name == "LOADED"
+    assert any("missing CONF_TRANSPORT" in msg for msg in caplog.messages)

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -899,3 +899,106 @@ async def test_device_sensors_not_created_when_disabled(hass: HomeAssistant):
     assert not any(isinstance(e, SungrowDeviceSensor) for e in added)
     # Plant sensors are still created.
     assert any(isinstance(e, SungrowSensor) for e in added)
+
+
+# ---------------------------------------------------------------------------
+# Bug condition exploration (hybrid MPPT / string sensors) — Property 1
+#
+# The hybrid MPPT codes reuse the string-inverter mpptN_* code names. mppt1-3 are
+# already in _DIAGNOSTIC_CODES via INVERTER_DIAGNOSTIC_POINTS ("5"-"10"), but mppt4_*
+# are NEW code names not present in that map, so on the UNFIXED code they are NOT in
+# _DIAGNOSTIC_CODES and this test FAILS — confirming the classification gap.
+# Validates: Requirements 2.2
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("code", ["mppt4_voltage", "mppt4_current"])
+def test_hybrid_mppt4_codes_are_diagnostic(code):
+    """Hybrid MPPT4 voltage/current codes must be classified diagnostic (Property 1).
+
+    On the UNFIXED code _DIAGNOSTIC_CODES is derived only from INVERTER_DIAGNOSTIC_POINTS
+    (mppt1-3) plus battery/comm codes, so mppt4_voltage/mppt4_current are absent and this
+    assertion FAILS — which is the intended proof that hybrid MPPT4 sensors would land in
+    the main sensors instead of the Diagnostic section.
+
+    Validates: Requirements 2.2
+    """
+    from custom_components.sungrow.sensor import _DIAGNOSTIC_CODES
+
+    assert code in _DIAGNOSTIC_CODES, f"{code} is not classified as diagnostic (not in _DIAGNOSTIC_CODES)"
+
+
+# ---------------------------------------------------------------------------
+# Preservation (hybrid MPPT / string sensors) — Property 2
+#
+# The upcoming fix unions ESS_MPPT_DIAGNOSTIC_POINTS.values() into _DIAGNOSTIC_CODES.
+# The union is additive, so every existing string-inverter diagnostic code must remain
+# classified as diagnostic afterwards. This baseline check passes on the unfixed code.
+# Validates: Requirement 3.5
+# ---------------------------------------------------------------------------
+
+
+def test_inverter_diagnostic_codes_stay_diagnostic():
+    """Every existing INVERTER_DIAGNOSTIC_POINTS code remains a member of _DIAGNOSTIC_CODES.
+
+    Guards the diagnostic classification of string-inverter MPPT/string/grid-health codes
+    against regression when the hybrid MPPT codes are later unioned in.
+
+    Validates: Requirement 3.5
+    """
+    from custom_components.sungrow.const import INVERTER_DIAGNOSTIC_POINTS
+    from custom_components.sungrow.sensor import _DIAGNOSTIC_CODES
+
+    missing = set(INVERTER_DIAGNOSTIC_POINTS.values()) - _DIAGNOSTIC_CODES
+    assert not missing, f"string-inverter diagnostic codes dropped from _DIAGNOSTIC_CODES: {sorted(missing)}"
+
+
+# ---------------------------------------------------------------------------
+# Fix Checking (hybrid MPPT / string sensors) — Property 1, Requirement 2.3
+#
+# Integration-style: an ESS device whose realtime response reports only MPPT1/MPPT2
+# produces exactly those diagnostic sensors; MPPT3/MPPT4 are silently skipped (no
+# sensor created), consistent with the string-inverter builder behavior.
+# ---------------------------------------------------------------------------
+
+
+async def test_ess_partial_mppt_only_reported_sensors_created(hass: HomeAssistant):
+    """Property 1 (Req 2.3): only the MPPTs the ESS actually reports become sensors.
+
+    The per-device builder skips points a model does not report, so a hybrid with only
+    MPPT1/MPPT2 wired produces mppt1/mppt2 voltage+current sensors and no mppt3/mppt4.
+    Mirrors test_battery_device_sensor_categories.
+    """
+    entry = MockConfigEntry(domain=DOMAIN, data=MOCK_CONFIG_DATA.copy())
+    entry.add_to_hass(hass)
+
+    coordinator = _coordinator_with("12345", "Plant A", {"total_active_power": {"value": "5.0", "unit": "kW"}})
+    coordinator.enable_device_sensors = True
+    coordinator.devices = [{"uuid": "ess-1", "device_name": "Hybrid1", "device_type": DeviceType.ENERGY_STORAGE_SYSTEM}]
+    # The cloud returns only MPPT1/MPPT2 for this hybrid; MPPT3/MPPT4 are unreported.
+    coordinator.device_data = {
+        "ess-1": {
+            "mppt1_voltage": {"id": "13001", "code": "mppt1_voltage", "value": "410.5", "unit": "V"},
+            "mppt1_current": {"id": "13002", "code": "mppt1_current", "value": "8.1", "unit": "A"},
+            "mppt2_voltage": {"id": "13105", "code": "mppt2_voltage", "value": "395.2", "unit": "V"},
+            "mppt2_current": {"id": "13106", "code": "mppt2_current", "value": "7.4", "unit": "A"},
+        }
+    }
+    entry.runtime_data = SungrowData(
+        coordinators=[coordinator], control=MagicMock(), devices={"12345": coordinator.devices}
+    )
+
+    added = []
+    await async_setup_entry(hass, entry, lambda entities: added.extend(entities))
+
+    by_code = {e.point_code: e for e in added if isinstance(e, SungrowDeviceSensor)}
+    # Only the reported MPPT1/MPPT2 sensors exist.
+    assert set(by_code) == {"mppt1_voltage", "mppt1_current", "mppt2_voltage", "mppt2_current"}
+    # MPPT3/MPPT4 are silently skipped (never reported -> no sensor).
+    for code in ("mppt3_voltage", "mppt3_current", "mppt4_voltage", "mppt4_current"):
+        assert code not in by_code
+    # The reported MPPT sensors land in the Diagnostic section with the right classes.
+    assert by_code["mppt1_voltage"].entity_category == EntityCategory.DIAGNOSTIC
+    assert by_code["mppt1_voltage"].device_class == SensorDeviceClass.VOLTAGE
+    assert by_code["mppt2_current"].entity_category == EntityCategory.DIAGNOSTIC
+    assert by_code["mppt2_current"].device_class == SensorDeviceClass.CURRENT

--- a/tests/test_strings.py
+++ b/tests/test_strings.py
@@ -32,14 +32,23 @@ def test_strings_has_required_steps(strings_data):
     assert "user" in steps, "Missing 'user' step"
     assert "auth_manual" in steps, "Missing 'auth_manual' step"
     assert "auth_callback" in steps, "Missing 'auth_callback' step"
+    assert "cloud_credentials" in steps, "Missing 'cloud_credentials' step"
+    assert "modbus_host" in steps, "Missing 'modbus_host' step"
+    assert "local_setup" in steps, "Missing 'local_setup' step"
 
 
 def test_strings_user_step_has_required_fields(strings_data):
-    """Test the user step defines all form fields used by the config flow."""
+    """Test the user step defines the transport selector field."""
     user_data = strings_data["config"]["step"]["user"]["data"]
+    assert "transport" in user_data, "Missing 'transport' field in user step"
+
+
+def test_strings_cloud_credentials_step_has_required_fields(strings_data):
+    """Test the cloud_credentials step defines all form fields used by the config flow."""
+    creds_data = strings_data["config"]["step"]["cloud_credentials"]["data"]
     required_fields = {"gateway", "app_key", "app_secret", "app_id", "redirect_uri"}
-    assert required_fields.issubset(set(user_data.keys())), (
-        f"Missing form fields: {required_fields - set(user_data.keys())}"
+    assert required_fields.issubset(set(creds_data.keys())), (
+        f"Missing form fields: {required_fields - set(creds_data.keys())}"
     )
 
 

--- a/tests/test_translation_properties.py
+++ b/tests/test_translation_properties.py
@@ -1,0 +1,67 @@
+"""Property-based test for translation key parity (#216).
+
+Feature: transport-mode-selector
+Property 4: Translation key parity
+Validates: Requirements 10.4
+"""
+
+import json
+from pathlib import Path
+
+import pytest
+from hypothesis import given, settings
+from hypothesis import strategies as st
+
+STRINGS_PATH = Path(__file__).parent.parent / "custom_components" / "sungrow" / "strings.json"
+EN_PATH = Path(__file__).parent.parent / "custom_components" / "sungrow" / "translations" / "en.json"
+
+
+def _flatten_keys(data: dict, prefix: str = "") -> list[str]:
+    """Return all dotted leaf-key paths in a nested dict."""
+    keys: list[str] = []
+    for key, value in data.items():
+        path = f"{prefix}.{key}" if prefix else key
+        if isinstance(value, dict):
+            keys.extend(_flatten_keys(value, path))
+        else:
+            keys.append(path)
+    return keys
+
+
+def _get_nested(data: dict, dotted_path: str):
+    """Retrieve a nested value by dotted key path."""
+    parts = dotted_path.split(".")
+    current = data
+    for part in parts:
+        if not isinstance(current, dict) or part not in current:
+            return None
+        current = current[part]
+    return current
+
+
+@pytest.fixture(scope="module")
+def strings_keys():
+    """All config+options key paths from strings.json."""
+    strings = json.loads(STRINGS_PATH.read_text())
+    config_keys = _flatten_keys(strings.get("config", {}), "config")
+    options_keys = _flatten_keys(strings.get("options", {}), "options")
+    return config_keys + options_keys
+
+
+@pytest.fixture(scope="module")
+def en_data():
+    """Loaded en.json data."""
+    return json.loads(EN_PATH.read_text())
+
+
+@settings(max_examples=100)
+@given(data=st.data())
+def test_translation_key_parity(data, strings_keys, en_data):
+    """Property 4: Every config/options key in strings.json exists in en.json with a non-empty string."""
+    if not strings_keys:
+        return
+    key_path = data.draw(st.sampled_from(strings_keys))
+    value = _get_nested(en_data, key_path)
+    assert value is not None, f"Key '{key_path}' missing from en.json"
+    assert isinstance(value, str), f"Key '{key_path}' is not a string in en.json"
+    assert value.strip(), f"Key '{key_path}' is empty in en.json"

--- a/tests/test_transport_constants.py
+++ b/tests/test_transport_constants.py
@@ -1,0 +1,28 @@
+"""Smoke tests for transport-mode constants (#216)."""
+
+from custom_components.sungrow.config_flow import SungrowConfigFlow
+from custom_components.sungrow.const import (
+    TRANSPORT_CLOUD_MODBUS,
+    TRANSPORT_CLOUD_ONLY,
+    TRANSPORT_MODBUS_ONLY,
+)
+
+
+def test_transport_cloud_only_value():
+    """TRANSPORT_CLOUD_ONLY equals 'cloud_only'."""
+    assert TRANSPORT_CLOUD_ONLY == "cloud_only"
+
+
+def test_transport_cloud_modbus_value():
+    """TRANSPORT_CLOUD_MODBUS equals 'cloud_modbus'."""
+    assert TRANSPORT_CLOUD_MODBUS == "cloud_modbus"
+
+
+def test_transport_modbus_only_value():
+    """TRANSPORT_MODBUS_ONLY equals 'modbus_only'."""
+    assert TRANSPORT_MODBUS_ONLY == "modbus_only"
+
+
+def test_config_flow_version_is_3():
+    """SungrowConfigFlow.VERSION is 3 after the breaking migration."""
+    assert SungrowConfigFlow.VERSION == 3

--- a/tests/test_transport_flow.py
+++ b/tests/test_transport_flow.py
@@ -1,0 +1,191 @@
+"""Unit tests for the transport-mode selector config flow (#216)."""
+
+from ipaddress import ip_address
+from unittest.mock import MagicMock, patch
+
+import pytest
+from homeassistant import config_entries, data_entry_flow
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.service_info.zeroconf import ZeroconfServiceInfo
+
+from custom_components.sungrow.const import (
+    CONF_MODBUS_HOST,
+    CONF_MODEL,
+    CONF_SERIAL,
+    CONF_TRANSPORT,
+    DOMAIN,
+    TRANSPORT_CLOUD_MODBUS,
+    TRANSPORT_CLOUD_ONLY,
+    TRANSPORT_MODBUS_ONLY,
+)
+
+from .conftest import MOCK_USER_INPUT
+
+
+@pytest.fixture(autouse=True)
+def mock_client_session():
+    """Mock async_get_clientsession."""
+    with patch(
+        "custom_components.sungrow.config_flow.async_get_clientsession",
+        return_value=MagicMock(),
+    ):
+        yield
+
+
+# ---------------------------------------------------------------------------
+# Transport selector step
+# ---------------------------------------------------------------------------
+
+
+async def test_step_user_shows_transport_selector(hass: HomeAssistant):
+    """async_step_user shows the transport selector form with 3 options."""
+    result = await hass.config_entries.flow.async_init(DOMAIN, context={"source": config_entries.SOURCE_USER})
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
+    assert result["step_id"] == "user"
+    # The schema should have a transport field
+    keys = {str(m.schema) for m in result["data_schema"].schema}
+    assert CONF_TRANSPORT in keys
+
+
+# ---------------------------------------------------------------------------
+# Cloud Only flow
+# ---------------------------------------------------------------------------
+
+
+async def test_cloud_only_flow_creates_correct_entry(hass: HomeAssistant):
+    """user → cloud_credentials → creates entry with transport=cloud_only."""
+    result = await hass.config_entries.flow.async_init(DOMAIN, context={"source": config_entries.SOURCE_USER})
+    result2 = await hass.config_entries.flow.async_configure(
+        result["flow_id"], user_input={CONF_TRANSPORT: TRANSPORT_CLOUD_ONLY}
+    )
+    assert result2["step_id"] == "cloud_credentials"
+
+    with patch("custom_components.sungrow.async_setup_entry", return_value=True):
+        result3 = await hass.config_entries.flow.async_configure(result["flow_id"], user_input=MOCK_USER_INPUT)
+        await hass.async_block_till_done()
+
+    assert result3["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
+    assert result3["data"][CONF_TRANSPORT] == TRANSPORT_CLOUD_ONLY
+    assert CONF_MODBUS_HOST not in result3["data"]
+
+
+# ---------------------------------------------------------------------------
+# Cloud + Modbus flow
+# ---------------------------------------------------------------------------
+
+
+async def test_cloud_modbus_flow_creates_correct_entry(hass: HomeAssistant):
+    """user → cloud_credentials → modbus_host → creates entry with transport=cloud_modbus."""
+    result = await hass.config_entries.flow.async_init(DOMAIN, context={"source": config_entries.SOURCE_USER})
+    result2 = await hass.config_entries.flow.async_configure(
+        result["flow_id"], user_input={CONF_TRANSPORT: TRANSPORT_CLOUD_MODBUS}
+    )
+    assert result2["step_id"] == "cloud_credentials"
+
+    result3 = await hass.config_entries.flow.async_configure(result["flow_id"], user_input=MOCK_USER_INPUT)
+    assert result3["step_id"] == "modbus_host"
+
+    with (
+        patch("custom_components.sungrow.helpers.async_test_modbus_host", return_value=True),
+        patch("custom_components.sungrow.async_setup_entry", return_value=True),
+    ):
+        result4 = await hass.config_entries.flow.async_configure(
+            result["flow_id"], user_input={CONF_MODBUS_HOST: "192.168.1.10"}
+        )
+        await hass.async_block_till_done()
+
+    assert result4["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
+    assert result4["data"][CONF_TRANSPORT] == TRANSPORT_CLOUD_MODBUS
+    assert result4["data"][CONF_MODBUS_HOST] == "192.168.1.10"
+
+
+# ---------------------------------------------------------------------------
+# Modbus Only flow
+# ---------------------------------------------------------------------------
+
+
+async def test_modbus_only_flow_creates_correct_entry(hass: HomeAssistant):
+    """user → local_setup → creates entry with transport=modbus_only + host/serial/model."""
+    result = await hass.config_entries.flow.async_init(DOMAIN, context={"source": config_entries.SOURCE_USER})
+    result2 = await hass.config_entries.flow.async_configure(
+        result["flow_id"], user_input={CONF_TRANSPORT: TRANSPORT_MODBUS_ONLY}
+    )
+    assert result2["step_id"] == "local_setup"
+
+    with (
+        patch("custom_components.sungrow.helpers.async_test_modbus_host", return_value=True),
+        patch("custom_components.sungrow.async_setup_entry", return_value=True),
+    ):
+        result3 = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            user_input={CONF_MODBUS_HOST: "10.0.0.5", CONF_SERIAL: "SN123", CONF_MODEL: "SG3.6RS"},
+        )
+        await hass.async_block_till_done()
+
+    assert result3["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
+    assert result3["data"][CONF_TRANSPORT] == TRANSPORT_MODBUS_ONLY
+    assert result3["data"][CONF_MODBUS_HOST] == "10.0.0.5"
+    assert result3["data"][CONF_SERIAL] == "SN123"
+    assert result3["data"][CONF_MODEL] == "SG3.6RS"
+
+
+# ---------------------------------------------------------------------------
+# Zeroconf bypasses transport step
+# ---------------------------------------------------------------------------
+
+
+async def test_zeroconf_bypasses_transport_step(hass: HomeAssistant):
+    """Zeroconf discovery flow does NOT show the transport step."""
+    discovery = ZeroconfServiceInfo(
+        ip_address=ip_address("192.168.1.93"),
+        ip_addresses=[ip_address("192.168.1.93")],
+        port=80,
+        hostname="SUNGROW.local.",
+        type="_http._tcp.local.",
+        name="WiNet-WebServer._http._tcp.local.",
+        properties={"inverter": "1;9732;A2340512345;1;516;SG3.6RS;1;1;"},
+    )
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_ZEROCONF}, data=discovery
+    )
+    # Goes directly to zeroconf_confirm, not the transport selector.
+    assert result["step_id"] == "zeroconf_confirm"
+
+
+# ---------------------------------------------------------------------------
+# Modbus host reachability errors
+# ---------------------------------------------------------------------------
+
+
+async def test_modbus_host_step_unreachable_shows_error(hass: HomeAssistant):
+    """Submitting an unreachable host in the modbus_host step shows an error."""
+    result = await hass.config_entries.flow.async_init(DOMAIN, context={"source": config_entries.SOURCE_USER})
+    await hass.config_entries.flow.async_configure(
+        result["flow_id"], user_input={CONF_TRANSPORT: TRANSPORT_CLOUD_MODBUS}
+    )
+    await hass.config_entries.flow.async_configure(result["flow_id"], user_input=MOCK_USER_INPUT)
+
+    with patch("custom_components.sungrow.helpers.async_test_modbus_host", return_value=False):
+        result_host = await hass.config_entries.flow.async_configure(
+            result["flow_id"], user_input={CONF_MODBUS_HOST: "10.0.0.99"}
+        )
+
+    assert result_host["type"] == data_entry_flow.FlowResultType.FORM
+    assert result_host["errors"]["base"] == "host_unreachable"
+
+
+async def test_local_setup_unreachable_shows_error(hass: HomeAssistant):
+    """Submitting an unreachable host in local_setup shows an error."""
+    result = await hass.config_entries.flow.async_init(DOMAIN, context={"source": config_entries.SOURCE_USER})
+    await hass.config_entries.flow.async_configure(
+        result["flow_id"], user_input={CONF_TRANSPORT: TRANSPORT_MODBUS_ONLY}
+    )
+
+    with patch("custom_components.sungrow.helpers.async_test_modbus_host", return_value=False):
+        result_local = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            user_input={CONF_MODBUS_HOST: "10.0.0.99", CONF_SERIAL: "SN1", CONF_MODEL: "SG3.6RS"},
+        )
+
+    assert result_local["type"] == data_entry_flow.FlowResultType.FORM
+    assert result_local["errors"]["base"] == "host_unreachable"


### PR DESCRIPTION
Resolves #189, #160, #216. 549 tests pass, ruff clean.

BREAKING CHANGE: Config entry VERSION bumped 2→3; existing cloud entries migrated to include explicit transport field.

See commit message for full details.