### PR TITLE
docs: model-support matrix (#253)

### DIFF
--- a/docs/SENSORS.md
+++ b/docs/SENSORS.md
@@ -2,7 +2,7 @@
 
 The integration models each iSolarCloud plant as a Home Assistant device, with the plant's physical devices (inverter, battery, meter, WiNet-S) nested underneath it. It adds a sensor for every realtime measure point the plant returns and **groups each one under the physical device it belongs to** when that device can be identified (see [Device grouping](#device-grouping)). The point codes come from the iSolarCloud API; this guide maps the most common ones to the values shown in the iSolarCloud app.
 
-> Not every inverter / battery / meter returns every point. The available set depends on your model, firmware, and region. If a value you expect is missing, see [Adding extra measure points](#adding-extra-measure-points) below.
+> Not every inverter / battery / meter returns every point. The available set depends on your model, firmware, and region. For a per-family breakdown of what to expect, see the [Model support matrix](model-support.md). If a value you expect is missing, see [Adding extra measure points](#adding-extra-measure-points) below.
 
 ## Device grouping
 

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -155,6 +155,9 @@ ask for, so hardware the upstream library hasn't catalogued — e.g. a **Sungrow
 AC011E EV charger** ([#18](https://github.com/KRoperUK/sungrow-hass/issues/18)) —
 won't create sensors automatically even though it appears in the iSolarCloud app.
 
+First, check the [Model support matrix](model-support.md) — the value may be a known
+limitation of your inverter model rather than a bug.
+
 To help map it:
 
 1. **Download diagnostics.** Go to **Settings → Devices & services → Sungrow
@@ -164,6 +167,9 @@ To help map it:
      `device_type` (unmapped hardware shows a raw numeric type).
    - `device_realtime` — a best-effort per-device realtime fetch for each device
      type, so any reachable charger points show up here.
+   - `points_catalog` — a flattened, per-device list of **every point your hardware
+     reports** (point ID, name, value, unit), so you can copy the IDs you want into
+     **Extra measure points** without portal-spelunking.
 2. **Attach that JSON to [#18](https://github.com/KRoperUK/sungrow-hass/issues/18)**
    so the point IDs can be added to the default mapping.
 3. **Surface the device's own sensors.** Enable **Configure → Create per-device

--- a/docs/index.md
+++ b/docs/index.md
@@ -22,7 +22,8 @@ inverters** through the **iSolarCloud** cloud API, using the
 - **Auto-discovery** — finds every plant linked to your account, and discovers WiNet-S
   dongles on the network for local Modbus.
 - **Rich sensors** — power, energy, battery SOC, and more, with correct device/state classes so
-  they work in the Energy dashboard out of the box.
+  they work in the Energy dashboard out of the box. See the
+  [Model support matrix](model-support.md) for what each inverter family reports.
 - **Device health & diagnostics** — per-device **Fault** and **Connectivity** binary sensors,
   device-level diagnostics (inverter temperature, MPPT, WLAN signal), and device cards enriched
   with model, serial number and manufacturer.

--- a/docs/model-support.md
+++ b/docs/model-support.md
@@ -1,0 +1,93 @@
+---
+icon: lucide/table-2
+---
+
+# Model support matrix
+
+Which sensors and controls you get depends on your **inverter family**. Sungrow expose
+different measure points (and different point IDs) per model, so this page shows what to
+expect for each family — and, when something is missing, whether that's a model limitation
+or something to report.
+
+The integration resolves the family automatically from the device's model code
+(`device_model_code`, e.g. `SG3.6RS`, `SH10RT-20`), and uses it to request the right
+points — for example the MPPT voltage/current range differs between string inverters and
+hybrids. A model the resolver doesn't recognise still works: it falls back to the generic,
+device-type behaviour, so nothing is lost — you just won't get the family-specific tuning.
+
+## Families
+
+| Family | Example models | Type | Battery |
+|---|---|---|---|
+| **SG · single-phase string** | SG3.0RS, SG3.6RS, SG5.0RS | PV string inverter | No |
+| **SG · three-phase string** | SG8.0RT, SG10RT, SG110CX | PV string inverter | No |
+| **SH · single-phase hybrid** | SH3.6RS, SH5.0RS, SH6.0RS | Hybrid / storage | Yes |
+| **SH · three-phase hybrid** | SH8.0RT, SH10RT‑20, SH20T | Hybrid / storage | Yes |
+
+Prefix `SG` = PV string inverter (no battery); `SH` = hybrid with a battery. Suffix `RS` =
+single-phase; `RT` / `T` / `CX` = three-phase.
+
+## What each family reports
+
+| Capability | SG single-phase | SG three-phase | SH single-phase | SH three-phase |
+|---|:--:|:--:|:--:|:--:|
+| PV power / daily & total yield | ✅ | ✅ | ✅ | ✅ |
+| MPPT voltage/current | ✅ (pts 5–10) | ✅ (pts 5–10) | ✅ (pts 13xxx) | ✅ (pts 13xxx) |
+| Per-string DC V/I | ✅ | ✅ | ✅ | ✅ |
+| Per-phase AC V/I | Phase A | A / B / C | Phase A | A / B / C |
+| Battery SOC / power / health | — | — | ✅ | ✅ |
+| Battery charge & discharge power | — | — | ✅ | ✅ |
+| Grid meter (import/export) | ✅ | ✅ | ✅ | ✅ |
+| Dispatch — grid/export limits | ✅ | ✅ | ✅ | ✅ |
+| Dispatch — charge/discharge, SOC, forced-charge | — | — | ✅ | ✅ |
+
+✅ = available where the API/model reports it. Points a specific model or firmware doesn't
+return are simply skipped (no broken entities). Battery rows depend on a battery actually
+being present — the dispatch battery controls are hidden on PV-only plants for safety.
+
+## Cloud vs local Modbus
+
+Most points are available over both the cloud API and local Modbus (WiNet-S), but coverage
+differs by family. See [Local Modbus](local-modbus.md) for setup.
+
+| Family | Cloud API | Local Modbus (WiNet-S) |
+|---|:--:|:--:|
+| SG single-phase string | ✅ | ✅ (SG-RS register map) |
+| SG three-phase string | ✅ | ⚠️ not yet mapped — see [#219](https://github.com/KRoperUK/sungrow-hass/issues/219) |
+| SH single-phase hybrid | ✅ | ✅ (SH register map) |
+| SH three-phase hybrid | ✅ | ✅ (SH register map) |
+
+Local Modbus is currently **read-only**; dispatch/control still goes through the cloud
+([#220](https://github.com/KRoperUK/sungrow-hass/issues/220)).
+
+## Known model-specific caveats
+
+- **SH20T — MPPT not exposed via cloud.** On some firmware the SH20T doesn't return MPPT
+  voltage/current over the iSolarCloud API even with per-device sensors enabled, so those
+  sensors won't appear (reported in
+  [#189](https://github.com/KRoperUK/sungrow-hass/issues/189)). This is a data limitation of
+  the model/firmware, not a bug in the integration.
+- **SH10RT‑20 — battery charge/discharge power.** Separate **Battery Charging Power** and
+  **Battery Discharging Power** sensors are requested automatically for hybrid inverters (no
+  manual configuration; [#31](https://github.com/KRoperUK/sungrow-hass/issues/31)).
+- **SG-RS — local `daily_yield`.** The daily-yield register read over Modbus can diverge from
+  the cloud value on some SG-RS firmware; the integration derives daily yield from the
+  trustworthy lifetime total instead ([#223](https://github.com/KRoperUK/sungrow-hass/issues/223)).
+
+## Missing a sensor?
+
+If a value you expect isn't appearing:
+
+1. Check the table above — it may be a known limitation of your model.
+2. Download a **diagnostics** dump from the device page. The `points_catalog` section lists
+   **every point your hardware actually reports** (point ID, name, value, unit) per device —
+   copy the IDs you want into **Extra measure points** (see
+   [Adding extra measure points](SENSORS.md#adding-extra-measure-points)).
+3. If a point *is* reported but not surfaced — or your model isn't recognised as the right
+   family — please [open an issue](https://github.com/KRoperUK/sungrow-hass/issues) with the
+   redacted diagnostics so the model map can be extended.
+
+!!! info "Help us grow the matrix"
+    This matrix is maintained from confirmed hardware reports. If your model behaves
+    differently from what's shown here, a diagnostics dump on an issue lets us correct it and
+    tune the per-model point requests for everyone with that model.

--- a/zensical.toml
+++ b/zensical.toml
@@ -15,6 +15,7 @@ nav = [
   { "Configuration" = "configuration.md" },
   { "Local Modbus" = "local-modbus.md" },
   { "Sensors" = "SENSORS.md" },
+  { "Model support" = "model-support.md" },
   { "Troubleshooting" = "TROUBLESHOOTING.md" },
 ]
 


### PR DESCRIPTION
## Summary

Third and final increment of the **Per-model capability mapping** milestone (follows #259 and #261). Adds a per-family model-support matrix so users can tell at a glance whether a missing sensor is a **model limitation** or a bug — the recurring uncertainty behind #189 (SH20T MPPT not exposed by cloud) and #31 (SH10RT-20 battery power).

## Changes

- **New `docs/model-support.md`**:
  - The four families the integration resolves from `device_model_code` (SG/SH × single/three-phase), and how detection + graceful fallback works.
  - A capability matrix (PV/MPPT, per-string, per-phase, battery, meter, dispatch) per family.
  - Cloud vs local-Modbus coverage per family (incl. the not-yet-mapped three-phase SG, #219; read-only note, #220).
  - Known model-specific caveats: SH20T MPPT (#189), SH10RT-20 battery power (#31), SG-RS local `daily_yield` (#223).
  - "Missing a sensor?" flow pointing at the diagnostics `points_catalog` from #252.
- Added the page to the Zensical nav (`zensical.toml`).
- Cross-links from `index.md`, `SENSORS.md`, and `TROUBLESHOOTING.md`'s "device isn't showing up" section.

## Validation

- `zensical build --clean` → **No issues found** (nav + internal links resolve).
- Docs-only; no `custom_components/**` changes.

Closes #253. Completes the milestone alongside #259 (capability map) and #261 (point-discovery diagnostic).