### PR TITLE
ci: gated read-only live smoke test against a real account (#257)

### DIFF
--- a/.github/workflows/live-smoke.yml
+++ b/.github/workflows/live-smoke.yml
@@ -1,0 +1,54 @@
+name: Live smoke test
+
+# Gated live smoke test against a real iSolarCloud account (#257). Unit tests mock
+# pysolarcloud, so API-contract regressions (e.g. the result_code handling behind
+# pysolarcloud #9, or the getDeviceRealTimeData 009 spam in #155) can't be caught by
+# them. This runs the read-only `-m live` suite on demand and on a nightly schedule.
+#
+# It never runs on PRs (protects secrets, respects the ~2000 calls/hr quota) and is
+# read-only (no dispatch writes). Without the credential/token secrets the live tests
+# skip cleanly, so a fork or an unconfigured repo sees a green, no-op run.
+
+on:
+  workflow_dispatch: {}
+  schedule:
+    # 03:17 UTC daily (off the hour to avoid the scheduler rush).
+    - cron: "17 3 * * *"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: live-smoke
+  cancel-in-progress: true
+
+jobs:
+  live:
+    # Never run the scheduled job on forks — they don't have the secrets and it would
+    # just be a pointless (or confusingly skipped) run.
+    if: github.repository == 'KRoperUK/sungrow-hass'
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - name: Set up Python
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
+        with:
+          python-version: "3.13"
+          cache: pip
+          cache-dependency-path: requirements_test.txt
+
+      - name: Install dependencies
+        run: pip install -r requirements_test.txt
+
+      - name: Run live smoke tests (read-only)
+        # The live fixtures skip when their secrets are absent, so this is a green no-op
+        # without them. `-m live` overrides the default `-m 'not live'` deselection.
+        env:
+          SUNGROW_APPKEY: ${{ secrets.SUNGROW_APPKEY }}
+          SUNGROW_APPSECRET: ${{ secrets.SUNGROW_APPSECRET }}
+          SUNGROW_APP_ID: ${{ secrets.SUNGROW_APP_ID }}
+          SUNGROW_HOST: ${{ secrets.SUNGROW_HOST }}
+          SUNGROW_TOKENS: ${{ secrets.SUNGROW_TOKENS }}
+        run: pytest tests/test_integration_live.py -m live -o addopts= -v

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -243,3 +243,26 @@ def live_credentials():
         "app_id": app_id,
         "host": host,
     }
+
+
+@pytest.fixture
+def live_tokens():
+    """Return stored OAuth tokens for authorized live smoke tests, or skip.
+
+    Authorized API calls (list plants, realtime) need OAuth tokens that can only be
+    obtained interactively, so they're supplied to CI as a ``SUNGROW_TOKENS`` secret
+    holding the JSON ``{"access_token", "refresh_token", "expires_at"}`` dict. Absent
+    that secret the test skips, so ordinary CI and local runs are unaffected (#257).
+    """
+    import json
+
+    raw = os.getenv("SUNGROW_TOKENS")
+    if not raw:
+        pytest.skip("SUNGROW_TOKENS not set; skipping authorized live smoke test")
+    try:
+        tokens = json.loads(raw)
+    except (TypeError, ValueError) as err:
+        pytest.skip(f"SUNGROW_TOKENS is not valid JSON: {err}")
+    if not isinstance(tokens, dict) or "access_token" not in tokens:
+        pytest.skip("SUNGROW_TOKENS must be a JSON object with at least an access_token")
+    return tokens

--- a/tests/test_integration_live.py
+++ b/tests/test_integration_live.py
@@ -43,3 +43,37 @@ async def test_auth_url_generation(live_credentials):
     assert isinstance(url, str)
     assert url.startswith("http")
     assert len(url) > 50  # Should be a full URL, not empty
+
+
+@pytest.mark.live
+async def test_live_list_plants_smoke(live_credentials, live_tokens):
+    """Read-only smoke test against a real account: authorize and list plants (#257).
+
+    Detects API-contract drift (e.g. the result_code handling behind pysolarcloud #9,
+    the getDeviceRealTimeData 009 regression in #155) before users do. Read-only: it
+    never writes dispatch parameters. Skips unless both app credentials and a stored
+    token secret are present, so it only runs in the gated live-smoke workflow.
+    """
+    from pysolarcloud.plants import Plants
+
+    auth = Auth(
+        host=live_credentials["host"],
+        appkey=live_credentials["app_key"],
+        access_key=live_credentials["app_secret"],
+        app_id=live_credentials["app_id"],
+    )
+    # Inject the stored tokens so the client can make authorized calls without an
+    # interactive OAuth round-trip; the library refreshes them as needed.
+    auth.tokens = live_tokens
+
+    plants_service = Plants(auth)
+    try:
+        plants = await plants_service.async_get_plants()
+    finally:
+        await auth.async_close()
+
+    assert isinstance(plants, list)
+    # If the account has plants, each entry should carry the identifiers the
+    # integration relies on for setup.
+    for plant in plants:
+        assert "ps_id" in plant


### PR DESCRIPTION
## Summary

Unit tests mock `pysolarcloud`, so API-contract regressions can't be caught by them — the class of bug behind pysolarcloud #9 (`result_code` handling), #155 (`getDeviceRealTimeData 009` log spam) and #231 (dispatch mode switch) only surfaced live, usually reported by users. This adds a **gated, read-only** live smoke test.

## Changes

- **New `.github/workflows/live-smoke.yml`**:
  - Triggers on `workflow_dispatch` and a nightly `schedule` — **never on PRs** (protects secrets, respects the ~2000 calls/hr quota).
  - `if: github.repository == 'KRoperUK/sungrow-hass'` so forks don't run it.
  - Runs `pytest -m live` with credentials/tokens from repo secrets; `-o addopts=` clears the default `-m 'not live'` deselection.
- **New authorized smoke test** `test_live_list_plants_smoke` — injects stored tokens and calls `async_get_plants()` (read-only), asserting the plant shape the integration relies on.
- **New `live_tokens` fixture** — reads a `SUNGROW_TOKENS` secret (JSON `{access_token, refresh_token, expires_at}`) and **skips** if absent/malformed.

## Skips cleanly without secrets

The existing `live_credentials` fixture and the new `live_tokens` fixture both `pytest.skip` when their env vars are missing, so forks, local runs, and an unconfigured repo see a **green no-op** (verified locally: all 3 live tests skip, exit 0).

## Secrets needed to actually exercise it

`SUNGROW_APPKEY`, `SUNGROW_APPSECRET`, `SUNGROW_APP_ID` (and optionally `SUNGROW_HOST`) enable the credential tests; adding `SUNGROW_TOKENS` (a stored OAuth token JSON) enables the authorized list-plants smoke. Read-only — it never writes dispatch parameters.

## Testing

- `pytest tests/test_integration_live.py -m live -o addopts=` → 3 skipped, exit 0.
- `ruff` clean; workflow YAML parses.

Closes #257.