### PR TITLE
docs: document the cloud_user (user-account) transport (#270)

### DIFF
--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -143,6 +143,24 @@ when iSolarCloud rejects requests for a reason you can act on:
 
 ---
 
+## User-account (unofficial) login fails or shows "account or password incorrect"
+
+The **Cloud (user account)** transport logs in with your normal iSolarCloud email/password
+via the unofficial app/web API. If setup (or reauth) fails:
+
+- **"account or password incorrect" — check the region first.** This is most often a
+  **wrong region**, not a wrong password: logging in against the wrong regional gateway
+  returns that message. Pick the region your account actually uses (the same one you log
+  into on the iSolarCloud app/web). Repeated failed attempts can temporarily **lock the
+  account**, so confirm the region before retrying.
+- **Confirm the credentials** are exactly what works in the official app (no stray spaces).
+- If it worked before and suddenly fails, the unofficial API may have changed — the
+  transport is experimental. The developer **Cloud-only** transport is the robust option.
+- This transport is **read-only** and surfaces plant-level data only; for dispatch/control
+  or per-device sensors, use the developer Cloud-only transport.
+
+---
+
 ## Sensors update too often / not often enough
 
 The default polling interval is **5 minutes**. You can change it:

--- a/docs/index.md
+++ b/docs/index.md
@@ -21,6 +21,9 @@ inverters** through the **iSolarCloud** cloud API, using the
   [Local Modbus](local-modbus.md).
 - **Auto-discovery** — finds every plant linked to your account, and discovers WiNet-S
   dongles on the network for local Modbus.
+- **User-account login (unofficial)** — connect with your normal iSolarCloud email +
+  password, without registering a developer application. Read-only, experimental — see
+  [Local Modbus & transport modes](local-modbus.md#cloud-user-account-unofficial).
 - **Rich sensors** — power, energy, battery SOC, and more, with correct device/state classes so
   they work in the Energy dashboard out of the box. See the
   [Model support matrix](model-support.md) for what each inverter family reports.

--- a/docs/local-modbus.md
+++ b/docs/local-modbus.md
@@ -39,9 +39,23 @@ the cloud plant in the device registry (`via_device`) — a soft “related to�
 
 | Mode | Data source | Cloud account | Control (dispatch) | Best for |
 | --- | --- | --- | --- | --- |
-| **Cloud-only** | iSolarCloud API | Required | ✅ Yes | Full plant sensors and battery/dispatch controls. |
+| **Cloud-only** | iSolarCloud OpenAPI | Developer app (App Key/Secret/ID) | ✅ Yes | Full plant sensors and battery/dispatch controls. |
+| **Cloud (user account)** *(unofficial)* | iSolarCloud app/web API | Just email + password | ❌ Not yet | No developer app — quickest cloud setup. See caveats below. |
 | **Modbus-only** *(local)* | Local Modbus only | **Not needed** | ❌ Read-only | Fast local metrics, offline / privacy-first. |
 | **Both** *(two entries)* | Each entry its own source | Cloud entry only | Via **cloud** entry | Compare or use cloud + local side by side. |
+
+### Cloud user account (unofficial)
+
+If you don't have (or don't want to register) an iSolarCloud **developer application**, you can connect with the **normal email + password** you use in the iSolarCloud app/web portal. Choose **Cloud (user account, unofficial)** as the transport and enter your email, password and region.
+
+!!! warning "Unofficial and experimental"
+    This uses Sungrow's **undocumented app/web API**, not the official OpenAPI. It may change or stop working without notice, and its use may be subject to Sungrow's terms of service. Your password is stored in the Home Assistant config entry and is never logged. Prefer the developer **Cloud-only** transport if you can.
+
+Current limitations:
+
+- **Plant-level data only** so far (e.g. current power, daily/total yield, alarm/fault counts) — from the `getPsDetail` endpoint. Per-device and richer measure points may follow.
+- **No dispatch/control** — read-only. Use the developer Cloud-only transport for charge/discharge and other controls.
+- If login fails with "account or password incorrect", it's most often the **wrong region** — pick the region your account actually uses.
 
 ```mermaid
 flowchart LR

--- a/docs/model-support.md
+++ b/docs/model-support.md
@@ -45,6 +45,15 @@ single-phase; `RT` / `T` / `CX` = three-phase.
 return are simply skipped (no broken entities). Battery rows depend on a battery actually
 being present — the dispatch battery controls are hidden on PV-only plants for safety.
 
+## Data sources
+
+Any model can be connected through one of several transports (see
+[transport modes](local-modbus.md#transport-modes)): the official **developer Cloud** (OAuth,
+full sensors + dispatch), an **unofficial user-account Cloud** login (email/password, read-only
+plant-level data, [experimental](local-modbus.md#cloud-user-account-unofficial)), and **local
+Modbus**. The matrix below describes what a model reports; which of those datapoints you actually
+get also depends on the transport.
+
 ## Cloud vs local Modbus
 
 Most points are available over both the cloud API and local Modbus (WiNet-S), but coverage


### PR DESCRIPTION
## Summary

Phase 4 (final) of the user-account transport epic (#267) — user-facing docs, now that the transport actually surfaces data (Phases 2 #275 + 3 #276).

## Changes

- **`local-modbus.md`** — extends the transport comparison to **four modes** and adds a **"Cloud user account (unofficial)"** section: email/password setup, no developer app required, a prominent **unofficial / ToS / brittleness** warning, and current limitations (plant-level data only, read-only/no dispatch, the region-mismatch "wrong password" gotcha).
- **`index.md`** — feature bullet for the user-account login.
- **`TROUBLESHOOTING.md`** — user-account login failures: **check the region first** (the common cause of "account or password incorrect") and the lockout caution.
- **`model-support.md`** — a "Data sources" note covering developer Cloud / user-account Cloud / local Modbus.

## Validation

`zensical build --clean` → **No issues found** (anchors/links resolve). Docs-only.

Closes #270 — completes the user-account transport milestone (#6).