### PR TITLE
feat: periodic EMS dispatch state read-back (#286)

### DIFF
--- a/custom_components/sungrow/select.py
+++ b/custom_components/sungrow/select.py
@@ -216,6 +216,9 @@ class SungrowDispatchSelect(CoordinatorEntity[SungrowPlantCoordinator], RestoreE
         # Set once the entity is removed (e.g. an entry reload) so an already-fired
         # auto-revert task doesn't act on the plant after this instance is gone (#157).
         self._removed = False
+        # Throttle counter for the periodic EMS-mode read-back (#286). Only the battery-
+        # mode select reads back; other selects leave this at 0.
+        self._readback_counter: int = 0
 
     def _normalize_restored_option(self, state: str) -> str | None:
         """Map a restored state to a current option (including pre-#255 legacy names)."""
@@ -281,6 +284,59 @@ class SungrowDispatchSelect(CoordinatorEntity[SungrowPlantCoordinator], RestoreE
             if isinstance(registry, dict):
                 registry.pop(self.entity_id, None)
         await super().async_will_remove_from_hass()
+
+    @callback
+    def _handle_coordinator_update(self) -> None:
+        """Handle a coordinator update — includes throttled EMS-mode read-back (#286).
+
+        Every 3rd coordinator update (~15 min at default 5-min poll), the battery-mode
+        select reads the inverter's actual EMS mode back. If the portal or an external
+        automation changed the mode, the entity reflects the device truth instead of the
+        stale assumed state.
+        """
+        super()._handle_coordinator_update()
+        if self.param != BATTERY_MODE_PARAM:
+            return
+        self._readback_counter += 1
+        if self._readback_counter < 3:
+            return
+        self._readback_counter = 0
+        self.hass.async_create_task(self._async_dispatch_readback())
+
+    async def _async_dispatch_readback(self) -> None:
+        """Read the inverter's EMS mode and reconcile with the assumed state (#286)."""
+        if self._removed:
+            return
+        still_self = await self._read_still_self_consumption()
+        if still_self is None:
+            return  # Unknown — don't change anything.
+        current = self._attr_current_option
+        if still_self and current in BATTERY_MODE_FORCED:
+            # The inverter is in Self-consumption but we think it's forced — the portal
+            # or a timeout reverted it externally. Sync the entity state.
+            _LOGGER.info(
+                "EMS read-back for %s shows Self-consumption; updating from assumed %s",
+                self.device_uuid,
+                current,
+            )
+            self._attr_current_option = BATTERY_MODE_SELF_CONSUMPTION
+            self._cancel_revert()
+            entry = self.coordinator.config_entry
+            if entry is not None:
+                await async_stop_heartbeat(self.hass, entry, self.coordinator.plant_id)
+            self._clear_not_actuated_issue()
+            self.async_write_ha_state()
+        elif not still_self and current in BATTERY_MODE_SAFE:
+            # The inverter is in a forced/compulsory mode but we think it's safe — an
+            # external tool forced it. We can't know which forced option, so just note
+            # it in the log. The entity stays at its current option (Self-consumption/Stop)
+            # since we don't know if it's charge or discharge.
+            _LOGGER.debug(
+                "EMS read-back for %s shows Forced mode but entity shows %s; "
+                "an external tool may have changed the mode",
+                self.device_uuid,
+                current,
+            )
 
     @staticmethod
     def _restore_revert_deadline(raw: Any) -> float | None:

--- a/tests/test_dispatch_readback.py
+++ b/tests/test_dispatch_readback.py
@@ -1,0 +1,160 @@
+"""Tests for the periodic EMS dispatch read-back (#286)."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from homeassistant.core import HomeAssistant
+from pysolarcloud import PySolarCloudException
+from pysolarcloud.control import Control
+
+from custom_components.sungrow.select import (
+    BATTERY_MODE_FORCE_CHARGE,
+    BATTERY_MODE_SELF_CONSUMPTION,
+    DISPATCH_SELECTS,
+    SungrowDispatchSelect,
+)
+
+
+def _make_select(hass: HomeAssistant, *, param: str = "battery_mode") -> SungrowDispatchSelect:
+    coordinator = MagicMock()
+    coordinator.plant_id = "plant_1"
+    coordinator.plant_name = "Test Plant"
+    coordinator.config_entry = MagicMock()
+    coordinator.config_entry.entry_id = "entry_1"
+    coordinator.has_battery = True
+    coordinator.dispatch_update_supported = True
+    coordinator.forced_dispatch_duration_minutes = 0
+    coordinator.devices = [{"uuid": "dev-1", "device_type": MagicMock(value=14)}]
+
+    control = MagicMock(spec=Control)
+    control.async_update_parameters = AsyncMock(return_value=[])
+    control.async_read_parameters = AsyncMock(return_value=[])
+
+    device = {"uuid": "dev-1", "device_name": "Inverter", "device_type": MagicMock(value=14)}
+    meta = DISPATCH_SELECTS[param]
+    select = SungrowDispatchSelect(coordinator, control, device, param, meta)
+    select.hass = hass
+    select._removed = False
+    return select
+
+
+def _trigger_readback(select: SungrowDispatchSelect) -> None:
+    """Fire 3 coordinator updates to trigger the throttled read-back."""
+    with patch.object(select, "async_write_ha_state"):
+        select._handle_coordinator_update()
+        select._handle_coordinator_update()
+        select._handle_coordinator_update()
+
+
+async def test_readback_not_triggered_before_third_poll(hass: HomeAssistant):
+    """Read-back only fires every 3rd coordinator update."""
+    select = _make_select(hass)
+    select._attr_current_option = BATTERY_MODE_FORCE_CHARGE
+
+    with patch.object(select, "async_write_ha_state"):
+        select._handle_coordinator_update()
+        select._handle_coordinator_update()
+    await hass.async_block_till_done()
+
+    select.control.async_read_parameters.assert_not_awaited()
+
+
+async def test_readback_fires_on_third_poll(hass: HomeAssistant):
+    """Read-back fires on the 3rd coordinator update."""
+    select = _make_select(hass)
+    select._attr_current_option = BATTERY_MODE_FORCE_CHARGE
+    select.control.async_read_parameters = AsyncMock(
+        return_value=[{"id": "10003", "code": "energy_management_mode", "value": 2}]
+    )
+
+    _trigger_readback(select)
+    await hass.async_block_till_done()
+
+    select.control.async_read_parameters.assert_awaited_once()
+    assert select._attr_current_option == BATTERY_MODE_FORCE_CHARGE
+
+
+async def test_readback_detects_external_revert_to_self_consumption(hass: HomeAssistant):
+    """If read-back shows Self-consumption while we assume forced, sync the state."""
+    select = _make_select(hass)
+    select._attr_current_option = BATTERY_MODE_FORCE_CHARGE
+    select.control.async_read_parameters = AsyncMock(
+        return_value=[{"id": "10003", "code": "energy_management_mode", "value": 0}]
+    )
+
+    with patch("custom_components.sungrow.select.async_stop_heartbeat", new_callable=AsyncMock) as stop_mock:
+        _trigger_readback(select)
+        await hass.async_block_till_done()
+
+    assert select._attr_current_option == BATTERY_MODE_SELF_CONSUMPTION
+    stop_mock.assert_awaited_once()
+
+
+async def test_readback_no_action_when_safe_and_self_consumption(hass: HomeAssistant):
+    """If entity is already Self-consumption and read-back confirms, no change."""
+    select = _make_select(hass)
+    select._attr_current_option = BATTERY_MODE_SELF_CONSUMPTION
+    select.control.async_read_parameters = AsyncMock(
+        return_value=[{"id": "10003", "code": "energy_management_mode", "value": 0}]
+    )
+
+    _trigger_readback(select)
+    await hass.async_block_till_done()
+
+    assert select._attr_current_option == BATTERY_MODE_SELF_CONSUMPTION
+
+
+async def test_readback_unknown_does_not_change_state(hass: HomeAssistant):
+    """If read-back returns unknown (read error), state stays unchanged."""
+    select = _make_select(hass)
+    select._attr_current_option = BATTERY_MODE_FORCE_CHARGE
+    select.control.async_read_parameters = AsyncMock(side_effect=PySolarCloudException("network"))
+
+    _trigger_readback(select)
+    await hass.async_block_till_done()
+
+    assert select._attr_current_option == BATTERY_MODE_FORCE_CHARGE
+
+
+async def test_readback_skipped_for_non_battery_mode_selects(hass: HomeAssistant):
+    """Non-battery-mode selects never trigger read-back."""
+    select = _make_select(hass, param="feed_in_limitation")
+
+    with patch.object(select, "async_write_ha_state"):
+        for _ in range(10):
+            select._handle_coordinator_update()
+    await hass.async_block_till_done()
+
+    select.control.async_read_parameters.assert_not_awaited()
+
+
+async def test_readback_counter_resets_after_firing(hass: HomeAssistant):
+    """The counter resets after the read-back fires, so it fires again after 3 more."""
+    select = _make_select(hass)
+    select._attr_current_option = BATTERY_MODE_FORCE_CHARGE
+    select.control.async_read_parameters = AsyncMock(
+        return_value=[{"id": "10003", "code": "energy_management_mode", "value": 2}]
+    )
+
+    # First batch: fires on 3rd.
+    _trigger_readback(select)
+    await hass.async_block_till_done()
+    assert select.control.async_read_parameters.await_count == 1
+
+    # Second batch: fires again on 6th total (3rd since reset).
+    _trigger_readback(select)
+    await hass.async_block_till_done()
+    assert select.control.async_read_parameters.await_count == 2
+
+
+async def test_readback_skipped_when_removed(hass: HomeAssistant):
+    """If the entity was removed, read-back is a no-op."""
+    select = _make_select(hass)
+    select._attr_current_option = BATTERY_MODE_FORCE_CHARGE
+    select._removed = True
+
+    _trigger_readback(select)
+    await hass.async_block_till_done()
+
+    select.control.async_read_parameters.assert_not_awaited()


### PR DESCRIPTION
## Summary

Adds periodic read-back of the inverter's actual EMS mode to detect when the portal or an external automation changes the battery dispatch state.

## Problem

Dispatch entities are write-only (`assumed_state = True`). If the user changes the mode via the iSolarCloud portal or app, or if the inverter times out of forced mode, the HA entity stays stale showing the old forced state indefinitely.

## Solution

Every 3rd coordinator update (~15 min at default 5-min poll), the battery-mode select reads the inverter's EMS mode (param 10003) back via `async_read_parameters`. If the device is in Self-consumption but the entity assumes a forced mode:
1. Updates `_attr_current_option` to Self-consumption
2. Cancels any pending auto-revert timer
3. Stops the EMS heartbeat (no longer needed)
4. Clears any "dispatch not actuated" Repair

The read-back is:
- **Best-effort**: a read error or ambiguous value leaves state unchanged
- **Fail-safe**: only a *positive* Self-consumption reading triggers a sync (unknown = no-op)
- **Throttled**: runs every 3rd poll to avoid wasting API quota
- **Battery-mode only**: other selects (feed_in_limitation, etc.) don't read back

## Limitations

When an external tool puts the inverter into forced mode while the entity shows Self-consumption, we can't determine *which* forced option (charge vs discharge) it is, so the entity stays at Self-consumption and logs a debug note. This is conservative by design.

## Tests

8 new tests in `tests/test_dispatch_readback.py`:
- Throttle counter behavior (fires on 3rd, resets, counter resets)
- Detects external revert to Self-consumption
- No-op when state already agrees
- Unknown/error leaves state unchanged
- Skipped for non-battery-mode selects and removed entities

## Verification
- All 637 tests pass
- mypy strict: no issues
- ruff: all clean