### PR TITLE
fix: normalize kW→W for cloud_user power sensors

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@ This is a **cloud-polling** integration — it does not talk to the inverter loc
 
 Entity IDs depend on your device name — check **Settings → Devices & Services → Sungrow** for the exact IDs. The examples below assume a device called `inverter`.
 
-**Charge the battery overnight (cheap tariff), then let it discharge during the peak:**
+**Charge the battery overnight (cheap tariff), then return to self-consumption:**
 
 ```yaml
 automation:
@@ -147,27 +147,26 @@ automation:
       - trigger: time
         at: "00:30:00"
     actions:
-      - action: select.select_option
-        target:
-          entity_id: select.inverter_charge_discharge_command
-        data:
-          option: "Charge"
       - action: number.set_value
         target:
           entity_id: number.inverter_charge_discharge_power
         data:
           value: 3000
+      - action: sungrow.set_battery_mode
+        data:
+          mode: force_charge
+          duration_minutes: 300   # auto-revert after 5 hours
+          entity_id: select.inverter_battery_mode
 
-  - alias: "Battery: stop forced charge at peak start"
+  - alias: "Battery: self-consumption at peak start"
     triggers:
       - trigger: time
         at: "05:30:00"
     actions:
-      - action: select.select_option
-        target:
-          entity_id: select.inverter_charge_discharge_command
+      - action: sungrow.set_battery_mode
         data:
-          option: "Stop"
+          mode: self_consumption
+          entity_id: select.inverter_battery_mode
 ```
 
 **Notify when the battery gets low:**

--- a/custom_components/sungrow/coordinator.py
+++ b/custom_components/sungrow/coordinator.py
@@ -43,7 +43,7 @@ from .const import (
     STRING_MPPT_POINTS,
     TRANSPORT_MODBUS_ONLY,
 )
-from .energy_units import normalize_energy_units, tag_source
+from .energy_units import normalize_energy_units, normalize_power_units, tag_source
 from .model_capabilities import mppt_points_for_model, resolve_capabilities
 
 # Upper bound on a single poll's cloud calls, so a hung request can neither stall
@@ -364,7 +364,7 @@ class SungrowPlantCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             raise UpdateFailed(f"iSolarCloud user-account poll failed: {err}") from err
         self._last_successful_update = self.hass.loop.time()
         points = map_plant_detail_to_points(detail)
-        return normalize_energy_units(tag_source(points, "cloud_user"))
+        return normalize_power_units(normalize_energy_units(tag_source(points, "cloud_user")))
 
     async def _async_apply_derived_daily_yield(self, data: dict[str, Any]) -> dict[str, Any]:
         """Replace Modbus ``daily_yield`` with total_yield − start-of-local-day baseline.

--- a/custom_components/sungrow/energy_units.py
+++ b/custom_components/sungrow/energy_units.py
@@ -1,8 +1,12 @@
-"""Normalize iSolarCloud energy units for consistent HA Energy dashboard use.
+"""Normalize iSolarCloud energy/power units for consistent HA use.
 
 Plant-level points often arrive in Wh while inverter points arrive in kWh for the
 same physical quantity (e.g. total_yield 6_467_800 Wh vs 6467.8 kWh). Converting
 Wh → kWh keeps related entities comparable and avoids mixed-unit Energy config.
+
+The cloud_user ``getPsDetail`` path returns power values in kW while the OAuth
+realtime endpoint uses W.  ``normalize_power_units`` converts kW → W so the
+cloud_user transport produces the same unit scale as OAuth.
 """
 
 from __future__ import annotations
@@ -10,6 +14,7 @@ from __future__ import annotations
 from typing import Any
 
 _WH_UNITS = frozenset({"wh", "w·h", "w.h", "watt-hour", "watt hour", "watthour"})
+_KW_UNITS = frozenset({"kw"})
 
 
 def normalize_energy_point(point: dict[str, Any]) -> dict[str, Any]:
@@ -27,12 +32,43 @@ def normalize_energy_point(point: dict[str, Any]) -> dict[str, Any]:
     return {**point, "value": round(num / 1000.0, 3), "unit": "kWh"}
 
 
+def normalize_power_point(point: dict[str, Any]) -> dict[str, Any]:
+    """Return a copy of *point* with kW values scaled to W.
+
+    The ``getPsDetail`` API (cloud_user transport) reports instantaneous power in kW
+    while the OAuth realtime endpoint uses W.  Converting kW → W (×1000) keeps both
+    transports aligned so sensors display the correct magnitude.
+    """
+    unit = str(point.get("unit") or "").strip()
+    if unit.lower() not in _KW_UNITS:
+        return point
+    raw = point.get("value")
+    if raw is None or raw == "":
+        return {**point, "unit": "W"}
+    try:
+        num = float(raw)
+    except (TypeError, ValueError):
+        return {**point, "unit": "W"}
+    return {**point, "value": round(num * 1000.0, 3), "unit": "W"}
+
+
 def normalize_energy_units(data: dict[str, Any]) -> dict[str, Any]:
     """Normalize every point dict in a realtime payload (plant or per-device)."""
     out: dict[str, Any] = {}
     for code, point in data.items():
         if isinstance(point, dict):
             out[code] = normalize_energy_point(point)
+        else:
+            out[code] = point
+    return out
+
+
+def normalize_power_units(data: dict[str, Any]) -> dict[str, Any]:
+    """Normalize kW → W for every power point in a cloud_user realtime payload."""
+    out: dict[str, Any] = {}
+    for code, point in data.items():
+        if isinstance(point, dict):
+            out[code] = normalize_power_point(point)
         else:
             out[code] = point
     return out

--- a/custom_components/sungrow/icons.json
+++ b/custom_components/sungrow/icons.json
@@ -41,9 +41,6 @@
       }
     },
     "select": {
-      "charge_discharge_command": {
-        "default": "mdi:battery-sync"
-      },
       "forced_charging": {
         "default": "mdi:battery-lock"
       },
@@ -58,6 +55,9 @@
       },
       "reactive_power_regulation_mode": {
         "default": "mdi:sine-wave"
+      },
+      "battery_mode": {
+        "default": "mdi:battery-sync"
       }
     }
   }

--- a/custom_components/sungrow/number.py
+++ b/custom_components/sungrow/number.py
@@ -299,12 +299,14 @@ class SungrowDispatchNumber(CoordinatorEntity[SungrowPlantCoordinator], RestoreN
         self._attr_native_value = value
 
 
-# Default duration (minutes) for a forced Charge/Discharge before auto-revert (#157).
-DEFAULT_FORCED_DISPATCH_DURATION = 0  # 0 = auto-revert disabled (legacy behaviour)
+# Default duration (minutes) for a forced Charge/Discharge before auto-revert (#157 / #255).
+# A non-zero default means forced commands always have a bounded lifetime out of the box;
+# users can still set 0 to opt out of auto-revert.
+DEFAULT_FORCED_DISPATCH_DURATION = 60
 
 
 class SungrowForcedDispatchDurationNumber(CoordinatorEntity[SungrowPlantCoordinator], RestoreNumber):
-    """Local number controlling the forced-dispatch auto-revert timeout (#157).
+    """Local number controlling the forced-dispatch auto-revert timeout (#157 / #255).
 
     Unlike the other dispatch numbers this writes *nothing* to the inverter — it only
     records, on the coordinator, how long a forced Charge/Discharge command may stay

--- a/custom_components/sungrow/select.py
+++ b/custom_components/sungrow/select.py
@@ -36,8 +36,34 @@ PARALLEL_UPDATES = 1
 _EMS_MODE_PARAM = "energy_management_mode"
 _EMS_MODE_SELF_CONSUMPTION = Control.encode_parameter("energy_management_mode", "self_consumption")
 _EMS_MODE_COMPULSORY = Control.encode_parameter("energy_management_mode", "compulsory")
+_CDC_PARAM = "charge_discharge_command"
 
-# Post-write actuation check (#254). After commanding Charge/Discharge we read Energy
+# Unified battery-mode select (#255). Replaces the raw charge/discharge command select.
+BATTERY_MODE_PARAM = "battery_mode"
+BATTERY_MODE_SELF_CONSUMPTION = "Self-consumption"
+BATTERY_MODE_FORCE_CHARGE = "Force charge"
+BATTERY_MODE_FORCE_DISCHARGE = "Force discharge"
+BATTERY_MODE_STOP = "Stop"
+BATTERY_MODE_FORCED = frozenset({BATTERY_MODE_FORCE_CHARGE, BATTERY_MODE_FORCE_DISCHARGE})
+BATTERY_MODE_SAFE = frozenset({BATTERY_MODE_SELF_CONSUMPTION, BATTERY_MODE_STOP})
+# Service / automation mode keys (snake_case) → display options.
+BATTERY_MODE_SERVICE_KEYS: dict[str, str] = {
+    "self_consumption": BATTERY_MODE_SELF_CONSUMPTION,
+    "force_charge": BATTERY_MODE_FORCE_CHARGE,
+    "force_discharge": BATTERY_MODE_FORCE_DISCHARGE,
+    "stop": BATTERY_MODE_STOP,
+}
+# Restore states from the pre-#255 charge_discharge_command select.
+_LEGACY_BATTERY_MODE_STATES: dict[str, str] = {
+    "Charge": BATTERY_MODE_FORCE_CHARGE,
+    "Discharge": BATTERY_MODE_FORCE_DISCHARGE,
+    "Stop": BATTERY_MODE_STOP,
+    "charge": BATTERY_MODE_FORCE_CHARGE,
+    "discharge": BATTERY_MODE_FORCE_DISCHARGE,
+    "stop": BATTERY_MODE_STOP,
+}
+
+# Post-write actuation check (#254). After commanding a forced mode we read Energy
 # Management Mode (10003) back and, if it is *still* Self-consumption, the inverter did
 # not enter Forced mode (the #231 failure) — the write was accepted but had no effect.
 # The read is deferred briefly so the device has time to apply the change.
@@ -47,11 +73,14 @@ _REPAIR_LEARN_MORE = "https://github.com/KRoperUK/sungrow-hass/blob/main/docs/TR
 
 # Select parameters exposed as HA Select entities.
 DISPATCH_SELECTS: dict[str, dict[str, Any]] = {
-    "charge_discharge_command": {
+    # Single battery mode (#255): Self-consumption / Force charge / Force discharge / Stop.
+    # Writes charge_discharge_command (10004) + energy_management_mode (10003) together.
+    BATTERY_MODE_PARAM: {
         "options_map": {
-            "Stop": Control.CHARGE_DISCHARGE_COMMANDS["stop"],
-            "Charge": Control.CHARGE_DISCHARGE_COMMANDS["charge"],
-            "Discharge": Control.CHARGE_DISCHARGE_COMMANDS["discharge"],
+            BATTERY_MODE_SELF_CONSUMPTION: "self_consumption",
+            BATTERY_MODE_FORCE_CHARGE: "force_charge",
+            BATTERY_MODE_FORCE_DISCHARGE: "force_discharge",
+            BATTERY_MODE_STOP: "stop",
         },
         # Battery actuation: meaningless (and harmful — see #148) without a battery.
         "battery_only": True,
@@ -188,6 +217,16 @@ class SungrowDispatchSelect(CoordinatorEntity[SungrowPlantCoordinator], RestoreE
         # auto-revert task doesn't act on the plant after this instance is gone (#157).
         self._removed = False
 
+    def _normalize_restored_option(self, state: str) -> str | None:
+        """Map a restored state to a current option (including pre-#255 legacy names)."""
+        if state in self.options_map:
+            return state
+        if self.param == BATTERY_MODE_PARAM:
+            mapped = _LEGACY_BATTERY_MODE_STATES.get(state)
+            if mapped in self.options_map:
+                return mapped
+        return None
+
     async def async_added_to_hass(self) -> None:
         """Restore the last selected option across restarts.
 
@@ -195,40 +234,52 @@ class SungrowDispatchSelect(CoordinatorEntity[SungrowPlantCoordinator], RestoreE
         last option the user chose is restored from state rather than fetched.
         """
         await super().async_added_to_hass()
+        # Register battery-mode selects so ``sungrow.set_battery_mode`` can find them (#255).
+        if self.param == BATTERY_MODE_PARAM and self.entity_id:
+            registry = self.hass.data.setdefault(DOMAIN, {}).setdefault("battery_mode_selects", {})
+            registry[self.entity_id] = self
         last = await self.async_get_last_state()
-        if last is not None and last.state in self.options_map:
-            self._attr_current_option = last.state
-            # If we were mid-charge/discharge before the restart, resume the EMS
-            # heartbeat: restoring current_option alone would leave the UI showing
-            # Charge/Discharge while the inverter silently times out of External-EMS
-            # mode. Only the command select owns the heartbeat, so this restarts it
-            # exactly once per plant; async_start_heartbeat is idempotent (it stops
-            # any existing loop first), so a stale loop is never double-started (#112).
-            if self.param == "charge_discharge_command" and last.state in {"Charge", "Discharge"}:
-                entry = self.coordinator.config_entry
-                assert entry is not None
-                # Restore the auto-revert deadline first (#157): if the forced command
-                # already timed out while HA was down, revert to Stop instead of resuming
-                # dispatch; otherwise resume the heartbeat and re-arm for the time left.
-                deadline = self._restore_revert_deadline(last.attributes.get("revert_at"))
-                if deadline is not None and deadline <= time.time():
-                    await self._do_revert()
-                    return
-                await async_start_heartbeat(
-                    self.hass,
-                    entry,
-                    self.coordinator.plant_id,
-                    self.device_uuid,
-                    interval=60,
-                )
-                if deadline is not None:
-                    self._arm_revert(deadline=deadline)
+        if last is None:
+            return
+        restored = self._normalize_restored_option(last.state)
+        if restored is None:
+            return
+        self._attr_current_option = restored
+        # If we were mid force-charge/discharge before the restart, resume the EMS
+        # heartbeat: restoring current_option alone would leave the UI showing a
+        # forced mode while the inverter silently times out of External-EMS mode.
+        # Only the battery-mode select owns the heartbeat, so this restarts it
+        # exactly once per plant; async_start_heartbeat is idempotent (it stops
+        # any existing loop first), so a stale loop is never double-started (#112).
+        if self.param == BATTERY_MODE_PARAM and restored in BATTERY_MODE_FORCED:
+            entry = self.coordinator.config_entry
+            assert entry is not None
+            # Restore the auto-revert deadline first (#157): if the forced command
+            # already timed out while HA was down, revert to Self-consumption instead
+            # of resuming dispatch; otherwise resume the heartbeat and re-arm.
+            deadline = self._restore_revert_deadline(last.attributes.get("revert_at"))
+            if deadline is not None and deadline <= time.time():
+                await self._do_revert()
+                return
+            await async_start_heartbeat(
+                self.hass,
+                entry,
+                self.coordinator.plant_id,
+                self.device_uuid,
+                interval=60,
+            )
+            if deadline is not None:
+                self._arm_revert(deadline=deadline)
 
     async def async_will_remove_from_hass(self) -> None:
         """Cancel the auto-revert and actuation-check timers when the select is removed."""
         self._removed = True
         self._cancel_revert()
         self._cancel_verify()
+        if self.param == BATTERY_MODE_PARAM and self.entity_id:
+            registry = self.hass.data.get(DOMAIN, {}).get("battery_mode_selects")
+            if isinstance(registry, dict):
+                registry.pop(self.entity_id, None)
         await super().async_will_remove_from_hass()
 
     @staticmethod
@@ -242,24 +293,39 @@ class SungrowDispatchSelect(CoordinatorEntity[SungrowPlantCoordinator], RestoreE
             return None
 
     def _command_payload(self, option: str, value: str) -> dict[str, str]:
-        """Build the param write for a charge/discharge command, including EMS mode (#231).
+        """Build the param write for a select option.
 
-        Without switching Energy Management Mode out of Self-consumption, the inverter
-        accepts 10004/10005 writes but continues normal self-consumption operation.
-        Compulsory mode matches the portal "Forced mode" tile; Stop restores
-        Self-consumption so the plant returns to default behaviour.
+        Battery mode (#255) writes charge_discharge_command (10004) together with
+        Energy Management Mode (10003). Without leaving Self-consumption, the inverter
+        accepts 10004/10005 writes but continues normal self-consumption operation
+        (#231). Compulsory mode matches the portal "Forced mode" tile; safe modes
+        restore Self-consumption so the plant returns to default behaviour.
         """
-        payload: dict[str, str] = {self.param: value}
-        if self.param != "charge_discharge_command":
-            return payload
-        if option in {"Charge", "Discharge"}:
-            payload[_EMS_MODE_PARAM] = _EMS_MODE_COMPULSORY
-        elif option == "Stop":
-            payload[_EMS_MODE_PARAM] = _EMS_MODE_SELF_CONSUMPTION
-        return payload
+        if self.param == BATTERY_MODE_PARAM:
+            if option == BATTERY_MODE_FORCE_CHARGE:
+                return {
+                    _CDC_PARAM: Control.CHARGE_DISCHARGE_COMMANDS["charge"],
+                    _EMS_MODE_PARAM: _EMS_MODE_COMPULSORY,
+                }
+            if option == BATTERY_MODE_FORCE_DISCHARGE:
+                return {
+                    _CDC_PARAM: Control.CHARGE_DISCHARGE_COMMANDS["discharge"],
+                    _EMS_MODE_PARAM: _EMS_MODE_COMPULSORY,
+                }
+            # Self-consumption and Stop both return the plant to the safe default.
+            return {
+                _CDC_PARAM: Control.CHARGE_DISCHARGE_COMMANDS["stop"],
+                _EMS_MODE_PARAM: _EMS_MODE_SELF_CONSUMPTION,
+            }
+        return {self.param: value}
 
-    async def async_select_option(self, option: str) -> None:
-        """Update the dispatch parameter on the inverter."""
+    async def async_select_option(self, option: str, *, duration_minutes: float | None = None) -> None:
+        """Update the dispatch parameter on the inverter.
+
+        ``duration_minutes`` (battery mode only) overrides the auto-revert timeout for
+        this forced command without changing the Forced Dispatch Duration number — used
+        by the ``sungrow.set_battery_mode`` service for tariff automations (#255).
+        """
         value = self.options_map[option]
         payload = self._command_payload(option, value)
         _LOGGER.debug("Setting %s to %s (%s) for %s", self.param, option, payload, self.device_uuid)
@@ -274,10 +340,10 @@ class SungrowDispatchSelect(CoordinatorEntity[SungrowPlantCoordinator], RestoreE
         # Remember the selected option so the UI reflects it and it survives restarts.
         self._attr_current_option = option
 
-        # Keep the inverter in dispatch mode while actively charging/discharging.
+        # Keep the inverter in dispatch mode while force-charging/discharging.
         entry = self.coordinator.config_entry
         assert entry is not None
-        if self.param == "charge_discharge_command" and option in {"Charge", "Discharge"}:
+        if self.param == BATTERY_MODE_PARAM and option in BATTERY_MODE_FORCED:
             await async_start_heartbeat(
                 self.hass,
                 entry,
@@ -285,12 +351,18 @@ class SungrowDispatchSelect(CoordinatorEntity[SungrowPlantCoordinator], RestoreE
                 self.device_uuid,
                 interval=60,
             )
-            # Arm the auto-revert so this forced command can't silently persist (#157).
-            self._arm_revert()
+            # Arm the auto-revert so this forced command can't silently persist (#157/#255).
+            if duration_minutes is not None and duration_minutes > 0:
+                self._arm_revert(deadline=time.time() + float(duration_minutes) * 60)
+            elif duration_minutes is not None and duration_minutes <= 0:
+                # Explicit 0 from the service: no auto-revert for this command.
+                self._cancel_revert()
+            else:
+                self._arm_revert()
             # Verify the inverter actually entered Forced mode shortly after (#254): the
             # write can be accepted while the plant stays in Self-consumption (#231).
             self._schedule_actuation_check()
-        elif self.param == "charge_discharge_command" and option == "Stop":
+        elif self.param == BATTERY_MODE_PARAM and option in BATTERY_MODE_SAFE:
             await async_stop_heartbeat(self.hass, entry, self.coordinator.plant_id)
             self._cancel_revert()
             # Stopping dispatch clears any "not actuated" Repair and pending check (#254).
@@ -305,7 +377,7 @@ class SungrowDispatchSelect(CoordinatorEntity[SungrowPlantCoordinator], RestoreE
     @property
     def extra_state_attributes(self) -> dict[str, Any] | None:
         """Expose the pending auto-revert deadline so it survives a restart (#157)."""
-        if self.param == "charge_discharge_command" and self._revert_deadline is not None:
+        if self.param == BATTERY_MODE_PARAM and self._revert_deadline is not None:
             return {"revert_at": self._revert_deadline}
         return None
 
@@ -341,30 +413,34 @@ class SungrowDispatchSelect(CoordinatorEntity[SungrowPlantCoordinator], RestoreE
         self.hass.async_create_task(self._do_revert())
 
     async def _do_revert(self) -> None:
-        """Revert a forced Charge/Discharge to Stop and stop the heartbeat (#157)."""
+        """Revert a forced mode to Self-consumption and stop the heartbeat (#157/#255)."""
         if self._removed:
             # The timer fired, but the entity was removed (e.g. an entry reload) before
             # this task ran. Acting now would stop a freshly-restored heartbeat and write
             # state on a dead entity, so bail out — the new instance owns the heartbeat.
             return
-        _LOGGER.info("Forced-dispatch timeout for %s: reverting to Stop", self.device_uuid)
-        stop_option = "Stop"
+        _LOGGER.info(
+            "Forced-dispatch timeout for %s: reverting to %s",
+            self.device_uuid,
+            BATTERY_MODE_SELF_CONSUMPTION,
+        )
+        safe_option = BATTERY_MODE_SELF_CONSUMPTION
         try:
             await self.control.async_update_parameters(
                 self.device_uuid,
-                self._command_payload(stop_option, self.options_map[stop_option]),
+                self._command_payload(safe_option, self.options_map[safe_option]),
             )
         except PySolarCloudException as err:
-            _LOGGER.warning("Auto-revert to Stop failed for %s: %s", self.device_uuid, err)
+            _LOGGER.warning("Auto-revert to %s failed for %s: %s", safe_option, self.device_uuid, err)
         entry = self.coordinator.config_entry
         if entry is not None:
             await async_stop_heartbeat(self.hass, entry, self.coordinator.plant_id)
         self._revert_deadline = None
         self._revert_cancel = None
-        # Reverting to Stop makes any "not actuated" Repair moot (#254).
+        # Reverting to a safe mode makes any "not actuated" Repair moot (#254).
         self._cancel_verify()
         self._clear_not_actuated_issue()
-        self._attr_current_option = stop_option
+        self._attr_current_option = safe_option
         self.async_write_ha_state()
 
     def _cancel_revert(self) -> None:
@@ -441,7 +517,7 @@ class SungrowDispatchSelect(CoordinatorEntity[SungrowPlantCoordinator], RestoreE
         and default to no action on an unknown/errored read-back (never a false alarm on a
         battery-control path). Only a positive Self-consumption read-back raises the Repair.
         """
-        if self._removed or self._attr_current_option not in {"Charge", "Discharge"}:
+        if self._removed or self._attr_current_option not in BATTERY_MODE_FORCED:
             return
         still_self = await self._read_still_self_consumption()
         if still_self is not True:
@@ -453,6 +529,7 @@ class SungrowDispatchSelect(CoordinatorEntity[SungrowPlantCoordinator], RestoreE
 
         # Confirmed still in Self-consumption: retry the forced-mode write once.
         option = self._attr_current_option
+        assert option is not None
         _LOGGER.debug("Dispatch %s for %s not actuated; re-issuing forced mode", option, self.device_uuid)
         try:
             await self.control.async_update_parameters(

--- a/custom_components/sungrow/services.py
+++ b/custom_components/sungrow/services.py
@@ -97,8 +97,10 @@ def _resolve_battery_mode_selects(hass: HomeAssistant, call: ServiceCall) -> lis
     for device_id in call.data.get(ATTR_DEVICE_ID) or []:
         ent_reg = er.async_get(hass)
         for ent in er.async_entries_for_device(ent_reg, device_id):
-            if ent.domain == "select" and ent.platform == DOMAIN and (ent.unique_id or "").endswith(
-                f"_{_BATTERY_MODE_PARAM}"
+            if (
+                ent.domain == "select"
+                and ent.platform == DOMAIN
+                and (ent.unique_id or "").endswith(f"_{_BATTERY_MODE_PARAM}")
             ):
                 entity_ids.add(ent.entity_id)
 
@@ -109,8 +111,10 @@ def _resolve_battery_mode_selects(hass: HomeAssistant, call: ServiceCall) -> lis
             raise ServiceValidationError(f"No Sungrow config entry found for '{entry_id}'")
         ent_reg = er.async_get(hass)
         for ent in er.async_entries_for_config_entry(ent_reg, entry.entry_id):
-            if ent.domain == "select" and ent.platform == DOMAIN and (ent.unique_id or "").endswith(
-                f"_{_BATTERY_MODE_PARAM}"
+            if (
+                ent.domain == "select"
+                and ent.platform == DOMAIN
+                and (ent.unique_id or "").endswith(f"_{_BATTERY_MODE_PARAM}")
             ):
                 entity_ids.add(ent.entity_id)
 

--- a/custom_components/sungrow/services.py
+++ b/custom_components/sungrow/services.py
@@ -116,18 +116,18 @@ def _resolve_battery_mode_selects(hass: HomeAssistant, call: ServiceCall) -> lis
 
     if not entity_ids:
         # No target: every registered battery-mode select (typical single-plant home).
-        selects = [s for s in registry.values() if isinstance(s, SungrowDispatchSelect)]
-        if not selects:
+        all_selects = [s for s in registry.values() if isinstance(s, SungrowDispatchSelect)]
+        if not all_selects:
             raise ServiceValidationError("No Sungrow battery mode select entities found")
-        return selects
+        return all_selects
 
-    selects: list[Any] = []
+    matched: list[Any] = []
     for eid in entity_ids:
         select = registry.get(eid)
         if not isinstance(select, SungrowDispatchSelect):
             raise ServiceValidationError(f"Entity '{eid}' is not a loaded Sungrow battery mode select")
-        selects.append(select)
-    return selects
+        matched.append(select)
+    return matched
 
 
 def async_setup_services(hass: HomeAssistant) -> None:

--- a/custom_components/sungrow/services.py
+++ b/custom_components/sungrow/services.py
@@ -1,13 +1,8 @@
-"""The on-demand Backfill service for the Sungrow iSolarCloud integration.
+"""Home Assistant services for the Sungrow iSolarCloud integration.
 
-Registers ``sungrow.backfill`` as an admin service. A call resolves the addressed cloud
-config entry (or every loaded cloud entry when none is given), reads its
-``runtime_data.backfill`` manager and asks it to run on demand. An optional ``start_date``
-(a date) is interpreted as UTC midnight and passed straight through as the run's window
-start override.
-
-See ``.kiro/specs/backfill-historical-statistics`` for the design and requirements
-(Requirements 2.1, 2.2, 2.3).
+* ``sungrow.backfill`` — on-demand historical statistics import (admin).
+* ``sungrow.set_battery_mode`` — set the unified battery mode for tariff/automation
+  dispatch (#255).
 """
 
 from __future__ import annotations
@@ -18,9 +13,11 @@ from typing import Any
 
 import voluptuous as vol
 from homeassistant.config_entries import ConfigEntryState
+from homeassistant.const import ATTR_DEVICE_ID, ATTR_ENTITY_ID
 from homeassistant.core import HomeAssistant, ServiceCall
-from homeassistant.exceptions import ServiceValidationError
+from homeassistant.exceptions import HomeAssistantError, ServiceValidationError
 from homeassistant.helpers import config_validation as cv
+from homeassistant.helpers import entity_registry as er
 from homeassistant.helpers.service import async_register_admin_service
 from homeassistant.util import dt as dt_util
 
@@ -29,13 +26,30 @@ from .const import CONF_TRANSPORT, DOMAIN, TRANSPORT_MODBUS_ONLY
 _LOGGER = logging.getLogger(__name__)
 
 SERVICE_BACKFILL = "backfill"
+SERVICE_SET_BATTERY_MODE = "set_battery_mode"
 ATTR_CONFIG_ENTRY = "config_entry"
 ATTR_START_DATE = "start_date"
+ATTR_MODE = "mode"
+ATTR_DURATION_MINUTES = "duration_minutes"
 
-_SERVICE_SCHEMA = vol.Schema(
+# Keep in sync with select.BATTERY_MODE_SERVICE_KEYS (avoid circular import with select).
+_BATTERY_MODE_KEYS = ("self_consumption", "force_charge", "force_discharge", "stop")
+_BATTERY_MODE_PARAM = "battery_mode"
+
+_BACKFILL_SCHEMA = vol.Schema(
     {
         vol.Optional(ATTR_CONFIG_ENTRY): cv.string,
         vol.Optional(ATTR_START_DATE): cv.date,
+    }
+)
+
+_SET_BATTERY_MODE_SCHEMA = vol.Schema(
+    {
+        vol.Required(ATTR_MODE): vol.In(list(_BATTERY_MODE_KEYS)),
+        vol.Optional(ATTR_DURATION_MINUTES): vol.All(vol.Coerce(float), vol.Range(min=0, max=1440)),
+        vol.Optional(ATTR_ENTITY_ID): cv.entity_ids,
+        vol.Optional(ATTR_DEVICE_ID): vol.All(cv.ensure_list, [cv.string]),
+        vol.Optional(ATTR_CONFIG_ENTRY): cv.string,
     }
 )
 
@@ -63,27 +77,112 @@ def _resolve_entries(hass: HomeAssistant, entry_id: str | None) -> list[Any]:
     return [entry]
 
 
+def _battery_mode_registry(hass: HomeAssistant) -> dict[str, Any]:
+    """Return the live battery-mode select registry (entity_id → entity)."""
+    domain_data = hass.data.get(DOMAIN)
+    if not isinstance(domain_data, dict):
+        return {}
+    registry = domain_data.get("battery_mode_selects")
+    return registry if isinstance(registry, dict) else {}
+
+
+def _resolve_battery_mode_selects(hass: HomeAssistant, call: ServiceCall) -> list[Any]:
+    """Resolve battery-mode select entities from the service call targets (#255)."""
+    # Local import avoids a circular import with select → __init__ → services.
+    from .select import SungrowDispatchSelect  # noqa: PLC0415
+
+    registry = _battery_mode_registry(hass)
+    entity_ids: set[str] = set(call.data.get(ATTR_ENTITY_ID) or [])
+
+    for device_id in call.data.get(ATTR_DEVICE_ID) or []:
+        ent_reg = er.async_get(hass)
+        for ent in er.async_entries_for_device(ent_reg, device_id):
+            if ent.domain == "select" and ent.platform == DOMAIN and (ent.unique_id or "").endswith(
+                f"_{_BATTERY_MODE_PARAM}"
+            ):
+                entity_ids.add(ent.entity_id)
+
+    entry_id = call.data.get(ATTR_CONFIG_ENTRY)
+    if entry_id:
+        entry = hass.config_entries.async_get_entry(entry_id)
+        if entry is None or entry.domain != DOMAIN:
+            raise ServiceValidationError(f"No Sungrow config entry found for '{entry_id}'")
+        ent_reg = er.async_get(hass)
+        for ent in er.async_entries_for_config_entry(ent_reg, entry.entry_id):
+            if ent.domain == "select" and ent.platform == DOMAIN and (ent.unique_id or "").endswith(
+                f"_{_BATTERY_MODE_PARAM}"
+            ):
+                entity_ids.add(ent.entity_id)
+
+    if not entity_ids:
+        # No target: every registered battery-mode select (typical single-plant home).
+        selects = [s for s in registry.values() if isinstance(s, SungrowDispatchSelect)]
+        if not selects:
+            raise ServiceValidationError("No Sungrow battery mode select entities found")
+        return selects
+
+    selects: list[Any] = []
+    for eid in entity_ids:
+        select = registry.get(eid)
+        if not isinstance(select, SungrowDispatchSelect):
+            raise ServiceValidationError(f"Entity '{eid}' is not a loaded Sungrow battery mode select")
+        selects.append(select)
+    return selects
+
+
 def async_setup_services(hass: HomeAssistant) -> None:
-    """Register the ``sungrow.backfill`` admin service exactly once (Requirement 2.1)."""
-    if hass.services.has_service(DOMAIN, SERVICE_BACKFILL):
-        return
+    """Register Sungrow services exactly once."""
+    if not hass.services.has_service(DOMAIN, SERVICE_BACKFILL):
 
-    async def _handle_backfill(call: ServiceCall) -> None:
-        """Dispatch an on-demand Backfill to the addressed cloud entries' managers."""
-        entry_id = call.data.get(ATTR_CONFIG_ENTRY)
-        start_date = call.data.get(ATTR_START_DATE)
-        # A date selector yields a date; interpret it as UTC midnight (Requirement 2.3).
-        start_override: datetime | None = None
-        if start_date is not None:
-            start_override = datetime.combine(start_date, time.min, tzinfo=dt_util.UTC)
+        async def _handle_backfill(call: ServiceCall) -> None:
+            """Dispatch an on-demand Backfill to the addressed cloud entries' managers."""
+            entry_id = call.data.get(ATTR_CONFIG_ENTRY)
+            start_date = call.data.get(ATTR_START_DATE)
+            # A date selector yields a date; interpret it as UTC midnight (Requirement 2.3).
+            start_override: datetime | None = None
+            if start_date is not None:
+                start_override = datetime.combine(start_date, time.min, tzinfo=dt_util.UTC)
 
-        entries = _resolve_entries(hass, entry_id)
-        for entry in entries:
-            manager = getattr(entry.runtime_data, "backfill", None)
-            if manager is None:
-                _LOGGER.debug("Skipping Backfill for entry %s: no manager", entry.entry_id)
-                continue
-            await manager.async_run_on_demand(plant_ids=None, start_date=start_override)
+            entries = _resolve_entries(hass, entry_id)
+            for entry in entries:
+                manager = getattr(entry.runtime_data, "backfill", None)
+                if manager is None:
+                    _LOGGER.debug("Skipping Backfill for entry %s: no manager", entry.entry_id)
+                    continue
+                await manager.async_run_on_demand(plant_ids=None, start_date=start_override)
 
-    async_register_admin_service(hass, DOMAIN, SERVICE_BACKFILL, _handle_backfill, schema=_SERVICE_SCHEMA)
-    _LOGGER.debug("Registered %s.%s service", DOMAIN, SERVICE_BACKFILL)
+        async_register_admin_service(hass, DOMAIN, SERVICE_BACKFILL, _handle_backfill, schema=_BACKFILL_SCHEMA)
+        _LOGGER.debug("Registered %s.%s service", DOMAIN, SERVICE_BACKFILL)
+
+    if not hass.services.has_service(DOMAIN, SERVICE_SET_BATTERY_MODE):
+
+        async def _handle_set_battery_mode(call: ServiceCall) -> None:
+            """Set battery mode on the targeted plant(s) (#255)."""
+            from .select import BATTERY_MODE_PARAM, BATTERY_MODE_SERVICE_KEYS  # noqa: PLC0415
+
+            mode_key = call.data[ATTR_MODE]
+            option = BATTERY_MODE_SERVICE_KEYS[mode_key]
+            duration = call.data.get(ATTR_DURATION_MINUTES)
+            selects = _resolve_battery_mode_selects(hass, call)
+            for select in selects:
+                try:
+                    await select.async_select_option(option, duration_minutes=duration)
+                    # Best-effort UI refresh when the entity is fully platform-bound.
+                    if select.hass is not None and getattr(select, "platform", None) is not None:
+                        select.async_write_ha_state()
+                except HomeAssistantError:
+                    raise
+                except Exception as err:  # pragma: no cover - defensive
+                    raise HomeAssistantError(
+                        translation_domain=DOMAIN,
+                        translation_key="dispatch_write_failed",
+                        translation_placeholders={"param": BATTERY_MODE_PARAM, "error": str(err)},
+                    ) from err
+
+        hass.services.async_register(
+            DOMAIN,
+            SERVICE_SET_BATTERY_MODE,
+            _handle_set_battery_mode,
+            schema=_SET_BATTERY_MODE_SCHEMA,
+        )
+        _LOGGER.debug("Registered %s.%s service", DOMAIN, SERVICE_SET_BATTERY_MODE)

--- a/custom_components/sungrow/services.yaml
+++ b/custom_components/sungrow/services.yaml
@@ -22,7 +22,6 @@ set_battery_mode:
             - force_charge
             - force_discharge
             - stop
-          translation_key: battery_mode
     duration_minutes:
       required: false
       example: 120

--- a/custom_components/sungrow/services.yaml
+++ b/custom_components/sungrow/services.yaml
@@ -9,3 +9,42 @@ backfill:
       required: false
       selector:
         date:
+
+set_battery_mode:
+  fields:
+    mode:
+      required: true
+      example: force_charge
+      selector:
+        select:
+          options:
+            - self_consumption
+            - force_charge
+            - force_discharge
+            - stop
+          translation_key: battery_mode
+    duration_minutes:
+      required: false
+      example: 120
+      selector:
+        number:
+          min: 0
+          max: 1440
+          unit_of_measurement: min
+          mode: box
+    entity_id:
+      required: false
+      selector:
+        entity:
+          integration: sungrow
+          domain: select
+    device_id:
+      required: false
+      selector:
+        device:
+          integration: sungrow
+    config_entry:
+      required: false
+      selector:
+        config_entry:
+          integration: sungrow

--- a/custom_components/sungrow/strings.json
+++ b/custom_components/sungrow/strings.json
@@ -199,9 +199,6 @@
       }
     },
     "select": {
-      "charge_discharge_command": {
-        "name": "Charge/Discharge Command"
-      },
       "forced_charging": {
         "name": "Forced Charging"
       },
@@ -216,6 +213,9 @@
       },
       "reactive_power_regulation_mode": {
         "name": "Reactive Power Mode"
+      },
+      "battery_mode": {
+        "name": "Battery Mode"
       }
     }
   },
@@ -236,6 +236,32 @@
         "start_date": {
           "name": "Start date",
           "description": "Optional earliest date to import from (interpreted as UTC midnight). Defaults to the configured backfill window."
+        }
+      }
+    },
+    "set_battery_mode": {
+      "name": "Set battery mode",
+      "description": "Set the plant battery mode (Self-consumption / Force charge / Force discharge / Stop). Optional duration overrides Forced Dispatch Duration for this command only.",
+      "fields": {
+        "mode": {
+          "name": "Mode",
+          "description": "Battery mode to apply."
+        },
+        "duration_minutes": {
+          "name": "Duration",
+          "description": "Minutes before auto-revert to Self-consumption (0 = no auto-revert for this command). Omit to use Forced Dispatch Duration."
+        },
+        "entity_id": {
+          "name": "Battery mode entity",
+          "description": "The Battery Mode select entity. Leave empty to target every battery plant."
+        },
+        "device_id": {
+          "name": "Device",
+          "description": "Dispatch device that owns the battery mode select."
+        },
+        "config_entry": {
+          "name": "Integration",
+          "description": "Sungrow config entry to target."
         }
       }
     }

--- a/custom_components/sungrow/translations/cy.json
+++ b/custom_components/sungrow/translations/cy.json
@@ -199,9 +199,6 @@
       }
     },
     "select": {
-      "charge_discharge_command": {
-        "name": "Gorchymyn Gwefru/Dadwefru"
-      },
       "forced_charging": {
         "name": "Gwefru Gorfodol"
       },
@@ -216,6 +213,9 @@
       },
       "reactive_power_regulation_mode": {
         "name": "Modd Pŵer Adweithiol"
+      },
+      "battery_mode": {
+        "name": "Modd batri"
       }
     }
   },
@@ -236,6 +236,32 @@
         "start_date": {
           "name": "Dyddiad dechrau",
           "description": "Dyddiad cynharaf dewisol i fewnforio ohono (dehonglir fel hanner nos UTC). Rhagosodiad yw'r ffenestr lenwi a ffurfweddwyd."
+        }
+      }
+    },
+    "set_battery_mode": {
+      "name": "Gosod modd batri",
+      "description": "Gosod modd batri (Hunan-ddefnydd / Gorfodi gwefru / Gorfodi rhyddhau / Stopio). Mae hyd dewisol yn diystyru Forced Dispatch Duration ar gyfer y gorchymyn hwn yn unig.",
+      "fields": {
+        "mode": {
+          "name": "Modd",
+          "description": "Modd batri i'w gymhwyso."
+        },
+        "duration_minutes": {
+          "name": "Hyd",
+          "description": "Munudau cyn dychwelyd i hunan-ddefnydd (0 = dim auto-ddychwelyd ar gyfer y gorchymyn hwn)."
+        },
+        "entity_id": {
+          "name": "Endid modd batri",
+          "description": "Yr endid select modd batri. Gadewch yn wag i dargedu pob planhigyn batri."
+        },
+        "device_id": {
+          "name": "Dyfais",
+          "description": "Dyfais dosbarthu sy'n berchen ar y select modd batri."
+        },
+        "config_entry": {
+          "name": "Integreiddio",
+          "description": "Cofnod cyfluniad Sungrow."
         }
       }
     }

--- a/custom_components/sungrow/translations/de.json
+++ b/custom_components/sungrow/translations/de.json
@@ -199,9 +199,6 @@
       }
     },
     "select": {
-      "charge_discharge_command": {
-        "name": "Lade-/Entladebefehl"
-      },
       "forced_charging": {
         "name": "Erzwungenes Laden"
       },
@@ -216,6 +213,9 @@
       },
       "reactive_power_regulation_mode": {
         "name": "Blindleistungsmodus"
+      },
+      "battery_mode": {
+        "name": "Batteriemodus"
       }
     }
   },
@@ -236,6 +236,32 @@
         "start_date": {
           "name": "Startdatum",
           "description": "Optionales frühestes Datum, ab dem importiert wird (als UTC-Mitternacht interpretiert). Standard ist das konfigurierte Rückfüllfenster."
+        }
+      }
+    },
+    "set_battery_mode": {
+      "name": "Batteriemodus setzen",
+      "description": "Setzt den Batteriemodus (Eigenverbrauch / Erzwungenes Laden / Erzwungenes Entladen / Stopp). Optionale Dauer überschreibt die Forced-Dispatch-Dauer nur für diesen Befehl.",
+      "fields": {
+        "mode": {
+          "name": "Modus",
+          "description": "Anzuwendender Batteriemodus."
+        },
+        "duration_minutes": {
+          "name": "Dauer",
+          "description": "Minuten bis zur automatischen Rückkehr zu Eigenverbrauch (0 = kein Auto-Revert für diesen Befehl)."
+        },
+        "entity_id": {
+          "name": "Batteriemodus-Entität",
+          "description": "Die Batteriemodus-Select-Entität. Leer lassen, um alle Batterieanlagen anzusprechen."
+        },
+        "device_id": {
+          "name": "Gerät",
+          "description": "Dispatch-Gerät mit dem Batteriemodus-Select."
+        },
+        "config_entry": {
+          "name": "Integration",
+          "description": "Sungrow-Konfigurationseintrag."
         }
       }
     }

--- a/custom_components/sungrow/translations/en.json
+++ b/custom_components/sungrow/translations/en.json
@@ -199,9 +199,6 @@
       }
     },
     "select": {
-      "charge_discharge_command": {
-        "name": "Charge/Discharge Command"
-      },
       "forced_charging": {
         "name": "Forced Charging"
       },
@@ -216,6 +213,9 @@
       },
       "reactive_power_regulation_mode": {
         "name": "Reactive Power Mode"
+      },
+      "battery_mode": {
+        "name": "Battery Mode"
       }
     }
   },
@@ -236,6 +236,32 @@
         "start_date": {
           "name": "Start date",
           "description": "Optional earliest date to import from (interpreted as UTC midnight). Defaults to the configured backfill window."
+        }
+      }
+    },
+    "set_battery_mode": {
+      "name": "Set battery mode",
+      "description": "Set the plant battery mode (Self-consumption / Force charge / Force discharge / Stop). Optional duration overrides Forced Dispatch Duration for this command only.",
+      "fields": {
+        "mode": {
+          "name": "Mode",
+          "description": "Battery mode to apply."
+        },
+        "duration_minutes": {
+          "name": "Duration",
+          "description": "Minutes before auto-revert to Self-consumption (0 = no auto-revert for this command). Omit to use Forced Dispatch Duration."
+        },
+        "entity_id": {
+          "name": "Battery mode entity",
+          "description": "The Battery Mode select entity. Leave empty to target every battery plant."
+        },
+        "device_id": {
+          "name": "Device",
+          "description": "Dispatch device that owns the battery mode select."
+        },
+        "config_entry": {
+          "name": "Integration",
+          "description": "Sungrow config entry to target."
         }
       }
     }

--- a/custom_components/sungrow/translations/es.json
+++ b/custom_components/sungrow/translations/es.json
@@ -199,9 +199,6 @@
       }
     },
     "select": {
-      "charge_discharge_command": {
-        "name": "Comando de carga/descarga"
-      },
       "forced_charging": {
         "name": "Carga forzada"
       },
@@ -216,6 +213,9 @@
       },
       "reactive_power_regulation_mode": {
         "name": "Modo de potencia reactiva"
+      },
+      "battery_mode": {
+        "name": "Modo de batería"
       }
     }
   },
@@ -236,6 +236,32 @@
         "start_date": {
           "name": "Fecha de inicio",
           "description": "Fecha más temprana opcional desde la que importar (interpretada como medianoche UTC). Por defecto usa la ventana de relleno configurada."
+        }
+      }
+    },
+    "set_battery_mode": {
+      "name": "Establecer modo de batería",
+      "description": "Establece el modo de batería (Autoconsumo / Carga forzada / Descarga forzada / Parar). La duración opcional anula Forced Dispatch Duration solo para este comando.",
+      "fields": {
+        "mode": {
+          "name": "Modo",
+          "description": "Modo de batería a aplicar."
+        },
+        "duration_minutes": {
+          "name": "Duración",
+          "description": "Minutos hasta volver a Autoconsumo (0 = sin auto-revertir este comando)."
+        },
+        "entity_id": {
+          "name": "Entidad de modo de batería",
+          "description": "La entidad select de modo de batería. Vacío para todas las plantas con batería."
+        },
+        "device_id": {
+          "name": "Dispositivo",
+          "description": "Dispositivo de dispatch con el select de modo de batería."
+        },
+        "config_entry": {
+          "name": "Integración",
+          "description": "Entrada de configuración Sungrow."
         }
       }
     }

--- a/custom_components/sungrow/translations/fr.json
+++ b/custom_components/sungrow/translations/fr.json
@@ -199,9 +199,6 @@
       }
     },
     "select": {
-      "charge_discharge_command": {
-        "name": "Commande de charge/décharge"
-      },
       "forced_charging": {
         "name": "Charge forcée"
       },
@@ -216,6 +213,9 @@
       },
       "reactive_power_regulation_mode": {
         "name": "Mode de puissance réactive"
+      },
+      "battery_mode": {
+        "name": "Mode batterie"
       }
     }
   },
@@ -236,6 +236,32 @@
         "start_date": {
           "name": "Date de début",
           "description": "Date la plus ancienne facultative à partir de laquelle importer (interprétée comme minuit UTC). Par défaut, la fenêtre de remplissage configurée."
+        }
+      }
+    },
+    "set_battery_mode": {
+      "name": "Définir le mode batterie",
+      "description": "Définit le mode batterie (Autoconsommation / Charge forcée / Décharge forcée / Arrêt). La durée optionnelle remplace Forced Dispatch Duration pour cette commande uniquement.",
+      "fields": {
+        "mode": {
+          "name": "Mode",
+          "description": "Mode batterie à appliquer."
+        },
+        "duration_minutes": {
+          "name": "Durée",
+          "description": "Minutes avant retour à l'autoconsommation (0 = pas d'auto-retour pour cette commande)."
+        },
+        "entity_id": {
+          "name": "Entité mode batterie",
+          "description": "L'entité select du mode batterie. Vide pour toutes les centrales avec batterie."
+        },
+        "device_id": {
+          "name": "Appareil",
+          "description": "Appareil de dispatch portant le select mode batterie."
+        },
+        "config_entry": {
+          "name": "Intégration",
+          "description": "Entrée de configuration Sungrow."
         }
       }
     }

--- a/docs/SENSORS.md
+++ b/docs/SENSORS.md
@@ -147,7 +147,7 @@ If your inverter / ESS supports parameter configuration, the integration also cr
 
 | Entity | Parameter | Range / options | Battery? |
 |---|---|---|---|
-| Charge/Discharge Command | `charge_discharge_command` | Stop / Charge / Discharge | ✅ |
+| Battery Mode | `battery_mode` | Self-consumption / Force charge / Force discharge / Stop | ✅ |
 | Charge/Discharge Power | `charge_discharge_power` | 0 W – device rating (fallback 5000 W) | ✅ |
 | SOC Upper Limit | `soc_upper_limit` | 70–100 % | ✅ |
 | SOC Lower Limit | `soc_lower_limit` | 0–50 % | ✅ |
@@ -163,25 +163,41 @@ If your inverter / ESS supports parameter configuration, the integration also cr
 | Reactive Power Mode | `reactive_power_regulation_mode` | Off / Power Factor / Q(t) / Q(P) / Q(U) | — |
 | Reactive Power Ratio Q(t) | `q_t` | −60–60 % | — |
 | Power Factor | `pf` | −1 to 1 | — |
-| Forced Dispatch Duration | *(local)* | 0–1440 min (0 = off) | ✅ |
+| Forced Dispatch Duration | *(local)* | 0–1440 min (default **60**; 0 = off) | ✅ |
 
 The power sliders (charge/discharge power, export limit power) are sized to the device's **rated power**, parsed from its model code (e.g. `SG3.6RS` → 3.6 kW), falling back to 5000 W when the rating can't be derived.
 
 The **reactive-power** controls work together: set **Reactive Power Mode** first, then the relevant value — **Power Factor** only takes effect in *Power Factor* mode, and **Reactive Power Ratio Q(t)** only in *Q(t)* mode. These are grid-quality controls and are available on PV-only plants too (they aren't battery-gated).
 
-When you set **Charge/Discharge Command** to *Charge* or *Discharge*, the integration:
+### Battery Mode (#255)
+
+**Battery Mode** is the single select for force charge/discharge (replacing the older Charge/Discharge Command entity). Options:
+
+| Option | What it does |
+|---|---|
+| **Self-consumption** | Safe default — EMS Self-consumption + stop command |
+| **Force charge** | Compulsory/Forced EMS mode + charge command + heartbeat |
+| **Force discharge** | Compulsory/Forced EMS mode + discharge command + heartbeat |
+| **Stop** | Same safe write as Self-consumption (ends a forced command) |
+
+When you select **Force charge** or **Force discharge**, the integration:
 
 1. Switches **Energy Management Mode** (param `10003`) to **Compulsory / Forced** — required for the command to take effect (writing charge/discharge alone is accepted by the device but ignored while the plant stays in Self-consumption).
-2. Starts the External EMS heartbeat (param `10017`) every 60 seconds.
+2. Writes **Charge/Discharge Command** (param `10004`).
+3. Starts the External EMS heartbeat (param `10017`) every 60 seconds.
+4. Arms **auto-revert** (see below).
 
-Selecting **Stop** restores Self-consumption mode and turns the heartbeat off. If you remove the dispatch entities, the heartbeat is also stopped.
+**Self-consumption** / **Stop** restore Self-consumption mode and turn the heartbeat off.
 
-If that heartbeat ever stops unexpectedly while a forced Charge/Discharge is active (so the inverter would silently time out of forced mode), the integration raises a **"Dispatch keepalive stopped"** Repair — see [Troubleshooting](TROUBLESHOOTING.md#a-repair-appeared-whitelist-rejection-or-rate-limit).
+Automations can use the **`sungrow.set_battery_mode`** service (with an optional per-call `duration_minutes`) instead of driving the select entity directly — useful for tariff schedules.
 
-After a Charge/Discharge command, the integration also reads the Energy Management Mode back to confirm the inverter actually entered **Forced** mode. If it was accepted but stayed in Self-consumption, the command is re-sent once; if it still hasn't switched, a **"Dispatch command was not applied"** Repair is raised so a silently-ignored command doesn't look successful.
+If that heartbeat ever stops unexpectedly while a forced mode is active (so the inverter would silently time out of forced mode), the integration raises a **"Dispatch keepalive stopped"** Repair — see [Troubleshooting](TROUBLESHOOTING.md#a-repair-appeared-whitelist-rejection-or-rate-limit).
 
-> **Auto-revert (safety).** Set **Forced Dispatch Duration** to a number of minutes and a forced *Charge*/*Discharge* automatically reverts to **Stop** after that long — so a forced command can't silently persist and curtail your solar (the [#148](https://github.com/KRoperUK/sungrow-hass/issues/148) footgun). The countdown survives a Home Assistant restart (if it expires while HA is down, the command reverts on startup). Leave it at **0** to keep the legacy behaviour (a forced command stays until you change it). It's a local control — it writes nothing to the inverter itself.
+After a forced command, the integration also reads the Energy Management Mode back to confirm the inverter actually entered **Forced** mode. If it was accepted but stayed in Self-consumption, the command is re-sent once; if it still hasn't switched, a **"Dispatch command was not applied"** Repair is raised so a silently-ignored command doesn't look successful.
 
+> **Auto-revert (safety).** **Forced Dispatch Duration** defaults to **60 minutes**. A forced *Force charge* / *Force discharge* automatically reverts to **Self-consumption** after that long — so a forced command can't silently persist and curtail your solar (the [#148](https://github.com/KRoperUK/sungrow-hass/issues/148) footgun). The countdown survives a Home Assistant restart (if it expires while HA is down, the command reverts on startup). Set it to **0** only if you deliberately want no auto-revert. The `set_battery_mode` service can override duration for a single call. It's a local control — it writes nothing to the inverter itself.
+
+> **Breaking change.** The old `select.*_charge_discharge_command` entity is replaced by `select.*_battery_mode` with options *Self-consumption / Force charge / Force discharge / Stop*. Update automations accordingly (or use `sungrow.set_battery_mode`). Restored *Charge*/*Discharge*/*Stop* states from the old entity map onto the new options.
 > Dispatch support requires the correct iSolarCloud API plan and firmware. The integration will only create dispatch entities if it can discover a compatible inverter or ESS device for the plant.
 
 > **⚠️ Battery controls are hidden on PV-only plants.** Charge/discharge, SOC, forced-charging and battery-first controls only appear when the plant has a battery/ESS. Sending a charge/discharge command to a **battery-less** inverter can force it into External-EMS mode and **suppress generation**, so these controls are withheld on PV-only systems. Export- and active-power-limiting controls remain available.

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -140,6 +140,11 @@ when iSolarCloud rejects requests for a reason you can act on:
   again; if it persists, your account/model may not support cloud dispatch (some
   require External-EMS to be enabled). The Repair clears once a command is confirmed
   applied or you Stop dispatch.
+- **Forced Charge/Discharge ends on its own.** That is intentional. **Forced Dispatch
+  Duration** (default **60 minutes**) auto-reverts a forced **Charge**/**Discharge** to
+  **Stop** so the command cannot silently persist across hours or restarts. Raise the
+  duration if you need a longer window, or set it to **0** only if you deliberately want
+  no auto-revert (not recommended).
 
 ---
 

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -122,29 +122,30 @@ when iSolarCloud rejects requests for a reason you can act on:
   root cause, **raise the polling interval** (Configure → Polling interval) and,
   if you have per-device sensors enabled, consider turning them off (each device
   type adds a call per poll). The Repair clears once the quota resets.
-- **"Dispatch keepalive stopped".** While a forced **Charge**/**Discharge** is
+- **"Dispatch keepalive stopped".** While **Force charge**/**Force discharge** is
   active, the integration runs a background keepalive (the External-EMS heartbeat)
   that holds the inverter in forced mode. If that keepalive stops unexpectedly, the
   inverter times out of forced mode and the command silently stops being applied —
-  so this Repair is raised. To recover, set **Charge/Discharge Command** back to
-  **Stop** and then to **Charge**/**Discharge** again to restart the keepalive; the
-  Repair clears when the keepalive restarts or you Stop dispatch. If it keeps
-  recurring, enable debug logging (below) and open an issue with the log around the
-  time it happened.
-- **"Dispatch command was not applied".** After you command **Charge**/**Discharge**,
-  the integration reads the inverter's Energy Management Mode back to confirm it
-  actually entered **Forced** mode. If the write was accepted but the inverter stayed
-  in **Self-consumption**, it re-sends the forced-mode command once; if it *still*
+  so this Repair is raised. To recover, set **Battery Mode** back to
+  **Self-consumption** (or **Stop**) and then to **Force charge**/**Force discharge**
+  again to restart the keepalive; the Repair clears when the keepalive restarts or you
+  leave forced mode. If it keeps recurring, enable debug logging (below) and open an
+  issue with the log around the time it happened.
+- **"Dispatch command was not applied".** After you command **Force charge**/**Force
+  discharge**, the integration reads the inverter's Energy Management Mode back to
+  confirm it actually entered **Forced** mode. If the write was accepted but the inverter
+  stayed in **Self-consumption**, it re-sends the forced-mode command once; if it *still*
   hasn't switched, this Repair is raised — the command isn't taking effect. This can
-  happen on some models/firmware or API plans. Try **Stop** then **Charge**/**Discharge**
-  again; if it persists, your account/model may not support cloud dispatch (some
-  require External-EMS to be enabled). The Repair clears once a command is confirmed
-  applied or you Stop dispatch.
-- **Forced Charge/Discharge ends on its own.** That is intentional. **Forced Dispatch
-  Duration** (default **60 minutes**) auto-reverts a forced **Charge**/**Discharge** to
-  **Stop** so the command cannot silently persist across hours or restarts. Raise the
-  duration if you need a longer window, or set it to **0** only if you deliberately want
-  no auto-revert (not recommended).
+  happen on some models/firmware or API plans. Try **Self-consumption** then **Force
+  charge**/**Force discharge** again; if it persists, your account/model may not support
+  cloud dispatch (some require External-EMS to be enabled). The Repair clears once a
+  command is confirmed applied or you leave forced mode.
+- **Forced charge/discharge ends on its own.** That is intentional. **Forced Dispatch
+  Duration** (default **60 minutes**) auto-reverts a forced mode to **Self-consumption**
+  so the command cannot silently persist across hours or restarts. Raise the duration if
+  you need a longer window, or set it to **0** only if you deliberately want no
+  auto-revert (not recommended). The `sungrow.set_battery_mode` service can also pass a
+  one-shot `duration_minutes`.
 
 ---
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -37,12 +37,14 @@ inverters** through the **iSolarCloud** cloud API, using the
   import/export electricity prices, surfaced as sensors on the plant device.
 - **Custom measure points** — request additional iSolarCloud point IDs (e.g. battery
   charge/discharge power or EV-charger values) from the options flow.
-- **Dispatch / control** — number and select entities for charge/discharge command, power, SOC
-  limits, forced charging and export/active-power limiting, with an automatic EMS heartbeat while
-  dispatching. Battery controls are hidden on PV-only plants.
+- **Dispatch / control** — a single **Battery Mode** select (Self-consumption / Force charge /
+  Force discharge / Stop), power and SOC numbers, forced charging and export/active-power
+  limiting, with an automatic EMS heartbeat while force-dispatching. Battery controls are hidden
+  on PV-only plants. Automations can call **`sungrow.set_battery_mode`**.
 - **Safer dispatch** — **Forced Dispatch Duration** (default **60 minutes**) auto-reverts a
-  forced charge/discharge to *Stop* after a set time (surviving restarts), so it can't silently
-  persist. Set the duration to `0` only if you intentionally want unbounded forced commands.
+  forced charge/discharge to *Self-consumption* after a set time (surviving restarts), so it can't
+  silently persist. Set the duration to `0` only if you intentionally want unbounded forced
+  commands.
 - **Resilient polling** — rides out brief API/network hiccups instead of flapping unavailable, and
   auto-backs-off when rate-limited.
 - **Guided repairs** — whitelist and rate-limit rejections, an unexpectedly-stopped

--- a/docs/index.md
+++ b/docs/index.md
@@ -40,8 +40,9 @@ inverters** through the **iSolarCloud** cloud API, using the
 - **Dispatch / control** — number and select entities for charge/discharge command, power, SOC
   limits, forced charging and export/active-power limiting, with an automatic EMS heartbeat while
   dispatching. Battery controls are hidden on PV-only plants.
-- **Safer dispatch** — an optional **Forced Dispatch Duration** auto-reverts a forced
-  charge/discharge to *Stop* after a set time (surviving restarts), so it can't silently persist.
+- **Safer dispatch** — **Forced Dispatch Duration** (default **60 minutes**) auto-reverts a
+  forced charge/discharge to *Stop* after a set time (surviving restarts), so it can't silently
+  persist. Set the duration to `0` only if you intentionally want unbounded forced commands.
 - **Resilient polling** — rides out brief API/network hiccups instead of flapping unavailable, and
   auto-backs-off when rate-limited.
 - **Guided repairs** — whitelist and rate-limit rejections, an unexpectedly-stopped

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -1348,7 +1348,7 @@ async def test_user_update_maps_plant_detail_points(hass: HomeAssistant):
     client = MagicMock()
     client.async_get_plant_detail = AsyncMock(
         return_value={
-            "curr_power": {"value": "3200", "unit": "W"},
+            "curr_power": {"value": "0.49", "unit": "kW"},
             "p83106_map_virgin": {"value": "12500", "unit": "Wh"},
         }
     )
@@ -1357,7 +1357,9 @@ async def test_user_update_maps_plant_detail_points(hass: HomeAssistant):
     data = await coordinator._async_update_data()
 
     client.async_get_plant_detail.assert_awaited_once_with("12345")
-    assert data["current_power"]["value"] == "3200"
+    # kW is normalised to W for the cloud_user path (×1000).
+    assert data["current_power"]["value"] == 490.0
+    assert data["current_power"]["unit"] == "W"
     assert data["current_power"]["source"] == "cloud_user"
     # The 83106 measure point is present (Wh normalised to kWh downstream).
     assert "83106" in data

--- a/tests/test_dispatch.py
+++ b/tests/test_dispatch.py
@@ -1085,7 +1085,9 @@ async def test_restored_command_reverts_when_deadline_passed(hass: HomeAssistant
     command = next(e for e in added if e.param == "battery_mode")
     command.hass = hass
     command.async_write_ha_state = MagicMock()
-    command.async_get_last_state = AsyncMock(return_value=State("select.x", "Force charge", {"revert_at": time.time() - 10}))
+    command.async_get_last_state = AsyncMock(
+        return_value=State("select.x", "Force charge", {"revert_at": time.time() - 10})
+    )
 
     with (
         patch.object(CoordinatorEntity, "async_added_to_hass", new=AsyncMock()),

--- a/tests/test_dispatch.py
+++ b/tests/test_dispatch.py
@@ -969,6 +969,23 @@ async def test_forced_dispatch_duration_number_is_local(hass: HomeAssistant):
     data.control.async_update_parameters.assert_not_called()
 
 
+async def test_forced_dispatch_duration_defaults_to_safe_bound(hass: HomeAssistant):
+    """New installs default to a non-zero duration so forced commands auto-revert (#255)."""
+    from custom_components.sungrow.number import (
+        DEFAULT_FORCED_DISPATCH_DURATION,
+        SungrowForcedDispatchDurationNumber,
+    )
+
+    entry = MockConfigEntry(domain=DOMAIN, data=MOCK_CONFIG_DATA.copy())
+    entry.add_to_hass(hass)
+    data = _setup_entry_data(entry, [{"uuid": "ess-1", "device_type": "ENERGY_STORAGE_SYSTEM"}])
+    number = SungrowForcedDispatchDurationNumber(data.coordinators[0], {"uuid": "ess-1"})
+
+    assert DEFAULT_FORCED_DISPATCH_DURATION > 0
+    assert number.native_value == DEFAULT_FORCED_DISPATCH_DURATION
+    assert data.coordinators[0].forced_dispatch_duration_minutes == DEFAULT_FORCED_DISPATCH_DURATION
+
+
 async def test_charge_arms_autorevert_and_stop_cancels(hass: HomeAssistant):
     """Selecting Charge arms the auto-revert (with a persisted deadline); Stop cancels it."""
     entry = MockConfigEntry(domain=DOMAIN, data=MOCK_CONFIG_DATA.copy())

--- a/tests/test_dispatch.py
+++ b/tests/test_dispatch.py
@@ -227,7 +227,7 @@ GRID_SIDE_NUMBERS = {
     "q_t",
     "pf",
 }
-BATTERY_ONLY_SELECTS = {"charge_discharge_command", "forced_charging", "battery_first"}
+BATTERY_ONLY_SELECTS = {"battery_mode", "forced_charging", "battery_first"}
 GRID_SIDE_SELECTS = {"feed_in_limitation", "limited_power_switch", "reactive_power_regulation_mode"}
 
 
@@ -497,9 +497,9 @@ async def test_select_setup_creates_entities_for_ess_device(hass: HomeAssistant)
     await select_setup_entry(hass, entry, lambda entities: added.extend(entities))
 
     assert len(added) == len(DISPATCH_SELECTS)
-    command = next(e for e in added if e.param == "charge_discharge_command")
+    command = next(e for e in added if e.param == "battery_mode")
     assert isinstance(command, SelectEntity)
-    assert set(command.options_map.keys()) == {"Stop", "Charge", "Discharge"}
+    assert set(command.options_map.keys()) == {"Self-consumption", "Force charge", "Force discharge", "Stop"}
 
 
 async def test_select_option_calls_control(hass: HomeAssistant):
@@ -511,11 +511,11 @@ async def test_select_option_calls_control(hass: HomeAssistant):
 
     added = []
     await select_setup_entry(hass, entry, lambda entities: added.extend(entities))
-    command = next(e for e in added if e.param == "charge_discharge_command")
+    command = next(e for e in added if e.param == "battery_mode")
     command.hass = hass
 
     with patch("custom_components.sungrow.select.async_start_heartbeat", new=AsyncMock()):
-        await command.async_select_option("Charge")
+        await command.async_select_option("Force charge")
     command._cancel_verify()  # cancel the scheduled actuation check (no lingering timer)
 
     # Charge/Discharge must also switch Energy Management Mode to Compulsory (10003=2)
@@ -535,7 +535,7 @@ async def test_select_stop_stops_heartbeat(hass: HomeAssistant):
 
     added = []
     await select_setup_entry(hass, entry, lambda entities: added.extend(entities))
-    command = next(e for e in added if e.param == "charge_discharge_command")
+    command = next(e for e in added if e.param == "battery_mode")
 
     command.hass = hass
     with patch("custom_components.sungrow.select.async_stop_heartbeat", new=AsyncMock()) as mock_stop:
@@ -558,11 +558,11 @@ async def test_select_discharge_switches_to_compulsory_mode(hass: HomeAssistant)
 
     added = []
     await select_setup_entry(hass, entry, lambda entities: added.extend(entities))
-    command = next(e for e in added if e.param == "charge_discharge_command")
+    command = next(e for e in added if e.param == "battery_mode")
     command.hass = hass
 
     with patch("custom_components.sungrow.select.async_start_heartbeat", new=AsyncMock()):
-        await command.async_select_option("Discharge")
+        await command.async_select_option("Force discharge")
     command._cancel_verify()  # cancel the scheduled actuation check (no lingering timer)
 
     entry_data.control.async_update_parameters.assert_awaited_once_with(
@@ -580,7 +580,7 @@ async def test_select_availability_follows_coordinator(hass: HomeAssistant):
 
     added = []
     await select_setup_entry(hass, entry, lambda entities: added.extend(entities))
-    command = next(e for e in added if e.param == "charge_discharge_command")
+    command = next(e for e in added if e.param == "battery_mode")
 
     assert command.current_option is None
     assert command.available is True
@@ -868,7 +868,7 @@ async def test_select_forced_charging_is_config(hass: HomeAssistant):
     await select_setup_entry(hass, entry, lambda entities: added.extend(entities))
     cats = {e.param: e._attr_entity_category for e in added}
 
-    assert cats["charge_discharge_command"] is None
+    assert cats["battery_mode"] is None
     assert cats["forced_charging"] == EntityCategory.CONFIG
 
 
@@ -905,7 +905,7 @@ async def test_select_restores_last_option(hass: HomeAssistant):
 
     added = []
     await select_setup_entry(hass, entry, lambda entities: added.extend(entities))
-    command = next(e for e in added if e.param == "charge_discharge_command")
+    command = next(e for e in added if e.param == "battery_mode")
     command.hass = hass
     # Restore a non-dispatching option so this stays a pure restore test; the
     # Charge/Discharge heartbeat-resume path is covered separately (#112).
@@ -921,7 +921,7 @@ async def test_restored_charge_command_resumes_heartbeat(hass: HomeAssistant):
     """A restored Charge command restarts the EMS heartbeat after a restart/reload (#112).
 
     Otherwise the inverter times out of External-EMS mode while the UI still shows
-    "Charge" — the command select must restore state AND resume the heartbeat.
+    "Force charge" — the battery-mode select must restore state AND resume the heartbeat.
     """
     from homeassistant.core import State
     from homeassistant.helpers.update_coordinator import CoordinatorEntity
@@ -932,9 +932,9 @@ async def test_restored_charge_command_resumes_heartbeat(hass: HomeAssistant):
 
     added = []
     await select_setup_entry(hass, entry, lambda entities: added.extend(entities))
-    command = next(e for e in added if e.param == "charge_discharge_command")
+    command = next(e for e in added if e.param == "battery_mode")
     command.hass = hass
-    command.async_get_last_state = AsyncMock(return_value=State("select.x", "Charge"))
+    command.async_get_last_state = AsyncMock(return_value=State("select.x", "Force charge"))
 
     with (
         patch.object(CoordinatorEntity, "async_added_to_hass", new=AsyncMock()),
@@ -942,7 +942,7 @@ async def test_restored_charge_command_resumes_heartbeat(hass: HomeAssistant):
     ):
         await command.async_added_to_hass()
 
-    assert command.current_option == "Charge"
+    assert command.current_option == "Force charge"
     mock_start.assert_awaited_once()
     # The heartbeat is started for the restored command's device.
     assert mock_start.call_args.args[3] == "ess-1"
@@ -995,14 +995,14 @@ async def test_charge_arms_autorevert_and_stop_cancels(hass: HomeAssistant):
 
     added: list = []
     await select_setup_entry(hass, entry, lambda e: added.extend(e))
-    command = next(e for e in added if e.param == "charge_discharge_command")
+    command = next(e for e in added if e.param == "battery_mode")
     command.hass = hass
 
     with (
         patch("custom_components.sungrow.select.async_start_heartbeat", new=AsyncMock()),
         patch("custom_components.sungrow.select.async_stop_heartbeat", new=AsyncMock()),
     ):
-        await command.async_select_option("Charge")
+        await command.async_select_option("Force charge")
         assert command._revert_deadline is not None
         assert command.extra_state_attributes == {"revert_at": command._revert_deadline}
 
@@ -1019,10 +1019,10 @@ async def test_autorevert_writes_stop_and_stops_heartbeat(hass: HomeAssistant):
 
     added: list = []
     await select_setup_entry(hass, entry, lambda e: added.extend(e))
-    command = next(e for e in added if e.param == "charge_discharge_command")
+    command = next(e for e in added if e.param == "battery_mode")
     command.hass = hass
     command.async_write_ha_state = MagicMock()
-    command._attr_current_option = "Charge"
+    command._attr_current_option = "Force charge"
 
     with patch("custom_components.sungrow.select.async_stop_heartbeat", new=AsyncMock()) as mock_stop:
         await command._do_revert()
@@ -1032,7 +1032,7 @@ async def test_autorevert_writes_stop_and_stops_heartbeat(hass: HomeAssistant):
         {"charge_discharge_command": "204", "energy_management_mode": "0"},
     )
     mock_stop.assert_awaited_once()
-    assert command.current_option == "Stop"
+    assert command.current_option == "Self-consumption"
     assert command._revert_deadline is None
 
 
@@ -1050,10 +1050,10 @@ async def test_autorevert_after_removal_is_noop(hass: HomeAssistant):
 
     added: list = []
     await select_setup_entry(hass, entry, lambda e: added.extend(e))
-    command = next(e for e in added if e.param == "charge_discharge_command")
+    command = next(e for e in added if e.param == "battery_mode")
     command.hass = hass
     command.async_write_ha_state = MagicMock()
-    command._attr_current_option = "Charge"
+    command._attr_current_option = "Force charge"
 
     # Removal (e.g. an entry reload) sets the guard flag.
     with patch.object(CoordinatorEntity, "async_will_remove_from_hass", new=AsyncMock()):
@@ -1082,10 +1082,10 @@ async def test_restored_command_reverts_when_deadline_passed(hass: HomeAssistant
 
     added: list = []
     await select_setup_entry(hass, entry, lambda e: added.extend(e))
-    command = next(e for e in added if e.param == "charge_discharge_command")
+    command = next(e for e in added if e.param == "battery_mode")
     command.hass = hass
     command.async_write_ha_state = MagicMock()
-    command.async_get_last_state = AsyncMock(return_value=State("select.x", "Charge", {"revert_at": time.time() - 10}))
+    command.async_get_last_state = AsyncMock(return_value=State("select.x", "Force charge", {"revert_at": time.time() - 10}))
 
     with (
         patch.object(CoordinatorEntity, "async_added_to_hass", new=AsyncMock()),
@@ -1100,7 +1100,7 @@ async def test_restored_command_reverts_when_deadline_passed(hass: HomeAssistant
         {"charge_discharge_command": "204", "energy_management_mode": "0"},
     )
     mock_start.assert_not_awaited()
-    assert command.current_option == "Stop"
+    assert command.current_option == "Self-consumption"
 
 
 async def test_restored_command_rearms_when_deadline_future(hass: HomeAssistant):
@@ -1116,10 +1116,10 @@ async def test_restored_command_rearms_when_deadline_future(hass: HomeAssistant)
 
     added: list = []
     await select_setup_entry(hass, entry, lambda e: added.extend(e))
-    command = next(e for e in added if e.param == "charge_discharge_command")
+    command = next(e for e in added if e.param == "battery_mode")
     command.hass = hass
     future = time.time() + 300
-    command.async_get_last_state = AsyncMock(return_value=State("select.x", "Charge", {"revert_at": future}))
+    command.async_get_last_state = AsyncMock(return_value=State("select.x", "Force charge", {"revert_at": future}))
 
     with (
         patch.object(CoordinatorEntity, "async_added_to_hass", new=AsyncMock()),
@@ -1143,7 +1143,7 @@ async def test_restored_stop_command_leaves_heartbeat_off(hass: HomeAssistant):
 
     added = []
     await select_setup_entry(hass, entry, lambda entities: added.extend(entities))
-    command = next(e for e in added if e.param == "charge_discharge_command")
+    command = next(e for e in added if e.param == "battery_mode")
     command.hass = hass
     command.async_get_last_state = AsyncMock(return_value=State("select.x", "Stop"))
 
@@ -1251,17 +1251,17 @@ async def test_select_option_api_error_raises_translated_error(hass: HomeAssista
 
     added = []
     await select_setup_entry(hass, entry, lambda entities: added.extend(entities))
-    command = next(e for e in added if e.param == "charge_discharge_command")
+    command = next(e for e in added if e.param == "battery_mode")
 
     with (
         patch("custom_components.sungrow.select.async_start_heartbeat", new=AsyncMock()),
         pytest.raises(HomeAssistantError) as exc,
     ):
-        await command.async_select_option("Charge")
+        await command.async_select_option("Force charge")
 
     assert exc.value.translation_key == "dispatch_write_failed"
     assert exc.value.translation_domain == DOMAIN
-    assert exc.value.translation_placeholders["param"] == "charge_discharge_command"
+    assert exc.value.translation_placeholders["param"] == "battery_mode"
 
 
 # ---------------------------------------------------------------------------
@@ -1327,9 +1327,9 @@ async def test_verify_flags_when_still_self_consumption(hass: HomeAssistant):
     data, entry = _command_select(hass)
     added: list = []
     await select_setup_entry(hass, entry, lambda e: added.extend(e))
-    command = next(e for e in added if e.param == "charge_discharge_command")
+    command = next(e for e in added if e.param == "battery_mode")
     command.hass = hass
-    command._attr_current_option = "Charge"
+    command._attr_current_option = "Force charge"
     data.control.async_read_parameters = AsyncMock(
         return_value=[{"id": "10003", "code": "energy_management_mode", "value": "0"}]
     )
@@ -1344,9 +1344,9 @@ async def test_verify_retry_recovers_no_issue(hass: HomeAssistant):
     data, entry = _command_select(hass)
     added: list = []
     await select_setup_entry(hass, entry, lambda e: added.extend(e))
-    command = next(e for e in added if e.param == "charge_discharge_command")
+    command = next(e for e in added if e.param == "battery_mode")
     command.hass = hass
-    command._attr_current_option = "Charge"
+    command._attr_current_option = "Force charge"
     # First read: still Self-consumption -> triggers a retry write; second read: Forced.
     data.control.async_read_parameters = AsyncMock(
         side_effect=[
@@ -1367,9 +1367,9 @@ async def test_verify_clears_issue_when_actuated(hass: HomeAssistant):
     data, entry = _command_select(hass)
     added: list = []
     await select_setup_entry(hass, entry, lambda e: added.extend(e))
-    command = next(e for e in added if e.param == "charge_discharge_command")
+    command = next(e for e in added if e.param == "battery_mode")
     command.hass = hass
-    command._attr_current_option = "Charge"
+    command._attr_current_option = "Force charge"
     ir.async_create_issue(
         hass,
         DOMAIN,
@@ -1393,9 +1393,9 @@ async def test_verify_skips_on_read_error(hass: HomeAssistant):
     data, entry = _command_select(hass)
     added: list = []
     await select_setup_entry(hass, entry, lambda e: added.extend(e))
-    command = next(e for e in added if e.param == "charge_discharge_command")
+    command = next(e for e in added if e.param == "battery_mode")
     command.hass = hass
-    command._attr_current_option = "Charge"
+    command._attr_current_option = "Force charge"
     data.control.async_read_parameters = AsyncMock(side_effect=PySolarCloudException("E900"))
 
     await command._verify_actuation()
@@ -1408,7 +1408,7 @@ async def test_verify_noop_when_not_charging(hass: HomeAssistant):
     data, entry = _command_select(hass)
     added: list = []
     await select_setup_entry(hass, entry, lambda e: added.extend(e))
-    command = next(e for e in added if e.param == "charge_discharge_command")
+    command = next(e for e in added if e.param == "battery_mode")
     command.hass = hass
     command._attr_current_option = "Stop"
     data.control.async_read_parameters = AsyncMock(return_value=[])
@@ -1424,15 +1424,109 @@ async def test_charge_schedules_check_and_stop_cancels(hass: HomeAssistant):
     data, entry = _command_select(hass)
     added: list = []
     await select_setup_entry(hass, entry, lambda e: added.extend(e))
-    command = next(e for e in added if e.param == "charge_discharge_command")
+    command = next(e for e in added if e.param == "battery_mode")
     command.hass = hass
 
     with (
         patch("custom_components.sungrow.select.async_start_heartbeat", new=AsyncMock()),
         patch("custom_components.sungrow.select.async_stop_heartbeat", new=AsyncMock()),
     ):
-        await command.async_select_option("Charge")
+        await command.async_select_option("Force charge")
         assert command._verify_cancel is not None  # a check is pending
 
         await command.async_select_option("Stop")
         assert command._verify_cancel is None  # cancelled, no lingering timer
+
+
+# ---------------------------------------------------------------------------
+# Unified battery mode + set_battery_mode service (#255)
+# ---------------------------------------------------------------------------
+
+
+async def test_legacy_charge_state_restores_as_force_charge(hass: HomeAssistant):
+    """Pre-#255 Charge/Discharge select states map onto the new battery mode options."""
+    from homeassistant.core import State
+    from homeassistant.helpers.update_coordinator import CoordinatorEntity
+
+    entry = MockConfigEntry(domain=DOMAIN, data=MOCK_CONFIG_DATA.copy())
+    entry.add_to_hass(hass)
+    _setup_entry_data(entry, [{"uuid": "ess-1", "device_type": "ENERGY_STORAGE_SYSTEM"}])
+
+    added: list = []
+    await select_setup_entry(hass, entry, lambda e: added.extend(e))
+    command = next(e for e in added if e.param == "battery_mode")
+    command.hass = hass
+    command.async_get_last_state = AsyncMock(return_value=State("select.x", "Charge"))
+
+    with (
+        patch.object(CoordinatorEntity, "async_added_to_hass", new=AsyncMock()),
+        patch("custom_components.sungrow.select.async_start_heartbeat", new=AsyncMock()) as mock_start,
+    ):
+        await command.async_added_to_hass()
+
+    assert command.current_option == "Force charge"
+    mock_start.assert_awaited_once()
+
+
+async def test_set_battery_mode_service_writes_and_overrides_duration(hass: HomeAssistant):
+    """sungrow.set_battery_mode targets the battery-mode select and can override duration."""
+    from custom_components.sungrow.const import DOMAIN
+    from custom_components.sungrow.services import async_setup_services
+    from custom_components.sungrow.select import BATTERY_MODE_FORCE_CHARGE
+
+    entry = MockConfigEntry(domain=DOMAIN, data=MOCK_CONFIG_DATA.copy())
+    entry.add_to_hass(hass)
+    data = _setup_entry_data(entry, [{"uuid": "ess-1", "device_type": "ENERGY_STORAGE_SYSTEM"}])
+    data.coordinators[0].forced_dispatch_duration_minutes = 60
+
+    added: list = []
+    await select_setup_entry(hass, entry, lambda e: added.extend(e))
+    command = next(e for e in added if e.param == "battery_mode")
+    command.hass = hass
+    command.entity_id = "select.test_battery_mode"
+    # Simulate async_added_to_hass registration without full HA entity lifecycle.
+    hass.data.setdefault(DOMAIN, {}).setdefault("battery_mode_selects", {})[command.entity_id] = command
+
+    async_setup_services(hass)
+
+    with patch("custom_components.sungrow.select.async_start_heartbeat", new=AsyncMock()):
+        await hass.services.async_call(
+            DOMAIN,
+            "set_battery_mode",
+            {"mode": "force_charge", "duration_minutes": 15, "entity_id": command.entity_id},
+            blocking=True,
+        )
+    command._cancel_verify()
+
+    data.control.async_update_parameters.assert_awaited_with(
+        "ess-1",
+        {"charge_discharge_command": "170", "energy_management_mode": "2"},
+    )
+    assert command.current_option == BATTERY_MODE_FORCE_CHARGE
+    assert command._revert_deadline is not None
+    # ~15 minutes, not the coordinator default of 60.
+    import time
+
+    remaining = command._revert_deadline - time.time()
+    assert 14 * 60 < remaining <= 15 * 60
+    command._cancel_revert()
+
+
+async def test_self_consumption_and_stop_share_safe_payload(hass: HomeAssistant):
+    """Self-consumption and Stop both restore EMS self-consumption + stop command."""
+    entry = MockConfigEntry(domain=DOMAIN, data=MOCK_CONFIG_DATA.copy())
+    entry.add_to_hass(hass)
+    data = _setup_entry_data(entry, [{"uuid": "ess-1", "device_type": "ENERGY_STORAGE_SYSTEM"}])
+
+    added: list = []
+    await select_setup_entry(hass, entry, lambda e: added.extend(e))
+    command = next(e for e in added if e.param == "battery_mode")
+    command.hass = hass
+
+    with patch("custom_components.sungrow.select.async_stop_heartbeat", new=AsyncMock()):
+        await command.async_select_option("Self-consumption")
+
+    data.control.async_update_parameters.assert_awaited_with(
+        "ess-1",
+        {"charge_discharge_command": "204", "energy_management_mode": "0"},
+    )

--- a/tests/test_dispatch.py
+++ b/tests/test_dispatch.py
@@ -1470,9 +1470,8 @@ async def test_legacy_charge_state_restores_as_force_charge(hass: HomeAssistant)
 
 async def test_set_battery_mode_service_writes_and_overrides_duration(hass: HomeAssistant):
     """sungrow.set_battery_mode targets the battery-mode select and can override duration."""
-    from custom_components.sungrow.const import DOMAIN
-    from custom_components.sungrow.services import async_setup_services
     from custom_components.sungrow.select import BATTERY_MODE_FORCE_CHARGE
+    from custom_components.sungrow.services import async_setup_services
 
     entry = MockConfigEntry(domain=DOMAIN, data=MOCK_CONFIG_DATA.copy())
     entry.add_to_hass(hass)

--- a/tests/test_energy_units.py
+++ b/tests/test_energy_units.py
@@ -3,6 +3,8 @@
 from custom_components.sungrow.energy_units import (
     normalize_energy_point,
     normalize_energy_units,
+    normalize_power_point,
+    normalize_power_units,
     tag_source,
 )
 
@@ -33,3 +35,60 @@ def test_payload_and_source_tag():
     # Does not overwrite an existing source.
     already = tag_source({"x": {"value": 1, "source": "modbus"}}, "cloud")
     assert already["x"]["source"] == "modbus"
+
+
+# --- Power normalization (kW → W) for cloud_user path ---
+
+
+def test_kw_to_w():
+    """A kW power point is scaled ×1000 to W."""
+    point = {"code": "current_power", "value": "0.49", "unit": "kW"}
+    out = normalize_power_point(point)
+    assert out["value"] == 490.0
+    assert out["unit"] == "W"
+
+
+def test_kw_to_w_larger_value():
+    """Typical residential system: 5.23 kW → 5230 W."""
+    point = {"code": "total_active_power", "value": "5.23", "unit": "kW"}
+    out = normalize_power_point(point)
+    assert out["value"] == 5230.0
+    assert out["unit"] == "W"
+
+
+def test_w_unchanged():
+    """A point already in W passes through untouched."""
+    point = {"code": "power", "value": "490", "unit": "W"}
+    assert normalize_power_point(point) is point
+
+
+def test_kw_empty_value():
+    """A kW point with no value still gets the unit fixed."""
+    point = {"code": "current_power", "value": "", "unit": "kW"}
+    out = normalize_power_point(point)
+    assert out["unit"] == "W"
+    assert out["value"] == ""
+
+
+def test_kw_none_value():
+    """A kW point with None value still gets the unit fixed."""
+    point = {"code": "current_power", "value": None, "unit": "kW"}
+    out = normalize_power_point(point)
+    assert out["unit"] == "W"
+
+
+def test_normalize_power_units_full_payload():
+    """normalize_power_units converts all kW points in a payload."""
+    data = {
+        "current_power": {"code": "current_power", "value": "0.49", "unit": "kW"},
+        "total_yield": {"code": "total_yield", "value": "6467.8", "unit": "kWh"},
+        "power": {"code": "power", "value": "490", "unit": "W"},
+    }
+    out = normalize_power_units(data)
+    assert out["current_power"]["value"] == 490.0
+    assert out["current_power"]["unit"] == "W"
+    # Energy units are NOT touched by power normalization.
+    assert out["total_yield"]["unit"] == "kWh"
+    # Already-W points pass through.
+    assert out["power"]["value"] == "490"
+    assert out["power"]["unit"] == "W"


### PR DESCRIPTION
## Summary

The `getPsDetail` API (cloud_user / username-password transport) returns power values in **kW** while the OAuth realtime endpoint returns them in **W**. This causes power sensors (e.g. "Current Power") to display 1000× too high — e.g. 490,000 W instead of 490 W.

## Changes

- **`energy_units.py`** — Added `normalize_power_point()` and `normalize_power_units()` that convert kW → W (×1000) for power points, mirroring the existing Wh → kWh energy normalization pattern.
- **`coordinator.py`** — Applied `normalize_power_units` in the cloud_user update path only (`_async_user_update`). The OAuth and Modbus paths are unaffected since they already return power in W.
- **Tests** — Added coverage for the new power normalization and updated the coordinator cloud_user test to verify kW→W conversion.

## What was tested

- Full test suite passes (620 tests, mypy strict, ruff clean)
- Normalization only triggers on "kW" unit string — existing "W" values pass through unchanged
- OAuth path is not affected (its kW values like `total_active_power` are left alone since `normalize_power_units` is only called in the cloud_user path)