### PR TITLE
feat: cloud_user realtime — map getPsDetail to measure points (#269)

### DIFF
--- a/custom_components/sungrow/coordinator.py
+++ b/custom_components/sungrow/coordinator.py
@@ -343,18 +343,18 @@ class SungrowPlantCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         return await self._async_apply_derived_daily_yield(data)
 
     async def _async_user_update(self) -> dict[str, Any]:
-        """Poll a cloud user-account entry via the app/web API (#268).
+        """Poll a cloud user-account entry via the app/web API (#268/#269).
 
-        Phase 2 proves authentication/connectivity only — mapping the user-API realtime
-        shapes onto the measure-point model is Phase 3 (#269), so no measure points are
-        produced yet. ``async_get_token`` logs in on the first poll and is a cheap cached
-        no-op thereafter; a dead credential (``AuthError``) triggers reauth, and a
-        transient failure rides out the availability grace window like the other paths.
+        Fetches the plant detail (``getPsDetail``) and maps it onto the measure-point
+        model. A dead credential (``AuthError``) triggers reauth; a transient failure
+        rides out the availability grace window like the other paths.
         """
+        from .user_realtime import map_plant_detail_to_points
+
         assert self._user_auth is not None
         try:
             async with asyncio.timeout(self._poll_timeout):
-                await self._user_auth.async_get_token()
+                detail = await self._user_auth.async_get_plant_detail(self.plant_id)
         except Exception as err:  # pylint: disable=broad-except
             if is_auth_error(err):
                 raise ConfigEntryAuthFailed(f"iSolarCloud user-account login failed: {err}") from err
@@ -363,7 +363,8 @@ class SungrowPlantCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                 return self.data
             raise UpdateFailed(f"iSolarCloud user-account poll failed: {err}") from err
         self._last_successful_update = self.hass.loop.time()
-        return self.data or {}
+        points = map_plant_detail_to_points(detail)
+        return normalize_energy_units(tag_source(points, "cloud_user"))
 
     async def _async_apply_derived_daily_yield(self, data: dict[str, Any]) -> dict[str, Any]:
         """Replace Modbus ``daily_yield`` with total_yield − start-of-local-day baseline.

--- a/custom_components/sungrow/manifest.json
+++ b/custom_components/sungrow/manifest.json
@@ -21,7 +21,7 @@
   ],
   "quality_scale": "platinum",
   "requirements": [
-    "sungrow-isolarcloud==0.11.0",
+    "sungrow-isolarcloud==0.12.0",
     "pymodbus>=3.6.0"
   ],
   "version": "4.1.0",

--- a/custom_components/sungrow/user_realtime.py
+++ b/custom_components/sungrow/user_realtime.py
@@ -1,0 +1,75 @@
+"""Map the user-account ``getPsDetail`` payload onto the measure-point model (#269).
+
+The unofficial app/web API returns a flat plant-detail dict rather than the OAuth
+realtime shape. The measure points arrive as ``p<ID>_map`` / ``p<ID>_map_virgin`` pairs
+(the ``_virgin`` variant carries the raw value in its base unit, e.g. ``Wh``) keyed by the
+same measure-point IDs the integration's catalog already knows, plus a handful of named
+plant-level fields (``curr_power`` etc). This module turns that into the integration's
+``{code: {id, code, value, unit}}`` realtime shape so the existing naming/classification
+(``resolve_name`` / ``resolve_classification``, keyed on point ID) produces correctly
+named, correctly classified sensors. Energy-unit normalisation is applied by the caller.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Any
+
+# ``p83106_map_virgin`` -> point id 83106 (raw value in its base unit — preferred).
+_VIRGIN_RE = re.compile(r"^p(\d+)_map_virgin$")
+# ``p83106_map`` -> point id 83106 (display value — fallback when no _virgin exists).
+_MAP_RE = re.compile(r"^p(\d+)_map$")
+
+# Named plant-level dict fields ({value, unit}) exposed with a stable code. These are
+# not catalog point IDs, so the code doubles as the naming/classification key.
+_NAMED_DICT_FIELDS: dict[str, str] = {
+    "curr_power": "current_power",
+    "month_energy": "month_energy",
+}
+# Named scalar diagnostic fields exposed as plain (unitless) sensors.
+_NAMED_SCALAR_FIELDS: dict[str, str] = {
+    "alarm_count": "alarm_count",
+    "fault_count": "fault_count",
+}
+
+
+def map_plant_detail_to_points(detail: dict[str, Any]) -> dict[str, Any]:
+    """Convert a ``getPsDetail`` ``result_data`` dict to the realtime point shape.
+
+    Prefers the raw ``p<ID>_map_virgin`` value (explicit base unit) over the display
+    ``p<ID>_map``; skips empty values. Returns ``{code: {id, code, value, unit}}``.
+    """
+    raw: dict[str, tuple[Any, Any]] = {}
+    # Pass 1: raw (virgin) values win — they carry the real base unit.
+    for key, val in detail.items():
+        if not isinstance(val, dict):
+            continue
+        m = _VIRGIN_RE.match(key)
+        if m:
+            raw[m.group(1)] = (val.get("value"), val.get("unit"))
+    # Pass 2: display values only for point IDs without a virgin variant.
+    for key, val in detail.items():
+        if not isinstance(val, dict):
+            continue
+        m = _MAP_RE.match(key)
+        if m and m.group(1) not in raw:
+            raw[m.group(1)] = (val.get("value"), val.get("unit"))
+
+    points: dict[str, Any] = {}
+    for point_id, (value, unit) in raw.items():
+        if value in (None, ""):
+            continue
+        code = f"p{point_id}"
+        points[code] = {"id": point_id, "code": code, "value": value, "unit": unit or ""}
+
+    for field, code in _NAMED_DICT_FIELDS.items():
+        val = detail.get(field)
+        if isinstance(val, dict) and val.get("value") not in (None, ""):
+            points[code] = {"id": code, "code": code, "value": val.get("value"), "unit": val.get("unit") or ""}
+
+    for field, code in _NAMED_SCALAR_FIELDS.items():
+        val = detail.get(field)
+        if val is not None and val != "":
+            points[code] = {"id": code, "code": code, "value": val, "unit": ""}
+
+    return points

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -11,5 +11,5 @@ ruff==0.15.21
 mypy==2.2.0
 
 # Component dependencies
-sungrow-isolarcloud==0.11.0
+sungrow-isolarcloud==0.12.0
 pymodbus==3.13.1

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -1343,16 +1343,24 @@ async def test_ess_mppt_ids_have_no_code_collision(hass: HomeAssistant):
 # ---------------------------------------------------------------------------
 
 
-async def test_user_update_success_returns_empty(hass: HomeAssistant):
-    """A cloud_user coordinator authenticates and returns no measure points yet (Phase 2)."""
+async def test_user_update_maps_plant_detail_points(hass: HomeAssistant):
+    """A cloud_user coordinator maps getPsDetail onto measure points (#269)."""
     client = MagicMock()
-    client.async_get_token = AsyncMock(return_value="T")
+    client.async_get_plant_detail = AsyncMock(
+        return_value={
+            "curr_power": {"value": "3200", "unit": "W"},
+            "p83106_map_virgin": {"value": "12500", "unit": "Wh"},
+        }
+    )
     coordinator = SungrowPlantCoordinator(hass, _make_entry(), None, "12345", "Test Plant", user_auth=client)
 
     data = await coordinator._async_update_data()
 
-    assert data == {}
-    client.async_get_token.assert_awaited_once()
+    client.async_get_plant_detail.assert_awaited_once_with("12345")
+    assert data["current_power"]["value"] == "3200"
+    assert data["current_power"]["source"] == "cloud_user"
+    # The p83106 measure point is present (Wh normalised to kWh downstream).
+    assert "p83106" in data
 
 
 async def test_user_update_auth_error_triggers_reauth(hass: HomeAssistant):
@@ -1361,7 +1369,7 @@ async def test_user_update_auth_error_triggers_reauth(hass: HomeAssistant):
     from pysolarcloud import AuthError
 
     client = MagicMock()
-    client.async_get_token = AsyncMock(side_effect=AuthError({"error": "user_login_failed"}))
+    client.async_get_plant_detail = AsyncMock(side_effect=AuthError({"error": "user_login_failed"}))
     coordinator = SungrowPlantCoordinator(hass, _make_entry(), None, "12345", "Test Plant", user_auth=client)
 
     with pytest.raises(ConfigEntryAuthFailed):
@@ -1371,7 +1379,7 @@ async def test_user_update_auth_error_triggers_reauth(hass: HomeAssistant):
 async def test_user_update_transient_rides_grace_window(hass: HomeAssistant):
     """A transient user-account failure keeps last-good data within the grace window (#268/#152)."""
     client = MagicMock()
-    client.async_get_token = AsyncMock(side_effect=RuntimeError("network blip"))
+    client.async_get_plant_detail = AsyncMock(side_effect=RuntimeError("network blip"))
     coordinator = SungrowPlantCoordinator(hass, _make_entry(), None, "12345", "Test Plant", user_auth=client)
     coordinator.data = {"total_active_power": {"value": "1.2"}}
     coordinator._last_successful_update = hass.loop.time()  # recent success

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -1047,6 +1047,7 @@ async def test_setup_cloud_user_entry(hass: HomeAssistant):
     client = MagicMock()
     client.async_get_plants = AsyncMock(return_value=[{"ps_id": 5, "ps_name": "Home"}])
     client.async_get_token = AsyncMock(return_value="T")
+    client.async_get_plant_detail = AsyncMock(return_value={"curr_power": {"value": "3200", "unit": "W"}})
 
     with patch("custom_components.sungrow.UserAuth", return_value=client):
         assert await hass.config_entries.async_setup(entry.entry_id)

--- a/tests/test_user_realtime.py
+++ b/tests/test_user_realtime.py
@@ -1,0 +1,55 @@
+"""Tests for the user-account getPsDetail -> measure-point mapper (#269)."""
+
+from custom_components.sungrow.user_realtime import map_plant_detail_to_points
+
+
+def test_maps_named_current_power():
+    """curr_power becomes a current_power point with its unit."""
+    points = map_plant_detail_to_points({"curr_power": {"value": "3200", "unit": "W"}})
+    assert points["current_power"] == {"id": "current_power", "code": "current_power", "value": "3200", "unit": "W"}
+
+
+def test_prefers_virgin_raw_value_over_display():
+    """The raw _map_virgin value (real base unit) wins over the display _map value."""
+    detail = {
+        "p83106_map": {"value": "12.5", "unit": ""},
+        "p83106_map_virgin": {"value": "12500", "unit": "Wh"},
+    }
+    points = map_plant_detail_to_points(detail)
+    assert points["p83106"] == {"id": "83106", "code": "p83106", "value": "12500", "unit": "Wh"}
+
+
+def test_falls_back_to_map_without_virgin():
+    """A point with only a display _map field is still mapped."""
+    points = map_plant_detail_to_points({"p83022_map": {"value": "5230", "unit": "W"}})
+    assert points["p83022"] == {"id": "83022", "code": "p83022", "value": "5230", "unit": "W"}
+
+
+def test_scalar_counts_mapped_unitless():
+    """alarm_count / fault_count become unitless diagnostic points."""
+    points = map_plant_detail_to_points({"alarm_count": 0, "fault_count": 2})
+    assert points["alarm_count"]["value"] == 0
+    assert points["fault_count"]["value"] == 2
+    assert points["fault_count"]["unit"] == ""
+
+
+def test_skips_empty_and_nondict_values():
+    """Empty values and non-point fields are ignored."""
+    detail = {
+        "p1_map_virgin": {"value": "", "unit": "Wh"},  # empty -> skipped
+        "p2_map": {"value": None, "unit": "W"},  # None -> skipped
+        "build_date": "2020-01-01",  # not a point field
+        "images": [],  # non-dict
+        "curr_power": {"value": "100", "unit": "W"},
+    }
+    points = map_plant_detail_to_points(detail)
+    assert "p1" not in points
+    assert "p2" not in points
+    assert set(points) == {"current_power"}
+
+
+def test_map_virgin_regex_not_confused_by_suffix():
+    """p<ID>_percent and other suffixes are not treated as points."""
+    points = map_plant_detail_to_points({"p83102_percent": "42", "p83102_map_virgin": {"value": "9", "unit": "kWh"}})
+    assert set(points) == {"p83102"}
+    assert points["p83102"]["unit"] == "kWh"


### PR DESCRIPTION
## Summary

Phase 3 of the user-account transport epic (#267). The `cloud_user` coordinator now fetches `getPsDetail` each poll (via `pysolarcloud` 0.12.0 `UserAuth.async_get_plant_detail`) and maps it onto the measure-point model — so the transport produces **real sensors**, not just a plant device.

## Changes

- **Pin → `sungrow-isolarcloud==0.12.0`** (manifest + requirements_test).
- **New `user_realtime.map_plant_detail_to_points`** — turns the flat `getPsDetail` payload into the integration's `{code: {id, code, value, unit}}` realtime shape:
  - Measure points arrive as `p<ID>_map` / `p<ID>_map_virgin` pairs keyed by point ID. The **`_virgin` raw value + base unit is preferred** (e.g. `Wh`, normalised to `kWh` downstream), keyed by point ID so the existing `resolve_name` / `resolve_classification` name and classify them correctly.
  - Named fields (`curr_power` → `current_power`, `month_energy`) and diagnostic counts (`alarm_count`/`fault_count`).
- **`coordinator._async_user_update`** — fetch detail → map → tag `source=cloud_user` → normalise energy units. `AuthError` → reauth; transient → availability grace (unchanged).

## Grounding

The mapping is based on a **read-only live probe** of a real account's `getPsDetail` (147 fields: `curr_power` W, `month_energy`, `design_capacity`, counts, and the `p83xxx_map`/`_virgin` measure-point fields).

## Testing

- New `test_user_realtime.py` (virgin-preferred, `_map` fallback, named/scalar fields, empty/non-point skipping, suffix regex safety).
- Coordinator user-path tests updated to assert mapped points + `source`.
- Full suite **608 passed**; `ruff` + `mypy` clean.

## Scope note

First data cut: `p<ID>` measure points get correct names/classes/units via the catalog, but entity IDs are `p<ID>`-based rather than matching the OAuth transport's code names — exact cross-transport entity-ID parity is a later refinement. Runtime validation via a dev build recommended (values sanity-checked against the live probe).

Closes #269.