### PR TITLE
ci: verify sungrow.zip asset is attached to stable releases (#256)

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -41,6 +41,26 @@ jobs:
                   bash scripts/package-hacs-zip.sh sungrow.zip
                   gh release upload "$TAG" sungrow.zip --clobber
 
+            # Regression guard for #245: v4.0.0 shipped without sungrow.zip, so every
+            # HACS install/update failed. Because hacs.json sets zip_release: true, a
+            # release missing the asset is broken for users. Fail the release loudly if
+            # the upload step above is ever dropped/renamed so it can't silently regress.
+            - name: Verify HACS zip asset is attached
+              if: ${{ steps.release.outputs.release_created == 'true' }}
+              env:
+                  GH_TOKEN: ${{ github.token }}
+                  TAG: ${{ steps.release.outputs.tag_name }}
+              run: |
+                  set -euo pipefail
+                  assets=$(gh release view "$TAG" --json assets --jq '.assets[].name')
+                  echo "Assets on ${TAG}:"
+                  printf '%s\n' "$assets"
+                  if ! printf '%s\n' "$assets" | grep -Fxq "sungrow.zip"; then
+                    echo "::error::Release ${TAG} is missing the sungrow.zip asset — HACS installs would fail (regression of #245)."
+                    exit 1
+                  fi
+                  echo "Verified sungrow.zip is attached to ${TAG}."
+
             # A published release supersedes every dev build. Prune them all so only
             # the real release remains (rc builds + any leftover branch builds).
             - name: Prune all dev pre-releases on a real release


### PR DESCRIPTION
## Summary

Regression guard for #245: v4.0.0 shipped **without** the `sungrow.zip` asset, so every HACS install/update failed (`hacs.json` sets `zip_release: true`). The upload step was added reactively in #243/4.0.1, but nothing guarantees it stays working — a future refactor of `release-please.yml` could silently drop it again.

## Change

Adds a **Verify HACS zip asset is attached** step to `release-please.yml`, right after the upload and before dev-release pruning. On a real release it asserts the release has a `sungrow.zip` asset and fails the job with a clear `::error::` if not — so a dropped/renamed upload step can't reach users.

```
Assets on v4.2.0:
sungrow.zip
Verified sungrow.zip is attached to v4.2.0.
```

## Testing

- Workflow YAML parses; the step is correctly ordered (Run release-please → Upload → **Verify** → Prune).
- Only fires when `release_created == 'true'` (stable releases); pre-releases/RCs are unaffected.

## Possible follow-up

A scheduled workflow that independently checks the latest stable release still has the asset would also catch the "both upload and verify steps removed" case. Left out here to keep the change focused; happy to add if you'd like it.

Closes #256.