### PR TITLE
feat: performance, tests, cloud_user sensors, refactor

### DIFF
--- a/custom_components/sungrow/coordinator.py
+++ b/custom_components/sungrow/coordinator.py
@@ -197,6 +197,10 @@ class SungrowPlantCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         self.enable_device_sensors: bool = bool(config_entry.options.get(CONF_ENABLE_DEVICE_SENSORS, False))
         # uuid -> { code: point } for per-device realtime (populated when enabled).
         self.device_data: dict[str, dict[str, Any]] = {}
+        # Device types that returned "unsupported" on a previous poll. Skipped on
+        # subsequent polls to avoid wasting API quota on endpoints that don't exist
+        # for this account/region (#288).
+        self._unsupported_device_types: set[Any] = set()
         # Whether the dispatch device accepts parameter writes. Checked once at
         # setup; defaults True (fail-open) so an unavailable/unknown check never
         # hides working controls.
@@ -543,6 +547,9 @@ class SungrowPlantCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             if type_id in seen_types:
                 continue
             seen_types.add(type_id)
+            # Skip device types that were previously marked unsupported (#288).
+            if type_id in self._unsupported_device_types:
+                continue
             # Forward the ps_key of every device of this type. getDeviceRealTimeData is
             # keyed per-device and rejects the call with result_code 009 when neither
             # ps_key_list nor sn_list is supplied (pysolarcloud >=0.9.1). Passing None
@@ -634,6 +641,10 @@ class SungrowPlantCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             except Exception as err:  # pylint: disable=broad-except
                 _LOGGER.debug("Per-device realtime failed for plant %s type %s: %s", self.plant_id, type_id, err)
                 continue
-            for uuid, points in (result or {}).items():
+            if not result:
+                # The endpoint is unavailable for this device type; skip on future polls.
+                self._unsupported_device_types.add(type_id)
+                continue
+            for uuid, points in result.items():
                 merged.setdefault(str(uuid), {}).update(points)
         return merged

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -116,9 +116,7 @@ async def test_backfill_service_with_start_date(hass: HomeAssistant):
     async_setup_services(hass)
 
     with patch.object(hass.config_entries, "async_entries", return_value=[entry]):
-        await hass.services.async_call(
-            DOMAIN, SERVICE_BACKFILL, {"start_date": date(2026, 1, 15)}, blocking=True
-        )
+        await hass.services.async_call(DOMAIN, SERVICE_BACKFILL, {"start_date": date(2026, 1, 15)}, blocking=True)
 
     call_kwargs = entry.runtime_data.backfill.async_run_on_demand.call_args.kwargs
     assert call_kwargs["start_date"].date() == date(2026, 1, 15)
@@ -147,6 +145,4 @@ async def test_set_battery_mode_no_selects_raises(hass: HomeAssistant):
     hass.data.setdefault(DOMAIN, {})["battery_mode_selects"] = {}
 
     with pytest.raises(ServiceValidationError, match="No Sungrow battery mode"):
-        await hass.services.async_call(
-            DOMAIN, SERVICE_SET_BATTERY_MODE, {"mode": "self_consumption"}, blocking=True
-        )
+        await hass.services.async_call(DOMAIN, SERVICE_SET_BATTERY_MODE, {"mode": "self_consumption"}, blocking=True)

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -1,0 +1,152 @@
+"""Tests for sungrow.backfill and sungrow.set_battery_mode services (#287)."""
+
+from __future__ import annotations
+
+from datetime import date
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from homeassistant.config_entries import ConfigEntryState
+from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import ServiceValidationError
+
+from custom_components.sungrow.const import CONF_TRANSPORT, DOMAIN, TRANSPORT_MODBUS_ONLY
+from custom_components.sungrow.services import (
+    SERVICE_BACKFILL,
+    SERVICE_SET_BATTERY_MODE,
+    _resolve_entries,
+    async_setup_services,
+)
+from tests.conftest import MOCK_CONFIG_DATA
+
+
+def _make_entry(hass, *, entry_id="test_entry", transport="cloud_only", state=ConfigEntryState.LOADED):
+    """Create a mock config entry."""
+    from unittest.mock import MagicMock as _MagicMock
+
+    entry = _MagicMock()
+    entry.entry_id = entry_id
+    entry.domain = DOMAIN
+    entry.state = state
+    entry.data = {**MOCK_CONFIG_DATA, CONF_TRANSPORT: transport}
+    entry.runtime_data = _MagicMock()
+    entry.runtime_data.backfill = _MagicMock()
+    entry.runtime_data.backfill.async_run_on_demand = AsyncMock()
+    return entry
+
+
+# ---------------------------------------------------------------------------
+# _resolve_entries
+# ---------------------------------------------------------------------------
+
+
+def test_resolve_entries_all_loaded(hass: HomeAssistant):
+    """With no entry_id, returns all loaded cloud entries."""
+    e1 = _make_entry(hass, entry_id="e1")
+    e2 = _make_entry(hass, entry_id="e2")
+    modbus = _make_entry(hass, entry_id="mb", transport=TRANSPORT_MODBUS_ONLY)
+
+    with patch.object(hass.config_entries, "async_entries", return_value=[e1, e2, modbus]):
+        result = _resolve_entries(hass, None)
+
+    assert result == [e1, e2]
+
+
+def test_resolve_entries_specific_entry(hass: HomeAssistant):
+    """With an entry_id, resolves that single entry."""
+    e1 = _make_entry(hass, entry_id="specific")
+
+    with patch.object(hass.config_entries, "async_get_entry", return_value=e1):
+        result = _resolve_entries(hass, "specific")
+
+    assert result == [e1]
+
+
+def test_resolve_entries_not_found_raises(hass: HomeAssistant):
+    """A bad entry_id raises ServiceValidationError."""
+    with (
+        patch.object(hass.config_entries, "async_get_entry", return_value=None),
+        pytest.raises(ServiceValidationError, match="No Sungrow config entry"),
+    ):
+        _resolve_entries(hass, "nonexistent")
+
+
+def test_resolve_entries_not_loaded_raises(hass: HomeAssistant):
+    """An unloaded entry raises ServiceValidationError."""
+    entry = _make_entry(hass, state=ConfigEntryState.NOT_LOADED)
+    with (
+        patch.object(hass.config_entries, "async_get_entry", return_value=entry),
+        pytest.raises(ServiceValidationError, match="not loaded"),
+    ):
+        _resolve_entries(hass, entry.entry_id)
+
+
+def test_resolve_entries_modbus_only_raises(hass: HomeAssistant):
+    """A Modbus-only entry raises ServiceValidationError."""
+    entry = _make_entry(hass, transport=TRANSPORT_MODBUS_ONLY)
+    with (
+        patch.object(hass.config_entries, "async_get_entry", return_value=entry),
+        pytest.raises(ServiceValidationError, match="Modbus"),
+    ):
+        _resolve_entries(hass, entry.entry_id)
+
+
+# ---------------------------------------------------------------------------
+# Backfill service
+# ---------------------------------------------------------------------------
+
+
+async def test_backfill_service_dispatches_to_manager(hass: HomeAssistant):
+    """The backfill service calls async_run_on_demand on addressed entries."""
+    entry = _make_entry(hass)
+
+    async_setup_services(hass)
+    assert hass.services.has_service(DOMAIN, SERVICE_BACKFILL)
+
+    with patch.object(hass.config_entries, "async_entries", return_value=[entry]):
+        await hass.services.async_call(DOMAIN, SERVICE_BACKFILL, {}, blocking=True)
+
+    entry.runtime_data.backfill.async_run_on_demand.assert_awaited_once_with(plant_ids=None, start_date=None)
+
+
+async def test_backfill_service_with_start_date(hass: HomeAssistant):
+    """A start_date is passed as UTC midnight datetime."""
+    entry = _make_entry(hass)
+
+    async_setup_services(hass)
+
+    with patch.object(hass.config_entries, "async_entries", return_value=[entry]):
+        await hass.services.async_call(
+            DOMAIN, SERVICE_BACKFILL, {"start_date": date(2026, 1, 15)}, blocking=True
+        )
+
+    call_kwargs = entry.runtime_data.backfill.async_run_on_demand.call_args.kwargs
+    assert call_kwargs["start_date"].date() == date(2026, 1, 15)
+
+
+async def test_backfill_service_skips_entry_without_manager(hass: HomeAssistant):
+    """An entry without a backfill manager is silently skipped."""
+    entry = _make_entry(hass)
+    entry.runtime_data.backfill = None
+
+    async_setup_services(hass)
+
+    with patch.object(hass.config_entries, "async_entries", return_value=[entry]):
+        # Should not raise.
+        await hass.services.async_call(DOMAIN, SERVICE_BACKFILL, {}, blocking=True)
+
+
+# ---------------------------------------------------------------------------
+# set_battery_mode service — target resolution
+# ---------------------------------------------------------------------------
+
+
+async def test_set_battery_mode_no_selects_raises(hass: HomeAssistant):
+    """No battery mode selects found raises ServiceValidationError."""
+    async_setup_services(hass)
+    hass.data.setdefault(DOMAIN, {})["battery_mode_selects"] = {}
+
+    with pytest.raises(ServiceValidationError, match="No Sungrow battery mode"):
+        await hass.services.async_call(
+            DOMAIN, SERVICE_SET_BATTERY_MODE, {"mode": "self_consumption"}, blocking=True
+        )


### PR DESCRIPTION
## Summary

Multi-issue improvement PR addressing performance, testing gaps, cloud_user data coverage, and code structure.

## Changes

### Performance fix (#288)
- **Cache unsupported device types** in `_async_fetch_device_data`. When a device type's per-device realtime endpoint returns empty, the type is skipped on subsequent polls. Eliminates redundant API calls per 5-minute poll cycle.

### Test coverage (#287)
- **New `tests/test_services.py`** — 9 tests for the `sungrow.backfill` and `sungrow.set_battery_mode` service resolution logic.

### Test coverage (#290)
- **New `tests/test_select_verification.py`** — 17 tests covering the safety-critical select.py actuation verification and auto-revert logic (`_reads_as_self_consumption`, `_verify_actuation`, `_do_revert`).

### Feature (#292)
- **Expand cloud_user `getPsDetail` field mappings** — Map additional named fields: `today_energy`, `total_energy`, `co2_reduce_total`, `today_income`, `total_income`. Add `CODE_ALIASES` for friendly sensor names.

### Refactor (#289)
- **Extract `device_helpers.py`** from `__init__.py` — Move `build_device_info`, `build_plant_device_info`, `select_dispatch_device`, `resolve_point_device`, `find_related_cloud_plant_id`, and `_matches_device_type` into a dedicated module. Re-exported from `__init__` for backward compat. Reduces `__init__.py` by ~120 lines.

## Verification
- All 651 tests pass
- mypy strict: no issues
- ruff check + format: all clean

## Issues closed as already-handled
- #291 (validate extra_measure_points) — already implemented
- #293 (OAuth flow cleanup) — already implemented
- #294 (Net Grid Power) — `meter_ac_power` already provides this