### PR TITLE
docs: document user-account creds env vars in .env.example (#267)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,3 +7,11 @@ SUNGROW_APP_ID="your_app_id"
 
 # Optional: Override Gateway Host (default: Europe)
 # SUNGROW_HOST="https://gateway.isolarcloud.eu"
+
+# --- User-account (reverse-engineered) transport — see issue #267 ---
+# Your NORMAL iSolarCloud app/web login (email + password), NOT the developer app
+# above. Used to live-test the upcoming `cloud_user` transport. Copy this file to
+# `.env` (which is gitignored) and fill these in locally — never commit real
+# credentials. The region reuses SUNGROW_HOST above (default: Europe).
+# SUNGROW_USER_ACCOUNT="your_isolarcloud_email"
+# SUNGROW_USER_PASSWORD="your_isolarcloud_password"


### PR DESCRIPTION
Documents where to put a normal iSolarCloud user account for live-testing the upcoming `cloud_user` transport (epic #267).

Adds commented `SUNGROW_USER_ACCOUNT` / `SUNGROW_USER_PASSWORD` placeholders to `.env.example`. `.env` is gitignored, so real credentials are never committed; the region reuses the existing `SUNGROW_HOST`.

No code paths consume these yet — that lands with Phase 2 (#268). This just establishes the convention.

Part of #267.