### PR TITLE
chore: bump sungrow-isolarcloud to 0.14.0

### DIFF
--- a/custom_components/sungrow/manifest.json
+++ b/custom_components/sungrow/manifest.json
@@ -21,7 +21,7 @@
   ],
   "quality_scale": "platinum",
   "requirements": [
-    "sungrow-isolarcloud==0.13.0",
+    "sungrow-isolarcloud==0.14.0",
     "pymodbus>=3.6.0"
   ],
   "version": "5.2.0",

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -11,5 +11,5 @@ ruff==0.15.21
 mypy==2.2.0
 
 # Component dependencies
-sungrow-isolarcloud==0.13.0
+sungrow-isolarcloud==0.14.0
 pymodbus==3.13.1


### PR DESCRIPTION
## Summary

Bump the pinned `sungrow-isolarcloud` client to **0.14.0** (now on PyPI).

### Library changes (0.13.0 → 0.14.0)
- `UserControl` — user-account session param read/write on `/openapi/paramSetting*` (clean-room, #271)
- `UserAuth.async_request_soft` + experimental `user_control_probe` for go/no-go probing
- Live-proven: user token works on `/openapi/paramSetting`, not `/openapi/platform/*`

## Test plan
- [ ] CI lint + test
- [ ] Confirm manifest requirement resolves from PyPI