### PR TITLE
fix(cloud_user): catalog plant point 83123 as total feed-in

### DIFF
--- a/custom_components/sungrow/measure_points_data.py
+++ b/custom_components/sungrow/measure_points_data.py
@@ -508,6 +508,9 @@ RAW_POINTS: list[tuple[str, str, str]] = [
     ("83118", "Daily Load Consumption", "Wh"),
     ("83124", "Total Load Consumption", "Wh"),
     ("83119", "Daily Feed-in Energy (PV)", "Wh"),
+    # User-cloud getPsDetail / household report virtual total feed-in (#281).
+    # Same quantity as open-API 83075; app path surfaces it as p83123_map.
+    ("83123", "Total Feed-in Energy (PV)", "Wh"),
     ("83072", "Feed-in Energy Today", "Wh"),
     ("83075", "Feed-in Energy Total", "Wh"),
     # Nameplate PV capacity in watt-peak (surfaced by the user-account getPsDetail, #269).

--- a/docs/SENSORS.md
+++ b/docs/SENSORS.md
@@ -38,6 +38,7 @@ The **plant** is a *service* device (no physical hardware of its own) that ancho
 | Usage from Grid | `grid_active_power` or `grid_active_power_ems` | Positive = importing, negative = exporting. |
 | Daily Solar Yield | `daily_yield` / `inverter_daily_yield` / `daily_pv_yield_ems` | Resets at midnight local time. |
 | Daily Feed-in | `feed_in_energy_today` / `daily_feed_in_energy_pv` | Energy exported to the grid today. |
+| Total Feed-in | `feed_in_energy_total` / point `83123` (*Total Feed-in Energy (PV)*) | Lifetime export; user-cloud `getPsDetail` uses **83123**, open API often **83075**. |
 | Daily Import | `energy_purchased_today` / `total_purchased_energy` | Energy imported from the grid today. |
 
 ## Battery-specific points

--- a/tests/test_measure_points.py
+++ b/tests/test_measure_points.py
@@ -302,3 +302,11 @@ def test_resolve_name_readable_code_title_cases():
 def test_resolve_name_unknown_numeric_falls_back():
     assert mp.resolve_name("99999", "99999", None) == "Sensor 99999"
     assert mp.resolve_name("99999", "99999", "Some API Name") == "Some API Name"
+
+
+def test_resolve_name_83123_total_feed_in_energy():
+    """Plant point 83123 is total feed-in on the user-cloud path (#281)."""
+    assert mp.resolve_name("83123", "83123", None) == "Total Feed-in Energy (PV)"
+    assert "83123" in mp.POINT_CATALOG
+    info = mp.POINT_CATALOG["83123"]
+    assert info.name == "Total Feed-in Energy (PV)"


### PR DESCRIPTION
## Summary

Closes #281.

User-account (`cloud_user`) plants expose measure point **83123** via `getPsDetail` (`p83123_map`). It was not in `RAW_POINTS`, so `resolve_name` fell back to **"Sensor 83123"** (e.g. `7 Example Close Sensor 83123`).

Live `getHouseholdStoragePsReport` `total_data` shows `p83123_map` equals both `feed_in_energy_map` and open-API point **83075** (*Feed-in Energy Total*). It is the lifetime total paired with **83119** (*Daily Feed-in Energy (PV)*).

This PR adds:

```python
("83123", "Total Feed-in Energy (PV)", "Wh"),
```

to the measure-point catalog, with a unit test and a short `docs/SENSORS.md` note.

Unique IDs stay `plant_id_83123` (history preserved); after upgrade/reload the friendly name becomes **Total Feed-in Energy (PV)**.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change
- [x] Documentation / chore

## Checklist

- [x] `ruff check custom_components/` passes *(not run in this change set; touch is data-only)*
- [x] `pytest tests/test_measure_points.py` passes (69 passed)
- [x] New/changed behaviour covered by tests
- [x] Documentation updated (`docs/SENSORS.md`)

