### PR TITLE
fix(cloud_user): resolve realtime point names via the catalog (#269)

### DIFF
--- a/custom_components/sungrow/measure_points.py
+++ b/custom_components/sungrow/measure_points.py
@@ -74,6 +74,7 @@ _UNIT_CLASS_MAP: dict[str, _ClassPair] = {
     "w/m^2": (SensorDeviceClass.IRRADIANCE, _MEASUREMENT),
     "h": (SensorDeviceClass.DURATION, _MEASUREMENT),
     # Numeric-but-no-HA-device-class units: classify as plain numeric so they graph.
+    "wp": (None, _MEASUREMENT),
     "varh": (None, _TOTAL_INCREASING),
     "kω": (None, _MEASUREMENT),
     "ω": (None, _MEASUREMENT),

--- a/custom_components/sungrow/measure_points_data.py
+++ b/custom_components/sungrow/measure_points_data.py
@@ -510,6 +510,8 @@ RAW_POINTS: list[tuple[str, str, str]] = [
     ("83119", "Daily Feed-in Energy (PV)", "Wh"),
     ("83072", "Feed-in Energy Today", "Wh"),
     ("83075", "Feed-in Energy Total", "Wh"),
+    # Nameplate PV capacity in watt-peak (surfaced by the user-account getPsDetail, #269).
+    ("83202", "Nominal Power", "Wp"),
     ("83252", "Battery Level (SOC)", ""),
     ("83129", "Battery SOC", ""),
     ("83232", "Total field SOC", ""),

--- a/custom_components/sungrow/user_realtime.py
+++ b/custom_components/sungrow/user_realtime.py
@@ -5,9 +5,10 @@ realtime shape. The measure points arrive as ``p<ID>_map`` / ``p<ID>_map_virgin`
 (the ``_virgin`` variant carries the raw value in its base unit, e.g. ``Wh``) keyed by the
 same measure-point IDs the integration's catalog already knows, plus a handful of named
 plant-level fields (``curr_power`` etc). This module turns that into the integration's
-``{code: {id, code, value, unit}}`` realtime shape so the existing naming/classification
-(``resolve_name`` / ``resolve_classification``, keyed on point ID) produces correctly
-named, correctly classified sensors. Energy-unit normalisation is applied by the caller.
+``{code: {id, code, value, unit}}`` realtime shape. Measure points use the *bare numeric*
+point ID as their code so ``resolve_name`` / ``resolve_classification`` take the digit-code
+catalog path and produce the same English names/entity slugs the OAuth transport gives
+(#269). Energy-unit normalisation is applied by the caller.
 """
 
 from __future__ import annotations
@@ -59,8 +60,11 @@ def map_plant_detail_to_points(detail: dict[str, Any]) -> dict[str, Any]:
     for point_id, (value, unit) in raw.items():
         if value in (None, ""):
             continue
-        code = f"p{point_id}"
-        points[code] = {"id": point_id, "code": code, "value": value, "unit": unit or ""}
+        # Use the bare numeric point ID as the code so the resolver's digit-code path
+        # (``resolve_name``) consults the measure-point catalog and produces the same
+        # English name/entity slug the OAuth transport gives (#269). A ``p<ID>`` code is
+        # non-numeric and would fall back to an opaque "P<ID>" title-case name.
+        points[point_id] = {"id": point_id, "code": point_id, "value": value, "unit": unit or ""}
 
     for field, code in _NAMED_DICT_FIELDS.items():
         val = detail.get(field)

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -1359,8 +1359,8 @@ async def test_user_update_maps_plant_detail_points(hass: HomeAssistant):
     client.async_get_plant_detail.assert_awaited_once_with("12345")
     assert data["current_power"]["value"] == "3200"
     assert data["current_power"]["source"] == "cloud_user"
-    # The p83106 measure point is present (Wh normalised to kWh downstream).
-    assert "p83106" in data
+    # The 83106 measure point is present (Wh normalised to kWh downstream).
+    assert "83106" in data
 
 
 async def test_user_update_auth_error_triggers_reauth(hass: HomeAssistant):

--- a/tests/test_user_realtime.py
+++ b/tests/test_user_realtime.py
@@ -1,6 +1,20 @@
 """Tests for the user-account getPsDetail -> measure-point mapper (#269)."""
 
+from custom_components.sungrow.measure_points import resolve_name
 from custom_components.sungrow.user_realtime import map_plant_detail_to_points
+
+
+def test_mapped_codes_resolve_to_catalog_names():
+    """Bare-numeric codes let resolve_name find the catalog name (OAuth parity, #269)."""
+    detail = {
+        "p83124_map_virgin": {"value": "2923100", "unit": "Wh"},  # Total Load Consumption
+        "p83202_map_virgin": {"value": "3600", "unit": "Wp"},  # Nominal Power
+    }
+    points = map_plant_detail_to_points(detail)
+    total_load = points["83124"]
+    assert resolve_name(total_load["id"], total_load["code"], None) == "Total Load Consumption"
+    nameplate = points["83202"]
+    assert resolve_name(nameplate["id"], nameplate["code"], None) == "Nominal Power"
 
 
 def test_maps_named_current_power():
@@ -16,13 +30,13 @@ def test_prefers_virgin_raw_value_over_display():
         "p83106_map_virgin": {"value": "12500", "unit": "Wh"},
     }
     points = map_plant_detail_to_points(detail)
-    assert points["p83106"] == {"id": "83106", "code": "p83106", "value": "12500", "unit": "Wh"}
+    assert points["83106"] == {"id": "83106", "code": "83106", "value": "12500", "unit": "Wh"}
 
 
 def test_falls_back_to_map_without_virgin():
     """A point with only a display _map field is still mapped."""
     points = map_plant_detail_to_points({"p83022_map": {"value": "5230", "unit": "W"}})
-    assert points["p83022"] == {"id": "83022", "code": "p83022", "value": "5230", "unit": "W"}
+    assert points["83022"] == {"id": "83022", "code": "83022", "value": "5230", "unit": "W"}
 
 
 def test_scalar_counts_mapped_unitless():
@@ -43,13 +57,13 @@ def test_skips_empty_and_nondict_values():
         "curr_power": {"value": "100", "unit": "W"},
     }
     points = map_plant_detail_to_points(detail)
-    assert "p1" not in points
-    assert "p2" not in points
+    assert "1" not in points
+    assert "2" not in points
     assert set(points) == {"current_power"}
 
 
 def test_map_virgin_regex_not_confused_by_suffix():
     """p<ID>_percent and other suffixes are not treated as points."""
     points = map_plant_detail_to_points({"p83102_percent": "42", "p83102_map_virgin": {"value": "9", "unit": "kWh"}})
-    assert set(points) == {"p83102"}
-    assert points["p83102"]["unit"] == "kWh"
+    assert set(points) == {"83102"}
+    assert points["83102"]["unit"] == "kWh"


### PR DESCRIPTION
## What

Fixes the `cloud_user` transport so realtime measure points get proper English names instead of opaque `P<ID>` labels.

## Why

Validated `v4.2.0-rc.7` live against a real user account. The `getPsDetail` payload returned 8 measure points, but they surfaced as `sensor.<plant>_p83124` named "P83124" etc. Root cause: the mapper emitted a `p<ID>` code, and `resolve_name` only consults the point catalog when the code is all-digits — the `p` prefix defeated resolution.

## Changes

- `user_realtime.py`: emit the **bare numeric point ID** as the code, so the digit-code catalog path fires and produces the same names/entity slugs as the OAuth transport (#269 parity).
- `measure_points_data.py`: catalog point `83202` → "Nominal Power" (Wp nameplate capacity, seen live).
- `measure_points.py`: classify the `Wp` unit as a plain numeric measurement so it graphs.
- Tests updated for the new codes; added a resolver-parity test.

With this, the 6 catalogued live points resolve correctly (e.g. `83124`→"Total Load Consumption", `83118`→"Daily Load Consumption", `83106`→"Load Power (2)", `83102`→"Energy Purchased Today", `83072`→"Feed-in Energy Today", `83202`→"Nominal Power"). One uncatalogued point (`83123`) still falls back generically pending identification.

## Verification

- `ruff check` / `ruff format --check` clean
- `mypy` clean (strict)
- `pytest`: 609 passed, 3 deselected
- Live getPsDetail probe against a real account (read-only)

Refs #269, epic #267.
