### PR TITLE
feat: point-discovery catalog in diagnostics (#252)

### DIFF
--- a/custom_components/sungrow/diagnostics.py
+++ b/custom_components/sungrow/diagnostics.py
@@ -11,6 +11,8 @@ from homeassistant.components.diagnostics import async_redact_data
 from homeassistant.core import HomeAssistant
 
 from . import SungrowConfigEntry, SungrowData
+from .measure_points import resolve_name
+from .model_capabilities import resolve_capabilities
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -82,25 +84,92 @@ def _jsonable(obj: Any) -> Any:
     return obj
 
 
-async def _probe_plant_devices(service: Any, plant_id: str) -> tuple[list[dict[str, Any]], dict[str, Any]]:
+def _catalog_rows(points: Any) -> list[dict[str, Any]]:
+    """Flatten a ``{code: point}`` realtime dict into tidy, sorted catalog rows.
+
+    Each row is ``{point_id, code, name, value, unit}`` — the exact fields a user needs
+    to pick a point for the "Extra measure points" option (#252). The friendly English
+    ``name`` comes from the measure-point catalog (``resolve_name``), not the API's
+    Chinese-for-English-locale name nor the user's device name, so the rows carry no PII.
+    """
+    if not isinstance(points, dict):
+        return []
+    rows: list[dict[str, Any]] = []
+    for code, point in points.items():
+        if not isinstance(point, dict):
+            continue
+        point_id = str(point.get("id") or code)
+        rows.append(
+            {
+                "point_id": point_id,
+                "code": str(code),
+                "name": resolve_name(point_id, str(code), point.get("name")),
+                "value": point.get("value"),
+                "unit": point.get("unit"),
+            }
+        )
+    return sorted(rows, key=lambda row: row["point_id"])
+
+
+def build_points_catalog(
+    plant_realtime: Any,
+    device_realtime: dict[str, Any],
+    models_by_type: dict[str, str | None],
+) -> dict[str, Any]:
+    """Build a human-readable catalog of every point the API reports (#252).
+
+    Turns the raw plant + per-device realtime dumps into flat, sorted point lists so a
+    user can see exactly which point IDs are available on their hardware and copy them
+    into the "Extra measure points" option, instead of hunting in the developer portal.
+    Each device type is annotated with the resolved model family / battery capability
+    (#251) so it is obvious which device a point belongs to. Contains only point
+    metadata and model codes — no uuids, serials or user-set names — so it is safe to
+    include in a shared diagnostics bundle.
+    """
+    catalog: dict[str, Any] = {"plant": _catalog_rows(plant_realtime), "devices": {}}
+    for type_id, per_device in device_realtime.items():
+        # Merge points across all devices of this type, deduped by point id (devices of
+        # one type report the same point set). ``per_device`` is ``{device_N: {code:
+        # point}}`` on success, or ``{"error": ...}`` when the probe failed.
+        merged: dict[str, dict[str, Any]] = {}
+        if isinstance(per_device, dict):
+            for payload in per_device.values():
+                for row in _catalog_rows(payload):
+                    merged.setdefault(row["point_id"], row)
+        model = models_by_type.get(type_id)
+        caps = resolve_capabilities(model)
+        catalog["devices"][type_id] = {
+            "model": model,
+            "family": caps.family.value,
+            "has_battery": caps.has_battery,
+            "points": sorted(merged.values(), key=lambda row: row["point_id"]),
+        }
+    return catalog
+
+
+async def _probe_plant_devices(
+    service: Any, plant_id: str
+) -> tuple[list[dict[str, Any]], dict[str, Any], dict[str, str | None]]:
     """Best-effort capture of every device and its per-device realtime data.
 
-    Returns ``(all_devices, device_realtime)``. The plant realtime endpoint only
-    returns point IDs the library knows about, so hardware like EV chargers never
-    shows up as sensors (issue #18). This walks the *full* device list (not just
-    inverter/ESS) and attempts a per-device realtime fetch for each distinct type,
-    so a diagnostics download reveals an unmapped device's type and reachable
-    points — enough to add a proper mapping. All failures are captured, never
-    raised, so a diagnostics download always succeeds.
+    Returns ``(all_devices, device_realtime, models_by_type)``. The plant realtime
+    endpoint only returns point IDs the library knows about, so hardware like EV
+    chargers never shows up as sensors (issue #18). This walks the *full* device list
+    (not just inverter/ESS) and attempts a per-device realtime fetch for each distinct
+    type, so a diagnostics download reveals an unmapped device's type and reachable
+    points — enough to add a proper mapping. ``models_by_type`` maps each device-type id
+    to that type's model code, so the point catalog can annotate device families (#252).
+    All failures are captured, never raised, so a diagnostics download always succeeds.
     """
     try:
         async with asyncio.timeout(PROBE_TIMEOUT):
             all_devices = await service.async_get_plant_devices(plant_id)
     except Exception as err:  # pylint: disable=broad-except
         _LOGGER.debug("Diagnostics: could not list devices for plant %s: %s", plant_id, err)
-        return [{"error": str(err)}], {}
+        return [{"error": str(err)}], {}, {}
 
     device_realtime: dict[str, Any] = {}
+    models_by_type: dict[str, str | None] = {}
     seen_types: set[Any] = set()
     # Shared across device types so a given device uuid always maps to the same
     # ``device_N`` placeholder within this plant's per-device realtime section (#122).
@@ -112,6 +181,9 @@ async def _probe_plant_devices(service: Any, plant_id: str) -> tuple[list[dict[s
         if device_type is None:
             continue
         type_id = getattr(device_type, "value", device_type)
+        # Record the model code for this type (first device of the type wins), for the
+        # point-catalog family annotation (#252).
+        models_by_type.setdefault(str(type_id), device.get("device_model_code"))
         if type_id in seen_types:
             continue
         seen_types.add(type_id)
@@ -123,7 +195,7 @@ async def _probe_plant_devices(service: Any, plant_id: str) -> tuple[list[dict[s
             _LOGGER.debug("Diagnostics: device realtime failed for type %s: %s", type_id, err)
             device_realtime[str(type_id)] = {"error": str(err)}
 
-    return _jsonable(all_devices), device_realtime
+    return _jsonable(all_devices), device_realtime, models_by_type
 
 
 async def async_get_config_entry_diagnostics(hass: HomeAssistant, entry: SungrowConfigEntry) -> dict[str, Any]:
@@ -131,7 +203,9 @@ async def async_get_config_entry_diagnostics(hass: HomeAssistant, entry: Sungrow
 
     Tokens and secrets are redacted; raw coordinator data, the full device list,
     and per-device realtime data are included to help identify unsupported point
-    IDs (e.g. EV chargers — see issue #18).
+    IDs (e.g. EV chargers — see issue #18). A flattened ``points_catalog`` lists
+    every reported point (id/name/value/unit) per device so users can pick point
+    IDs for the "Extra measure points" option without portal-spelunking (#252).
     """
     data = getattr(entry, "runtime_data", None)
     coordinators = data.coordinators if isinstance(data, SungrowData) else []
@@ -143,8 +217,9 @@ async def async_get_config_entry_diagnostics(hass: HomeAssistant, entry: Sungrow
         service = getattr(coordinator, "plants_service", None)
         all_devices: list[dict[str, Any]] = []
         device_realtime: dict[str, Any] = {}
+        models_by_type: dict[str, str | None] = {}
         if service is not None:
-            all_devices, device_realtime = await _probe_plant_devices(service, plant_id)
+            all_devices, device_realtime, models_by_type = await _probe_plant_devices(service, plant_id)
 
         modbus_diag: dict[str, Any] = {}
         if getattr(coordinator, "modbus_diagnostics", None):
@@ -160,6 +235,9 @@ async def async_get_config_entry_diagnostics(hass: HomeAssistant, entry: Sungrow
             "all_devices": all_devices,
             # Per-device-type realtime data (best effort; {} where unsupported).
             "device_realtime": device_realtime,
+            # Flattened, human-readable catalog of every reported point (#252): the
+            # point IDs a user can copy into the "Extra measure points" option.
+            "points_catalog": build_points_catalog(coordinator.data, device_realtime, models_by_type),
             # Local Modbus-only diagnostic metadata (skipped blocks, last error, family).
             "modbus_diagnostics": modbus_diag,
         }

--- a/tests/test_diagnostics.py
+++ b/tests/test_diagnostics.py
@@ -266,3 +266,125 @@ async def test_diagnostics_without_service_skips_probe(hass: HomeAssistant):
 
     assert diag["plants"]["1"]["all_devices"] == []
     assert diag["plants"]["1"]["device_realtime"] == {}
+
+
+async def test_points_catalog_lists_points_per_device(hass: HomeAssistant):
+    """The points_catalog flattens plant + per-device points into pickable rows (#252)."""
+    entry = MagicMock()
+    entry.entry_id = "e"
+    entry.data = {"gateway": "Europe", "app_id": "a"}
+    entry.options = {}
+
+    service = MagicMock()
+    service.async_get_plant_devices = AsyncMock(
+        return_value=[
+            {
+                "uuid": "ess-1",
+                "device_name": "My Inverter",
+                "device_type": DeviceType.ENERGY_STORAGE_SYSTEM,
+                "device_model_code": "SH10RT-20",
+            },
+        ]
+    )
+    service.async_get_device_realtime = AsyncMock(
+        return_value={
+            "ess-1": {
+                "battery_charge_power": {"id": "13126", "code": "battery_charge_power", "value": "800", "unit": "W"},
+                "operating_status": {"id": "13146", "code": "operating_status", "value": "13"},
+            }
+        }
+    )
+    coordinator = _make_coordinator(
+        "1",
+        "P",
+        {"total_active_power": {"id": "83022", "code": "total_active_power", "value": "5.2", "unit": "kW"}},
+        plants_service=service,
+    )
+    entry.runtime_data = SungrowData(coordinators=[coordinator], control=MagicMock(), devices={})
+
+    diag = await async_get_config_entry_diagnostics(hass, entry)
+    catalog = diag["plants"]["1"]["points_catalog"]
+
+    # Plant-level points are listed with id/code/value/unit.
+    plant_ids = {row["point_id"] for row in catalog["plant"]}
+    assert "83022" in plant_ids
+
+    ess_type = str(DeviceType.ENERGY_STORAGE_SYSTEM.value)
+    device = catalog["devices"][ess_type]
+    # The device is annotated with its resolved family/battery capability (#251).
+    assert device["model"] == "SH10RT-20"
+    assert device["family"] == "sh_rt"
+    assert device["has_battery"] is True
+    rows = {row["point_id"]: row for row in device["points"]}
+    assert rows["13126"]["code"] == "battery_charge_power"
+    assert rows["13126"]["unit"] == "W"
+    assert "13146" in rows
+    # Rows are sorted by point id for stable, scannable output.
+    assert [r["point_id"] for r in device["points"]] == sorted(rows)
+    json.dumps(diag)
+
+
+async def test_points_catalog_contains_no_pii(hass: HomeAssistant):
+    """The catalog carries only point metadata + model code — no uuids/serials/names (#252)."""
+    entry = MagicMock()
+    entry.entry_id = "e"
+    entry.data = {"gateway": "Europe", "app_id": "a"}
+    entry.options = {}
+
+    service = MagicMock()
+    service.async_get_plant_devices = AsyncMock(
+        return_value=[
+            {
+                "uuid": "secret-uuid",
+                "device_name": "7 Acacia Avenue Inverter",
+                "device_sn": "SN-SECRET",
+                "device_type": DeviceType.INVERTER,
+                "device_model_code": "SG3.6RS",
+            }
+        ]
+    )
+    service.async_get_device_realtime = AsyncMock(
+        return_value={
+            "secret-uuid": {"mppt1_voltage": {"id": "5", "code": "mppt1_voltage", "value": "320", "unit": "V"}}
+        }
+    )
+    coordinator = _make_coordinator("1", "P", {}, plants_service=service)
+    entry.runtime_data = SungrowData(coordinators=[coordinator], control=MagicMock(), devices={})
+
+    diag = await async_get_config_entry_diagnostics(hass, entry)
+    catalog = diag["plants"]["1"]["points_catalog"]
+
+    dumped = json.dumps(catalog)
+    for secret in ("secret-uuid", "SN-SECRET", "7 Acacia Avenue"):
+        assert secret not in dumped
+    # A string inverter is correctly flagged as having no battery.
+    inv = catalog["devices"][str(DeviceType.INVERTER.value)]
+    assert inv["has_battery"] is False
+    assert inv["model"] == "SG3.6RS"
+
+
+async def test_points_catalog_handles_probe_error(hass: HomeAssistant):
+    """A per-device probe error yields an empty point list for that type, never a crash (#252)."""
+    entry = MagicMock()
+    entry.entry_id = "e"
+    entry.data = {"gateway": "Europe", "app_id": "a"}
+    entry.options = {}
+
+    service = MagicMock()
+    service.async_get_plant_devices = AsyncMock(
+        return_value=[{"uuid": "chg-1", "device_type": 999, "device_model_code": "AC011E"}]
+    )
+    service.async_get_device_realtime = AsyncMock(side_effect=RuntimeError("nope"))
+    coordinator = _make_coordinator("1", "P", None, plants_service=service)
+    entry.runtime_data = SungrowData(coordinators=[coordinator], control=MagicMock(), devices={})
+
+    diag = await async_get_config_entry_diagnostics(hass, entry)
+    catalog = diag["plants"]["1"]["points_catalog"]
+
+    # Plant data was None -> empty plant list; the errored type has no points but is
+    # still listed (as an unknown family, since AC011E isn't an SG/SH inverter).
+    assert catalog["plant"] == []
+    charger = catalog["devices"]["999"]
+    assert charger["points"] == []
+    assert charger["family"] == "unknown"
+    json.dumps(diag)


### PR DESCRIPTION
## Summary

Second increment of the **Per-model capability mapping** milestone (follows #259). Adds a flattened, human-readable `points_catalog` to the config-entry diagnostics download so users can see exactly which point IDs their hardware reports and copy them into the **Extra measure points** option — instead of hunting for IDs in the iSolarCloud developer portal.

This is the friction point behind #31 and #189: in #31 a user couldn't find the point IDs in the raw data and had to send a portal screenshot for manual mapping.

## Changes

- **`build_points_catalog`** — turns the raw plant + per-device realtime dumps into flat, sorted `{point_id, code, name, value, unit}` rows. The friendly English `name` comes from the measure-point catalog (`resolve_name`), not the API's localized name nor the user's device name.
- Each device type is annotated with its **resolved model family / battery capability** (via `model_capabilities`, from #251), so it's obvious which device a point belongs to.
- The diagnostics probe now records the model code per device type to drive that annotation (`_probe_plant_devices` returns `models_by_type`).
- Contains only point metadata + model codes — **no uuids, serials or user-set names** — so it's safe in a shared diagnostics bundle (asserted by a dedicated no-PII test).

## Example (redacted diagnostics excerpt)

```json
"points_catalog": {
  "plant": [ {"point_id": "83022", "code": "total_active_power", "name": "Total Active Power", "value": "5.2", "unit": "kW"} ],
  "devices": {
    "14": {
      "model": "SH10RT-20", "family": "sh_rt", "has_battery": true,
      "points": [
        {"point_id": "13126", "code": "battery_charge_power", "name": "Battery Charging Power", "value": "800", "unit": "W"},
        {"point_id": "13146", "code": "operating_status", "name": "Operating Status", "value": "13", "unit": null}
      ]
    }
  }
}
```

## Testing

- New tests: catalog shape/sorting/family annotation, the no-PII guarantee, and probe-error handling (errored type → empty point list, no crash).
- Full suite **576 passed**, 2 deselected. `ruff` / `mypy` clean. Coverage 94%.

## Follow-up (same milestone)

- #253 — model-support matrix docs (can be data-driven from the same family resolution).

Closes #252.