### PR TITLE
fix(config-flow): back-fill app_id at setup time, not only migration (#245)

### DIFF
--- a/custom_components/sungrow/__init__.py
+++ b/custom_components/sungrow/__init__.py
@@ -436,7 +436,8 @@ async def async_migrate_entry(hass: HomeAssistant, config_entry: ConfigEntry) ->
     # Defensive back-fill: ensure cloud entries carry app_id (#245).
     # The unique_id for cloud entries IS the app_id (set during initial setup).
     # If the data key was lost (corrupt storage, partial migration, older RC builds)
-    # we can recover it from unique_id.
+    # we can recover it from unique_id. Kept here as a safety net even though
+    # async_setup_entry also back-fills, since migration runs before setup.
     if config_entry.version >= 3:
         data = dict(config_entry.data)
         transport = data.get(CONF_TRANSPORT)
@@ -536,10 +537,18 @@ async def async_setup_entry(hass: HomeAssistant, entry: SungrowConfigEntry) -> b
     # Split legacy hybrid cloud+Modbus entries into pure cloud + separate local.
     _async_split_legacy_hybrid(hass, entry)
 
-    # Guard: cloud entries require app_id to authenticate. If missing (legacy/corrupt),
-    # trigger reauth so the reconfigure flow can collect it from the user (#245).
+    # Defensive back-fill: recover app_id from unique_id if missing (#245).
+    # async_migrate_entry only runs on version mismatch, so entries already at v3
+    # skip migration entirely — this catches them at load time.
     if not entry.data.get(CONF_APP_ID):
-        raise ConfigEntryAuthFailed("Missing app_id; reconfigure the entry to supply it")
+        uid = entry.unique_id
+        if uid and not uid.startswith("modbus_"):
+            new_data = dict(entry.data)
+            new_data[CONF_APP_ID] = uid
+            hass.config_entries.async_update_entry(entry, data=new_data)
+            _LOGGER.info("Back-filled missing app_id from unique_id for entry %s", entry.title)
+        else:
+            raise ConfigEntryAuthFailed("Missing app_id; reconfigure the entry to supply it")
 
     if "tokens" not in entry.data:
         # Nothing to authenticate with — ask the user to re-authorize.


### PR DESCRIPTION
## Problem

The back-fill added in #246 lives in `async_migrate_entry`, which HA only calls when the entry's stored version differs from the config flow `VERSION`. Entries already at v3 skip migration entirely, so the back-fill never fires — confirmed on a live instance where the entry stayed broken with "Missing app_id; reconfigure the entry to supply it".

## Fix

Move the `app_id` recovery into `async_setup_entry` so it runs on every load:
- If `unique_id` is available (it IS the app_id for cloud entries), the entry self-heals silently on restart.
- Otherwise, `ConfigEntryAuthFailed` directs the user to reconfigure.

The migration-time back-fill is kept as a belt-and-braces safety net for entries that DO undergo version migration (e.g. v1→v3 upgrades).

## 
The back-fill added in #246 lives in `async_migrate_entry`, which HA only calrted, entry self-healed from `unique_id`
- 549 tests pass, ruff clean

Follow-up to #246. Closes #245.