### PR TITLE
fix(dispatch): default Forced Dispatch Duration to 60 minutes

### DIFF
--- a/custom_components/sungrow/number.py
+++ b/custom_components/sungrow/number.py
@@ -299,12 +299,14 @@ class SungrowDispatchNumber(CoordinatorEntity[SungrowPlantCoordinator], RestoreN
         self._attr_native_value = value
 
 
-# Default duration (minutes) for a forced Charge/Discharge before auto-revert (#157).
-DEFAULT_FORCED_DISPATCH_DURATION = 0  # 0 = auto-revert disabled (legacy behaviour)
+# Default duration (minutes) for a forced Charge/Discharge before auto-revert (#157 / #255).
+# A non-zero default means forced commands always have a bounded lifetime out of the box;
+# users can still set 0 to opt out of auto-revert.
+DEFAULT_FORCED_DISPATCH_DURATION = 60
 
 
 class SungrowForcedDispatchDurationNumber(CoordinatorEntity[SungrowPlantCoordinator], RestoreNumber):
-    """Local number controlling the forced-dispatch auto-revert timeout (#157).
+    """Local number controlling the forced-dispatch auto-revert timeout (#157 / #255).
 
     Unlike the other dispatch numbers this writes *nothing* to the inverter — it only
     records, on the coordinator, how long a forced Charge/Discharge command may stay

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -140,6 +140,11 @@ when iSolarCloud rejects requests for a reason you can act on:
   again; if it persists, your account/model may not support cloud dispatch (some
   require External-EMS to be enabled). The Repair clears once a command is confirmed
   applied or you Stop dispatch.
+- **Forced Charge/Discharge ends on its own.** That is intentional. **Forced Dispatch
+  Duration** (default **60 minutes**) auto-reverts a forced **Charge**/**Discharge** to
+  **Stop** so the command cannot silently persist across hours or restarts. Raise the
+  duration if you need a longer window, or set it to **0** only if you deliberately want
+  no auto-revert (not recommended).
 
 ---
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -40,8 +40,9 @@ inverters** through the **iSolarCloud** cloud API, using the
 - **Dispatch / control** — number and select entities for charge/discharge command, power, SOC
   limits, forced charging and export/active-power limiting, with an automatic EMS heartbeat while
   dispatching. Battery controls are hidden on PV-only plants.
-- **Safer dispatch** — an optional **Forced Dispatch Duration** auto-reverts a forced
-  charge/discharge to *Stop* after a set time (surviving restarts), so it can't silently persist.
+- **Safer dispatch** — **Forced Dispatch Duration** (default **60 minutes**) auto-reverts a
+  forced charge/discharge to *Stop* after a set time (surviving restarts), so it can't silently
+  persist. Set the duration to `0` only if you intentionally want unbounded forced commands.
 - **Resilient polling** — rides out brief API/network hiccups instead of flapping unavailable, and
   auto-backs-off when rate-limited.
 - **Guided repairs** — whitelist and rate-limit rejections, an unexpectedly-stopped

--- a/tests/test_dispatch.py
+++ b/tests/test_dispatch.py
@@ -969,6 +969,23 @@ async def test_forced_dispatch_duration_number_is_local(hass: HomeAssistant):
     data.control.async_update_parameters.assert_not_called()
 
 
+async def test_forced_dispatch_duration_defaults_to_safe_bound(hass: HomeAssistant):
+    """New installs default to a non-zero duration so forced commands auto-revert (#255)."""
+    from custom_components.sungrow.number import (
+        DEFAULT_FORCED_DISPATCH_DURATION,
+        SungrowForcedDispatchDurationNumber,
+    )
+
+    entry = MockConfigEntry(domain=DOMAIN, data=MOCK_CONFIG_DATA.copy())
+    entry.add_to_hass(hass)
+    data = _setup_entry_data(entry, [{"uuid": "ess-1", "device_type": "ENERGY_STORAGE_SYSTEM"}])
+    number = SungrowForcedDispatchDurationNumber(data.coordinators[0], {"uuid": "ess-1"})
+
+    assert DEFAULT_FORCED_DISPATCH_DURATION > 0
+    assert number.native_value == DEFAULT_FORCED_DISPATCH_DURATION
+    assert data.coordinators[0].forced_dispatch_duration_minutes == DEFAULT_FORCED_DISPATCH_DURATION
+
+
 async def test_charge_arms_autorevert_and_stop_cancels(hass: HomeAssistant):
     """Selecting Charge arms the auto-revert (with a persisted deadline); Stop cancels it."""
     entry = MockConfigEntry(domain=DOMAIN, data=MOCK_CONFIG_DATA.copy())


### PR DESCRIPTION
## Summary

Part of #255.

Forced Charge/Discharge already supports auto-revert to **Stop** (#157), but **Forced Dispatch Duration** defaulted to **0** (disabled). That meant new installs could leave a forced command sticky indefinitely unless the user noticed the config number — the main footgun #255 calls out.

This PR changes the default to **60 minutes**. Setting the number to **0** remains an explicit opt-out.

Existing installations that already restored a stored duration are unchanged (`RestoreNumber`).

Also updates docs (`index.md`, `TROUBLESHOOTING.md`) and adds a regression test for the default.

## Remaining for #255

Not in this PR (breaking / larger scope):
- Single **battery mode** select replacing raw charge/discharge + EMS registers
- Services for scheduled / tariff-driven dispatch

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change
- [x] Documentation / chore

## Checklist

- [x] `pytest tests/test_dispatch.py -k "forced_dispatch or autorevert or charge_arms"` passes
- [x] Documentation updated
