### PR TITLE
ci: prune superseded rc/pr pre-releases consistently

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -326,6 +326,29 @@ jobs:
           fi
           gh pr edit "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" --add-label "dev-release-cut"
 
+      # Each push to the PR mints a fresh vX.Y.Z-pr.<PR>.<run> build; the newest one
+      # supersedes the rest. Prune the older builds for this PR now rather than leaving
+      # them until the PR closes (cleanup-pr-release.yml) or the weekly sweep.
+      - name: Prune superseded builds for this PR
+        if: steps.prerelease.outputs.available == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          KEEP_TAG: ${{ steps.tag.outputs.tag }}
+        run: |
+          echo "Keeping ${KEEP_TAG}; pruning older pr.${PR_NUMBER} builds."
+          gh release list --limit 1000 --json tagName,isPrerelease \
+            --jq '.[] | select(.isPrerelease) | .tagName' \
+          | { grep -E "^v[0-9]+\\.[0-9]+\\.[0-9]+-pr\\.${PR_NUMBER}\\." || true; } \
+          | while read -r tag; do
+              if [ "$tag" = "$KEEP_TAG" ]; then
+                continue
+              fi
+              echo "Deleting superseded PR pre-release: ${tag}"
+              gh release delete "$tag" --yes --cleanup-tag || true
+            done
+
   # Main release-candidate dev builds — a push to main that changed the component,
   # once CI is green. Never for the "chore(main): release X.Y.Z" commit (matched via
   # ": release ") which release-please lands when its PR merges.
@@ -426,6 +449,7 @@ jobs:
             done
 
       - name: Create pre-release
+        id: create
         if: ${{ steps.tag.outputs.skip != 'true' }}
         env:
           GH_TOKEN: ${{ github.token }}
@@ -526,6 +550,9 @@ jobs:
               export TAG COMMIT_SHA
               bash scripts/verify-dev-release-target.sh
               echo "Created ${TAG} -> ${SYNTHETIC_SHA} (base ${BASE_SHA}, version ${DEV_VERSION})"
+              # Publish the tag actually created (RC_NUMBER may have rolled over on
+              # collision) so the follow-up prune keeps the right one.
+              echo "created_tag=${TAG}" >> "$GITHUB_OUTPUT"
               exit 0
             fi
             echo "gh release create failed for ${TAG} (attempt ${attempt}):"
@@ -540,3 +567,27 @@ jobs:
           done
           echo "Exhausted ${max_attempts} RC tag attempts without creating a release." >&2
           exit 1
+
+      # The RC just created supersedes every earlier RC of the same version line, so
+      # prune them immediately instead of leaving the long tail for the weekly sweep.
+      # Cross-version RCs were already pruned before creation; this keeps only the
+      # newest RC of the current line (new vX.Y.Z-rc.N and legacy dev-vX.Y.Z-rc.N).
+      - name: Prune superseded RCs of this version line
+        if: ${{ steps.tag.outputs.skip != 'true' && steps.create.outputs.created_tag != '' }}
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+          VERSION: ${{ steps.tag.outputs.base_version }}
+          KEEP_TAG: ${{ steps.create.outputs.created_tag }}
+        run: |
+          echo "Keeping ${KEEP_TAG}; pruning older RCs of v${VERSION}."
+          gh release list --limit 1000 --json tagName,isPrerelease \
+            --jq '.[] | select(.isPrerelease) | .tagName' \
+          | { grep -E "^(dev-)?v${VERSION}-rc\\.[0-9]+$" || true; } \
+          | while read -r tag; do
+              if [ "$tag" = "$KEEP_TAG" ]; then
+                continue
+              fi
+              echo "Deleting superseded RC pre-release: ${tag}"
+              gh release delete "$tag" --yes --cleanup-tag || true
+            done

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -62,17 +62,24 @@ jobs:
                   echo "Verified sungrow.zip is attached to ${TAG}."
 
             # A published release supersedes every dev build. Prune them all so only
-            # the real release remains (rc builds + any leftover branch builds).
+            # the real release remains. Covers both the current tag schemes
+            # (vX.Y.Z-rc.N release candidates, vX.Y.Z-pr.P.R PR builds) and the legacy
+            # dev-* scheme — matching the weekly sweep in cleanup-dev-releases.yml.
             - name: Prune all dev pre-releases on a real release
               if: ${{ steps.release.outputs.release_created == 'true' }}
               env:
                   GH_TOKEN: ${{ github.token }}
                   GH_REPO: ${{ github.repository }}
               run: |
-                  echo "Release created; deleting all dev-* pre-releases."
+                  echo "Release created; deleting all dev pre-releases (rc / pr / legacy dev-*)."
                   gh release list --limit 1000 --json tagName,isPrerelease \
-                    --jq '.[] | select(.isPrerelease and (.tagName | startswith("dev-"))) | .tagName' \
+                    --jq '.[] | select(.isPrerelease) | .tagName' \
                   | while read -r tag; do
+                      case "$tag" in
+                        dev-*) ;;
+                        v[0-9]*.[0-9]*.[0-9]*-rc.*|v[0-9]*.[0-9]*.[0-9]*-pr.*) ;;
+                        *) continue ;;
+                      esac
                       echo "Deleting ${tag}"
                       gh release delete "$tag" --yes --cleanup-tag
                     done


### PR DESCRIPTION
## What

Makes dev-pre-release pruning consistent across the release lifecycle so superseded builds don't linger.

## The gap

`release-please.yml`'s "Prune all dev pre-releases on a real release" only matched **legacy `dev-*`** tags. The current schemes — `vX.Y.Z-rc.N` (main RCs) and `vX.Y.Z-pr.P.R` (PR builds) — were left behind on a real release, despite the step's comment claiming it prunes "rc builds + any leftover branch builds". That's why e.g. `v4.2.0-rc.7` would survive shipping `4.2.0` until the 30-day sweep.

## Changes

- **release-please.yml**: prune step now deletes every dev pre-release (`vX.Y.Z-rc.*`, `vX.Y.Z-pr.*`, legacy `dev-*`), using the same tag shapes as the weekly `cleanup-dev-releases.yml` sweep.
- **ci.yml (main RC job)**: after successfully creating the new RC, prune older RCs of the *same* version line, keeping only the just-created tag. The create step now outputs the actual `created_tag` (RC number can roll over on tag collision), and `next-main-rc-number.sh` stays monotonic because the highest RC is always retained.
- **ci.yml (PR job)**: after creating the new PR build, prune this PR's older builds instead of waiting for PR-close cleanup.

## Coverage after this change

| Trigger | Prunes |
| --- | --- |
| New main RC cut | other-version RCs (before) + older same-line RCs (after) |
| New PR build | older builds for that PR |
| PR closed | that PR's builds (`cleanup-pr-release.yml`) |
| Real release | **all** dev pre-releases (rc / pr / legacy) |
| Weekly | any dev pre-release >30d (backstop) |

pysolarcloud has no dev-pre-release scheme (pure PyPI via release-please), so no change there.

## Verification

- YAML parses for both workflows.
- Shell patterns mirror the existing, working `cleanup-*.yml` and `next-main-rc-number.sh` conventions.
- Monotonic RC numbering preserved (highest RC always kept; `matching-refs` still counts orphaned/immutable tags).
