### PR TITLE
chore: bump sungrow-isolarcloud to 0.11.0 (#268)

### DIFF
--- a/custom_components/sungrow/manifest.json
+++ b/custom_components/sungrow/manifest.json
@@ -21,7 +21,7 @@
   ],
   "quality_scale": "platinum",
   "requirements": [
-    "sungrow-isolarcloud==0.10.4",
+    "sungrow-isolarcloud==0.11.0",
     "pymodbus>=3.6.0"
   ],
   "version": "4.1.0",

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -11,5 +11,5 @@ ruff==0.15.21
 mypy==2.2.0
 
 # Component dependencies
-sungrow-isolarcloud==0.10.4
+sungrow-isolarcloud==0.11.0
 pymodbus==3.13.1


### PR DESCRIPTION
## Summary

Bumps the pinned `sungrow-isolarcloud` from 0.10.4 → **0.11.0** in `manifest.json` and `requirements_test.txt` (kept in sync). 0.11.0 publishes **`UserAuth`** — the reverse-engineered user-account (app/web) login, live-validated against a real account — which is the prerequisite for the `cloud_user` transport (Phase 2, #268).

The OAuth `Auth`/`Plants`/`Control` paths are unchanged; 0.11.0 only adds `UserAuth` (+ a `cryptography` dep). Full suite **596 passed** against 0.11.0.

First step of Phase 2 (#268); the transport + config-flow wiring follows.