### PR TITLE
docs: release runbook + code-review expectation to reduce bus factor (#258)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -34,10 +34,63 @@ Run the same checks CI runs:
 ## Pull requests
 
 - Use **Conventional Commits** for PR titles and commits (`fix:`, `feat:`,
-  `chore:`, `docs:` …). This drives automated changelog and version bumps.
+  `chore:`, `docs:` …). This drives automated changelog and version bumps. Use
+  `feat!:` or a `BREAKING CHANGE:` footer for changes that bump the major version
+  (e.g. anything that changes entity IDs).
 - Keep changes focused; add or update tests for any behaviour change.
 - All PRs target `main` and must pass CI (lint, tests, HACS + hassfest validation)
   and at least one review before merge.
+
+### Code review
+
+`main` is protected and the project is largely single-maintainer, so a second pair
+of eyes matters — especially since many PRs are AI-assisted.
+
+- Request a **Copilot code review** (or a second human reviewer, if available) on any
+  non-trivial PR. Treat AI-generated changes the same: they still get a review pass.
+- Pay particular attention to changes touching the high-risk areas: `auth.py`,
+  `config_flow.py`, `coordinator.py`, and the dispatch controls (`number.py` /
+  `select.py`). These are behind the historical token-persistence and dispatch bugs.
+- A PR that changes the integration also mints a **dev pre-release** you can install
+  via HACS to validate on real hardware before merging — see below.
+
+## Releasing
+
+Releases are automated with [release-please](https://github.com/googleapis/release-please);
+you should never hand-edit the version or changelog. This section documents the flow so
+anyone (not just the original maintainer) can cut a release or recover from a bad one.
+
+### Cutting a stable release
+
+1. Merge Conventional-Commit PRs to `main` as normal.
+2. release-please keeps an open **`chore(main): release X.Y.Z`** PR that accumulates the
+   changelog and the next version. Review it, then **merge it** to publish.
+3. On that merge, `release-please.yml` tags the release, packages **`sungrow.zip`** and
+   attaches it (HACS `zip_release`), **verifies the asset is present** (guards the #245
+   regression), and prunes the dev/RC pre-releases.
+
+The version is bumped from the commit types since the last release: `fix:` → patch,
+`feat:` → minor, `feat!:` / `BREAKING CHANGE:` → major.
+
+### Dev & RC pre-releases (testing builds)
+
+`main` is never mutated for pre-releases — they point at a *synthetic* commit that only
+rewrites the version files, so HACS shows a real, sortable version.
+
+- **Per-PR dev builds** — a component-touching PR, once CI is green, publishes
+  `vX.Y.Z-pr.<pr>.<run>` (see the `dev-release` job in `ci.yml`). Install it via HACS
+  (enable pre-releases) to test the PR on real hardware. This is the main way to get
+  hybrid/three-phase models validated, since the maintainer's rig can't cover them.
+- **RC builds on `main`** — a push to `main` publishes `vX.Y.Z-rc.N` (`dev-release-main`).
+
+### Recovering from a bad release
+
+- **Missing `sungrow.zip` (HACS install fails, à la #245):** the post-release verify step
+  now fails loudly, but if a release ever ships broken, land a `fix:` commit and merge the
+  next release-please PR to cut a patch — do **not** hand-edit the tag.
+- **Bad code shipped:** revert on `main` with a `fix:`/`revert:` PR and release again;
+  avoid deleting published release tags (HACS clients may already have them).
+- Re-apply branch protection with `scripts/setup-branch-protection.sh` if it drifts.
 
 ## Project layout
 


### PR DESCRIPTION
## Summary

The project is effectively single-maintainer: sole codeowner, and nearly every PR is self-authored (often AI-assisted) and self-merged. `main` is protected with good required checks, but there's no documented release process and no stated review expectation — the biggest organizational risk. This addresses both, lightweight and no new headcount.

## Changes to `CONTRIBUTING.md`

- **Code review** subsection: request Copilot (or a second human) review on non-trivial PRs; treat AI-generated changes the same; extra scrutiny for the historically bug-prone areas (`auth.py`, `config_flow.py`, `coordinator.py`, dispatch `number.py`/`select.py`); and a pointer that each component PR mints a dev pre-release for hardware validation.
- **Releasing** runbook so anyone can cut or recover a release:
  - Cutting a stable release (merge the release-please PR; version bump rules).
  - The dev/RC pre-release system (per-PR `-pr.` builds for hardware testing, `-rc.` builds on `main`; `main` never mutated).
  - **Recovering from a bad release**, including the #245 missing-`sungrow.zip` scenario (land a `fix:` and cut a patch; don't hand-edit tags), reverting bad code, and re-applying branch protection.
- Clarified Conventional Commit guidance for major bumps (`feat!:` / `BREAKING CHANGE:`).

## Notes

- Docs-only, at repo root (not the Zensical site), so no build impact.
- Actually enforcing required reviews / enabling Copilot auto-review is a repo setting rather than code; this documents the expectation. Happy to also flip the branch-protection setting if you'd like.

Closes #258.