### PR TITLE
feat: per-model measure-point capability map (#251)

### DIFF
--- a/custom_components/sungrow/const.py
+++ b/custom_components/sungrow/const.py
@@ -108,6 +108,19 @@ ESS_BATTERY_POWER_POINTS: dict[str, str] = {
     "13150": "battery_discharge_power",
 }
 
+# String-inverter MPPT voltage/current (points 5-10, MPPT1-3). Named so the per-model
+# capability resolver (#251) and the ESS branch can reference the exact string-inverter
+# MPPT id set instead of a duplicated literal. Merged into INVERTER_DIAGNOSTIC_POINTS
+# below so the diagnostic map is unchanged.
+STRING_MPPT_POINTS: dict[str, str] = {
+    "5": "mppt1_voltage",
+    "6": "mppt1_current",
+    "7": "mppt2_voltage",
+    "8": "mppt2_current",
+    "9": "mppt3_voltage",
+    "10": "mppt3_current",
+}
+
 # Inverter/ESS device-level measuring points surfaced as diagnostic sensors (#149),
 # requested per-device when device sensors are enabled. Maps the documented inverter
 # point ID -> a stable code. Every ID is already in the measure-point catalog, so it
@@ -119,12 +132,8 @@ INVERTER_DIAGNOSTIC_POINTS: dict[str, str] = {
     "4": "internal_temperature",
     "27": "grid_frequency",
     "94": "array_insulation_resistance",
-    "5": "mppt1_voltage",
-    "6": "mppt1_current",
-    "7": "mppt2_voltage",
-    "8": "mppt2_current",
-    "9": "mppt3_voltage",
-    "10": "mppt3_current",
+    # String-inverter MPPT voltage/current (points 5-10) — see STRING_MPPT_POINTS above.
+    **STRING_MPPT_POINTS,
     # Grid-side health (#179). Per-phase voltages/currents, power quality and DC-link
     # voltage — all live-confirmed on real hardware except the AFCI/insulation extras,
     # which the per-device builder simply skips when a model doesn't report them.

--- a/custom_components/sungrow/coordinator.py
+++ b/custom_components/sungrow/coordinator.py
@@ -40,9 +40,11 @@ from .const import (
     INVERTER_DIAGNOSTIC_POINTS,
     INVERTER_OPERATING_STATUS_POINT,
     METER_DEVICE_POINTS,
+    STRING_MPPT_POINTS,
     TRANSPORT_MODBUS_ONLY,
 )
 from .energy_units import normalize_energy_units, tag_source
+from .model_capabilities import mppt_points_for_model, resolve_capabilities
 
 # Upper bound on a single poll's cloud calls, so a hung request can neither stall
 # the coordinator indefinitely nor let successive polls pile up.
@@ -521,17 +523,30 @@ class SungrowPlantCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                 for d in self.devices
                 if getattr(d.get("device_type"), "value", d.get("device_type")) == type_id and d.get("ps_key")
             ]
+            # Resolve the inverter family from the model code (#251). The cloud sometimes
+            # types a hybrid as a plain INVERTER; the model's battery signal is used to
+            # request battery/MPPT points that the device-type heuristic alone would miss.
+            model_code = device.get("device_model_code")
+            caps = resolve_capabilities(model_code)
+            is_ess = type_id == DeviceType.ENERGY_STORAGE_SYSTEM.value
+
             extra: dict[str, str] = {}
             # Always request the operating-status point for inverters/ESS so the Fault
             # binary sensor can surface a reason regardless of the device-sensor option
             # (#182). Inverters use point 29, ESS/hybrids 13146.
-            if type_id == DeviceType.ENERGY_STORAGE_SYSTEM.value:
+            if is_ess:
                 extra.update(ESS_OPERATING_STATUS_POINT)
                 # Always request battery charge/discharge power for ESS devices so hybrid
                 # users see separate charge and discharge power sensors (#31).
                 extra.update(ESS_BATTERY_POWER_POINTS)
             elif type_id == DeviceType.INVERTER.value:
                 extra.update(INVERTER_OPERATING_STATUS_POINT)
+                # A hybrid the cloud typed as a plain inverter still has a battery — request
+                # its charge/discharge power so those sensors appear without manual config
+                # (#31/#251). The battery power ids are ESS-specific, so a true string
+                # inverter (has_battery False) never requests them.
+                if caps.has_battery is True:
+                    extra.update(ESS_BATTERY_POWER_POINTS)
             # The full diagnostic/battery/meter/comm sets (and user extras) are only
             # fetched when the user has opted into per-device sensors (#149/#154/#179).
             # With the option on, an unmapped device type still gets a best-effort fetch
@@ -539,25 +554,34 @@ class SungrowPlantCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             if self.enable_device_sensors:
                 extra.update(self.extra_measure_points)
                 if type_id in (DeviceType.INVERTER.value, DeviceType.ENERGY_STORAGE_SYSTEM.value):
-                    diagnostic = INVERTER_DIAGNOSTIC_POINTS
-                    if type_id == DeviceType.ENERGY_STORAGE_SYSTEM.value:
+                    diagnostic = dict(INVERTER_DIAGNOSTIC_POINTS)
+                    # Pick the MPPT id range by model family when known (#251): SG-family
+                    # string inverters report MPPT on points 5-10, SH-family hybrids on a
+                    # separate 13xxx range. Both ranges share the mpptN_* codes, so mixing
+                    # them would map two ids to one code and silently overwrite each other
+                    # in the per-device merge — hence we swap the range wholesale rather
+                    # than union it. Falls back to the device-type heuristic for unknown
+                    # models so nothing regresses.
+                    model_mppt = mppt_points_for_model(model_code)
+                    if model_mppt:
+                        for pid in set(STRING_MPPT_POINTS) | set(ESS_MPPT_DIAGNOSTIC_POINTS):
+                            diagnostic.pop(pid, None)
+                        diagnostic.update(model_mppt)
+                    elif is_ess:
+                        for pid in STRING_MPPT_POINTS:
+                            diagnostic.pop(pid, None)
+                        diagnostic.update(ESS_MPPT_DIAGNOSTIC_POINTS)
+                    if is_ess:
                         # An ESS reports operating status on 13146 (already requested above);
                         # drop the inverter point 29 so the two don't collide on the shared
                         # "operating_status" code and silently overwrite each other (#182).
-                        # ESS also reports MPPT on a separate 13xxx range: drop the
-                        # string-inverter MPPT IDs (5-10) and merge the hybrid MPPT IDs
-                        # instead. Both ranges share the mpptN_* codes, so requesting BOTH
-                        # would map two IDs to one code and silently overwrite each other in
-                        # the per-device merge.
-                        string_inverter_mppt_ids = {"5", "6", "7", "8", "9", "10"}
-                        diagnostic = {
-                            pid: code
-                            for pid, code in INVERTER_DIAGNOSTIC_POINTS.items()
-                            if pid != "29" and pid not in string_inverter_mppt_ids
-                        }
-                        diagnostic = {**diagnostic, **ESS_MPPT_DIAGNOSTIC_POINTS}
+                        diagnostic.pop("29", None)
                     extra.update(diagnostic)
-                if type_id in (DeviceType.BATTERY.value, DeviceType.ENERGY_STORAGE_SYSTEM.value):
+                # Battery device points for an ESS/battery device, or a hybrid the cloud
+                # typed as a plain inverter (model says it has a battery) (#251).
+                if type_id in (DeviceType.BATTERY.value, DeviceType.ENERGY_STORAGE_SYSTEM.value) or (
+                    type_id == DeviceType.INVERTER.value and caps.has_battery is True
+                ):
                     extra.update(BATTERY_DEVICE_POINTS)
                 # Communication modules report WLAN/wireless signal strength (#149).
                 if type_id == DeviceType.COMMUNICATION_MODULE.value:

--- a/custom_components/sungrow/model_capabilities.py
+++ b/custom_components/sungrow/model_capabilities.py
@@ -1,0 +1,117 @@
+"""Per-model capability mapping for Sungrow inverters (#251).
+
+Which measure points a device exposes — and under which point ID — varies by inverter
+family, not just by the coarse iSolarCloud ``device_type``. The clearest example is
+MPPT voltage/current: string inverters (SG-family) report it on points 5-10, while
+SH-family hybrids report it on a separate 13xxx range. Historically the integration
+picked the range from ``device_type`` alone, which mis-served hybrids whose typing is
+ambiguous and drove the recurring "missing battery/MPPT sensor" reports (#31, #189).
+
+This module resolves the model *family* from ``device_model_code`` (e.g. ``SG3.6RS``,
+``SH10RT-20``, ``SH20T``) and exposes what that family is capable of, so the coordinator
+can request the right point IDs automatically. Everything degrades gracefully: an
+unrecognised model yields :data:`UNKNOWN_CAPABILITIES` (no battery assumption, empty
+MPPT set), and callers fall back to the existing device-type behaviour — so no existing
+install regresses.
+
+Model-code shapes (Sungrow residential/commercial naming):
+    * ``SG`` prefix -> PV string inverter, no battery.
+    * ``SH`` prefix -> hybrid/storage inverter, has a battery.
+    * ``...RS`` suffix -> single-phase; ``...RT`` / ``...T`` / others -> three-phase.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from enum import StrEnum
+
+from .const import ESS_MPPT_DIAGNOSTIC_POINTS, STRING_MPPT_POINTS
+
+
+class ModelFamily(StrEnum):
+    """Coarse inverter family resolved from a Sungrow model code."""
+
+    SG_RS = "sg_rs"  # single-phase PV string inverter
+    SG_RT = "sg_rt"  # three-phase PV string inverter (SG..RT / CX / ...)
+    SH_RS = "sh_rs"  # single-phase hybrid (battery)
+    SH_RT = "sh_rt"  # three-phase hybrid (battery) — SH..RT / SH..T
+    UNKNOWN = "unknown"
+
+
+@dataclass(frozen=True)
+class ModelCapabilities:
+    """What an inverter family can report.
+
+    ``has_battery`` / ``phases`` are ``None`` when the family is unknown, so callers can
+    distinguish "known to have no battery" (a string inverter) from "don't know".
+    ``mppt_points`` is the correct point-id -> code map for this family's MPPT range, or
+    an empty dict when unknown.
+    """
+
+    family: ModelFamily
+    has_battery: bool | None
+    phases: int | None
+    mppt_points: dict[str, str]
+
+
+UNKNOWN_CAPABILITIES = ModelCapabilities(
+    family=ModelFamily.UNKNOWN,
+    has_battery=None,
+    phases=None,
+    mppt_points={},
+)
+
+# A single-phase model code ends in the "RS" residential-single suffix (e.g. SG3.6RS,
+# SH5.0RS). Everything else Sungrow ships in these prefixes (RT, T, CX, ...) is
+# three-phase. Matched case-insensitively against the trimmed model code.
+_SINGLE_PHASE_RE = re.compile(r"RS$", re.IGNORECASE)
+
+
+def resolve_model_family(model_code: str | None) -> ModelFamily:
+    """Resolve the :class:`ModelFamily` from a device's ``device_model_code``.
+
+    Returns :attr:`ModelFamily.UNKNOWN` for empty/unrecognised codes.
+    """
+    if not model_code:
+        return ModelFamily.UNKNOWN
+    code = str(model_code).strip().upper()
+    if not code:
+        return ModelFamily.UNKNOWN
+    single_phase = bool(_SINGLE_PHASE_RE.search(code))
+    if code.startswith("SH"):
+        return ModelFamily.SH_RS if single_phase else ModelFamily.SH_RT
+    if code.startswith("SG"):
+        return ModelFamily.SG_RS if single_phase else ModelFamily.SG_RT
+    return ModelFamily.UNKNOWN
+
+
+def resolve_capabilities(model_code: str | None) -> ModelCapabilities:
+    """Resolve the full :class:`ModelCapabilities` for a device's model code."""
+    family = resolve_model_family(model_code)
+    match family:
+        case ModelFamily.SG_RS:
+            return ModelCapabilities(family, has_battery=False, phases=1, mppt_points=dict(STRING_MPPT_POINTS))
+        case ModelFamily.SG_RT:
+            return ModelCapabilities(family, has_battery=False, phases=3, mppt_points=dict(STRING_MPPT_POINTS))
+        case ModelFamily.SH_RS:
+            return ModelCapabilities(family, has_battery=True, phases=1, mppt_points=dict(ESS_MPPT_DIAGNOSTIC_POINTS))
+        case ModelFamily.SH_RT:
+            return ModelCapabilities(family, has_battery=True, phases=3, mppt_points=dict(ESS_MPPT_DIAGNOSTIC_POINTS))
+        case _:
+            return UNKNOWN_CAPABILITIES
+
+
+def model_has_battery(model_code: str | None) -> bool | None:
+    """Return True/False if the model family implies a battery, else None (unknown)."""
+    return resolve_capabilities(model_code).has_battery
+
+
+def mppt_points_for_model(model_code: str | None) -> dict[str, str]:
+    """Return the MPPT point-id -> code map for the model, or {} when unknown.
+
+    SG families use the string-inverter range (points 5-10); SH families use the hybrid
+    13xxx range. An empty dict signals "unknown model" so callers fall back to the
+    device-type heuristic.
+    """
+    return resolve_capabilities(model_code).mppt_points

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -578,6 +578,111 @@ async def test_ess_operating_status_avoids_point29_collision(hass: HomeAssistant
     assert extra["14"] == "total_dc_power"
 
 
+async def test_hybrid_typed_as_inverter_requests_battery_power(hass: HomeAssistant):
+    """A hybrid the cloud types as a plain INVERTER still gets battery power points (#251).
+
+    The model code (SH10RT-20) says it has a battery, so charge/discharge power is
+    requested even though the device type is INVERTER and per-device sensors are off.
+    """
+    plants = MagicMock()
+    plants.async_get_realtime_data = AsyncMock(return_value=MOCK_REALTIME_DATA)
+    plants.async_get_device_realtime = AsyncMock(return_value={})
+    devices = [
+        {
+            "uuid": "inv-1",
+            "device_type": DeviceType.INVERTER,
+            "device_model_code": "SH10RT-20",
+            "ps_key": "12345_1_1_1",
+        }
+    ]
+    coordinator = SungrowPlantCoordinator(hass, _make_entry(), plants, "12345", "Test Plant", devices)
+
+    await coordinator._async_update_data()
+
+    extra = plants.async_get_device_realtime.await_args.kwargs["extra_measure_points"]
+    assert extra["29"] == "operating_status"  # inverter-typed -> inverter status point
+    assert extra["13126"] == "battery_charge_power"
+    assert extra["13150"] == "battery_discharge_power"
+
+
+async def test_string_inverter_never_requests_battery_power(hass: HomeAssistant):
+    """An SG string inverter (no battery) is not asked for battery power points (#251)."""
+    plants = MagicMock()
+    plants.async_get_realtime_data = AsyncMock(return_value=MOCK_REALTIME_DATA)
+    plants.async_get_device_realtime = AsyncMock(return_value={})
+    devices = [
+        {
+            "uuid": "inv-1",
+            "device_type": DeviceType.INVERTER,
+            "device_model_code": "SG3.6RS",
+            "ps_key": "12345_1_1_1",
+        }
+    ]
+    coordinator = SungrowPlantCoordinator(hass, _make_entry(), plants, "12345", "Test Plant", devices)
+
+    await coordinator._async_update_data()
+
+    extra = plants.async_get_device_realtime.await_args.kwargs["extra_measure_points"]
+    assert extra == {"29": "operating_status"}
+    assert "13126" not in extra
+    assert "13150" not in extra
+
+
+async def test_sh_model_uses_hybrid_mppt_range(hass: HomeAssistant):
+    """An SH hybrid (even typed INVERTER) requests the hybrid MPPT range, not points 5-10 (#251)."""
+    plants = MagicMock()
+    plants.async_get_realtime_data = AsyncMock(return_value=MOCK_REALTIME_DATA)
+    plants.async_get_device_realtime = AsyncMock(return_value={})
+    devices = [
+        {
+            "uuid": "inv-1",
+            "device_type": DeviceType.INVERTER,
+            "device_model_code": "SH10RT-20",
+            "ps_key": "12345_1_1_1",
+        }
+    ]
+    coordinator = SungrowPlantCoordinator(
+        hass, _make_entry({CONF_ENABLE_DEVICE_SENSORS: True}), plants, "12345", "Test Plant", devices
+    )
+
+    await coordinator._async_update_data()
+
+    extra = plants.async_get_device_realtime.await_args.kwargs["extra_measure_points"]
+    # Hybrid MPPT range (13xxx) is requested; the string-inverter ids (5-10) are dropped.
+    assert extra["13001"] == "mppt1_voltage"
+    assert "5" not in extra
+    assert "7" not in extra
+    # Battery device points are requested too (model has a battery).
+    assert extra["58604"] == "battery_level"
+
+
+async def test_sg_model_uses_string_mppt_range(hass: HomeAssistant):
+    """An SG string inverter keeps the string MPPT range (points 5-10), not the 13xxx range (#251)."""
+    plants = MagicMock()
+    plants.async_get_realtime_data = AsyncMock(return_value=MOCK_REALTIME_DATA)
+    plants.async_get_device_realtime = AsyncMock(return_value={})
+    devices = [
+        {
+            "uuid": "inv-1",
+            "device_type": DeviceType.INVERTER,
+            "device_model_code": "SG3.6RS",
+            "ps_key": "12345_1_1_1",
+        }
+    ]
+    coordinator = SungrowPlantCoordinator(
+        hass, _make_entry({CONF_ENABLE_DEVICE_SENSORS: True}), plants, "12345", "Test Plant", devices
+    )
+
+    await coordinator._async_update_data()
+
+    extra = plants.async_get_device_realtime.await_args.kwargs["extra_measure_points"]
+    assert extra["5"] == "mppt1_voltage"
+    assert extra["7"] == "mppt2_voltage"
+    assert "13001" not in extra
+    # No battery device points for a string inverter.
+    assert "58604" not in extra
+
+
 async def test_device_data_best_effort_on_error(hass: HomeAssistant):
     """A failing device type is skipped without failing the whole update."""
     plants = MagicMock()

--- a/tests/test_model_capabilities.py
+++ b/tests/test_model_capabilities.py
@@ -1,0 +1,89 @@
+"""Tests for the per-model capability resolver (#251)."""
+
+import pytest
+
+from custom_components.sungrow.const import ESS_MPPT_DIAGNOSTIC_POINTS, STRING_MPPT_POINTS
+from custom_components.sungrow.model_capabilities import (
+    ModelFamily,
+    model_has_battery,
+    mppt_points_for_model,
+    resolve_capabilities,
+    resolve_model_family,
+)
+
+
+@pytest.mark.parametrize(
+    ("model_code", "family"),
+    [
+        ("SG3.6RS", ModelFamily.SG_RS),
+        ("SG5.0RS", ModelFamily.SG_RS),
+        ("sg3.6rs", ModelFamily.SG_RS),  # case-insensitive
+        (" SG3.6RS ", ModelFamily.SG_RS),  # trimmed
+        ("SG10RT", ModelFamily.SG_RT),
+        ("SG110CX", ModelFamily.SG_RT),
+        ("SH5.0RS", ModelFamily.SH_RS),
+        ("SH10RT-20", ModelFamily.SH_RT),
+        ("SH20T", ModelFamily.SH_RT),
+        ("", ModelFamily.UNKNOWN),
+        ("   ", ModelFamily.UNKNOWN),  # whitespace-only
+        (None, ModelFamily.UNKNOWN),
+        ("WiNet-S", ModelFamily.UNKNOWN),
+        ("SBR256", ModelFamily.UNKNOWN),  # battery module, not an inverter model
+    ],
+)
+def test_resolve_model_family(model_code, family):
+    """Model codes resolve to the expected family; junk resolves to UNKNOWN."""
+    assert resolve_model_family(model_code) == family
+
+
+def test_sg_family_is_string_inverter_no_battery():
+    """SG-family: no battery, string-inverter MPPT range (points 5-10)."""
+    caps = resolve_capabilities("SG3.6RS")
+    assert caps.has_battery is False
+    assert caps.phases == 1
+    assert caps.mppt_points == STRING_MPPT_POINTS
+    # Three-phase string inverter.
+    assert resolve_capabilities("SG110CX").phases == 3
+
+
+def test_sh_family_is_hybrid_with_battery():
+    """SH-family: has a battery, hybrid MPPT range (13xxx)."""
+    caps = resolve_capabilities("SH10RT-20")
+    assert caps.has_battery is True
+    assert caps.phases == 3
+    assert caps.mppt_points == ESS_MPPT_DIAGNOSTIC_POINTS
+    # Single-phase hybrid.
+    assert resolve_capabilities("SH5.0RS").phases == 1
+
+
+def test_unknown_model_makes_no_assumptions():
+    """An unrecognised model returns None battery/phases and an empty MPPT map.
+
+    This is what lets callers fall back to the existing device-type heuristic rather
+    than regress an install with a model the map doesn't know yet.
+    """
+    caps = resolve_capabilities("mystery-9000")
+    assert caps.family is ModelFamily.UNKNOWN
+    assert caps.has_battery is None
+    assert caps.phases is None
+    assert caps.mppt_points == {}
+
+
+def test_model_has_battery_helper():
+    """model_has_battery distinguishes known-no-battery from unknown."""
+    assert model_has_battery("SH10RT-20") is True
+    assert model_has_battery("SG3.6RS") is False
+    assert model_has_battery(None) is None
+    assert model_has_battery("WiNet-S") is None
+
+
+def test_mppt_points_for_model_swaps_range_by_family():
+    """MPPT ids are the string range for SG and the hybrid range for SH; {} when unknown."""
+    assert mppt_points_for_model("SG3.6RS") == STRING_MPPT_POINTS
+    assert mppt_points_for_model("SH10RT-20") == ESS_MPPT_DIAGNOSTIC_POINTS
+    assert mppt_points_for_model("nope") == {}
+
+
+def test_string_and_hybrid_mppt_ranges_are_disjoint():
+    """The two MPPT ranges must not share point ids, or a swap couldn't be clean."""
+    assert set(STRING_MPPT_POINTS) & set(ESS_MPPT_DIAGNOSTIC_POINTS) == set()


### PR DESCRIPTION
## Summary

First increment of the **Per-model capability mapping** milestone. Resolves the inverter family from `device_model_code` and lets it drive which per-device points to request, instead of choosing the MPPT range and battery points from `device_type` alone.

This retires the root cause behind the two most-commented issues:
- **#31** — battery charge/discharge power on hybrids (e.g. SH10RT-20)
- **#189** — MPPT / string values, which live on a different point range for SH-family hybrids

Point IDs and availability vary by model; previously they were discovered by hand, per model, per issue.

## Changes

- **New `model_capabilities.py`** — resolves SG/SH × single/three-phase families from the model code and exposes `has_battery`, `phases`, and the correct MPPT point range. Unknown models return `None`/`{}` so callers fall back to the existing device-type behaviour — **no regression** for installs whose model the map doesn't know yet.
- **`const.py`** — extracted `STRING_MPPT_POINTS` (points 5–10) as a named constant, replacing a literal that was duplicated/hardcoded in the coordinator. `INVERTER_DIAGNOSTIC_POINTS` content is unchanged (verified by existing `test_const.py`).
- **`coordinator.py`** — the per-device fetch now:
  - picks the MPPT id range by model family (SG → 5–10, SH → 13xxx) rather than the device-type heuristic;
  - requests battery charge/discharge power **and** battery device points for a hybrid even when the cloud mistypes it as a plain `INVERTER` (the exact #31 SH10RT-20 case);
  - leaves operating-status handling untouched to avoid the point-29 / 13146 shared-code collision (unchanged from #182).

## Why model-aware, not type-aware

The cloud sometimes types a hybrid as a plain `INVERTER`. The model code (`SH10RT-20`, `SH20T`, …) is a more reliable signal of "has a battery" and "which MPPT range", so it drives those decisions while the device-type path remains the fallback.

## Testing

- New `tests/test_model_capabilities.py` (family resolution, capabilities, battery/MPPT helpers, disjoint-range invariant).
- New coordinator tests: hybrid-typed-as-inverter requests battery power; string inverter never does; SH uses the 13xxx MPPT range; SG keeps 5–10.
- Full suite **592 passed**, 2 deselected. `ruff check` / `ruff format --check` / `mypy` clean. Coverage 94% total; new module fully covered.

## Follow-ups (same milestone)

- #252 — diagnostic listing all API-reported points per device (point-and-click Extra measure points)
- #253 — model-support matrix docs

## Validation ask

I can't self-validate SH/hybrid or three-phase hardware (test rig is a PV-only SG3.6RS). A dev pre-release from this PR would let the #31 (SH10RT-20) and #189 (SH20T) reporters confirm the model detection on their systems.

Closes #251.