### PR TITLE
chore: bump sungrow-isolarcloud to 0.13.0

### DIFF
--- a/custom_components/sungrow/manifest.json
+++ b/custom_components/sungrow/manifest.json
@@ -21,7 +21,7 @@
   ],
   "quality_scale": "platinum",
   "requirements": [
-    "sungrow-isolarcloud==0.12.0",
+    "sungrow-isolarcloud==0.13.0",
     "pymodbus>=3.6.0"
   ],
   "version": "5.1.0",

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -11,5 +11,5 @@ ruff==0.15.21
 mypy==2.2.0
 
 # Component dependencies
-sungrow-isolarcloud==0.12.0
+sungrow-isolarcloud==0.13.0
 pymodbus==3.13.1


### PR DESCRIPTION
## Summary

Bump the pinned `sungrow-isolarcloud` library from 0.12.0 to 0.13.0.

## What's in 0.13.0

- **fix**: `async_get_historical_data` loop variable shadowing and data overwrite (#49)
- **fix**: `auth_url()` missing default case raises `ValueError` on unknown server (#50)
- **fix**: `async_authorize` raises `AuthError` on failure instead of silent return (#51)
- **feat**: `UserAuth` expanded with `async_get_devices`, `async_get_device_realtime`, `async_get_historical_data` (#53)
- **chore**: mypy targets Python 3.12 to match `requires-python` (#52)
- **fix**: `param_valuest` typo in control.py debug log

## Files changed

- `custom_components/sungrow/manifest.json` — `sungrow-isolarcloud==0.13.0`
- `requirements_test.txt` — `sungrow-isolarcloud==0.13.0`

## Verification

- All 637 tests pass with 0.13.0 installed