### PR TITLE
feat: enable cloud_user dispatch via UserControl (#271)

### DIFF
--- a/custom_components/sungrow/__init__.py
+++ b/custom_components/sungrow/__init__.py
@@ -16,7 +16,7 @@ from homeassistant.exceptions import ConfigEntryAuthFailed, ConfigEntryNotReady
 from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.event import async_call_later
-from pysolarcloud import UserAuth
+from pysolarcloud import UserAuth, UserControl
 from pysolarcloud.control import Control
 from pysolarcloud.plants import DeviceType, Plants
 
@@ -84,9 +84,9 @@ PLATFORMS: list[Platform] = [Platform.BINARY_SENSOR, Platform.NUMBER, Platform.S
 # list — unloading a platform that was never set up fails the unload, which breaks the
 # options-change reload and takes every entity unavailable.
 MODBUS_ONLY_PLATFORMS: list[Platform] = [Platform.BINARY_SENSOR, Platform.SENSOR]
-# A cloud user-account entry has no dispatch (no Control) and, in Phase 2, no realtime
-# points yet — only the sensor platform is forwarded; data lands in Phase 3 (#268/#269).
-CLOUD_USER_PLATFORMS: list[Platform] = [Platform.SENSOR]
+# cloud_user has sensors plus dispatch (UserControl over the app/web API, #271). No
+# binary sensors (device fault/connectivity come from the OAuth device list shape).
+CLOUD_USER_PLATFORMS: list[Platform] = [Platform.NUMBER, Platform.SELECT, Platform.SENSOR]
 
 
 def _entry_platforms(entry: SungrowConfigEntry) -> list[Platform]:
@@ -107,13 +107,18 @@ SETUP_TIMEOUT = 60
 _LOGGER = logging.getLogger(__name__)
 
 
+# Dispatch client: OAuth ``Control`` or user-account ``UserControl`` (#271).
+type DispatchControl = Control | UserControl
+
+
 @dataclass
 class SungrowData:
     """Runtime data stored on the config entry (``entry.runtime_data``)."""
 
     coordinators: list[SungrowPlantCoordinator]
     # None for a Modbus-only (cloud-free) entry, which has no dispatch/control (#159).
-    control: Control | None
+    # OAuth entries use ``Control``; cloud_user uses ``UserControl`` (#271).
+    control: DispatchControl | None
     devices: dict[str, list[dict[str, Any]]]
     # plant_id -> (stop_event, task) for the running EMS heartbeat loops.
     heartbeats: dict[str, tuple[asyncio.Event, asyncio.Task[None]]] = field(default_factory=dict)
@@ -124,7 +129,7 @@ class SungrowData:
 type SungrowConfigEntry = ConfigEntry[SungrowData]
 
 
-async def _async_dispatch_supported(control: Control, devices: list[dict[str, Any]]) -> bool:
+async def _async_dispatch_supported(control: DispatchControl, devices: list[dict[str, Any]]) -> bool:
     """Return whether the plant's dispatch device accepts parameter writes.
 
     Fail-open: returns True unless the API explicitly reports the device does not
@@ -297,11 +302,11 @@ async def _async_setup_modbus_only(hass: HomeAssistant, entry: SungrowConfigEntr
 
 
 async def _async_setup_cloud_user(hass: HomeAssistant, entry: SungrowConfigEntry) -> bool:
-    """Set up a cloud entry authenticated with a user account (email/password) (#268).
+    """Set up a cloud entry authenticated with a user account (email/password) (#268/#271).
 
     Uses the unofficial app/web API via ``UserAuth`` instead of the developer OAuth app.
-    Phase 2 authenticates, discovers plants and registers each plant device; realtime
-    sensor data is Phase 3 (#269), so the coordinator produces no measure points yet.
+    Discovers plants, maps realtime points, and attaches dispatch via ``UserControl``
+    (same number/select entities and safety rails as OAuth when the device accepts writes).
     Isolated from the OAuth path so the unofficial transport can't destabilise it.
     """
     session = async_get_clientsession(hass)
@@ -312,6 +317,7 @@ async def _async_setup_cloud_user(hass: HomeAssistant, entry: SungrowConfigEntry
         entry.data[CONF_USER_PASSWORD],
         websession=session,
     )
+    control_service: DispatchControl = UserControl(user_auth)
 
     try:
         async with asyncio.timeout(SETUP_TIMEOUT):
@@ -322,10 +328,21 @@ async def _async_setup_cloud_user(hass: HomeAssistant, entry: SungrowConfigEntry
         raise ConfigEntryNotReady(f"Unable to reach iSolarCloud (user account): {err}") from err
 
     coordinators: list[SungrowPlantCoordinator] = []
+    devices_by_plant: dict[str, list[dict[str, Any]]] = {}
     for plant_info in plant_list:
         plant_id = str(plant_info["ps_id"])
         plant_name = plant_info.get("ps_name") or f"Plant {plant_id}"
-        coordinator = SungrowPlantCoordinator(hass, entry, None, plant_id, plant_name, user_auth=user_auth)
+
+        # Device list powers dispatch targeting and battery gating (#271). Failures are
+        # non-fatal — plant sensors still work; controls appear when devices are known.
+        try:
+            async with asyncio.timeout(SETUP_TIMEOUT):
+                devices = await user_auth.async_get_devices(plant_id)
+        except Exception as err:  # pylint: disable=broad-except
+            _LOGGER.warning("Could not fetch devices for plant %s (user account): %s", plant_name, err)
+            devices = []
+
+        coordinator = SungrowPlantCoordinator(hass, entry, None, plant_id, plant_name, devices, user_auth=user_auth)
         try:
             await coordinator.async_config_entry_first_refresh()
         except ConfigEntryAuthFailed:
@@ -333,13 +350,22 @@ async def _async_setup_cloud_user(hass: HomeAssistant, entry: SungrowConfigEntry
         except ConfigEntryNotReady as err:
             _LOGGER.warning("Plant %s failed its initial user-account refresh, skipping: %s", plant_name, err)
             continue
+
+        coordinator.dispatch_update_supported = await _async_dispatch_supported(control_service, devices)
+        # User API has no design_capacity_battery plant-detail field in this path; gate
+        # battery-only controls on ESS/battery device presence (same fail-open default).
+        coordinator.has_battery = _has_battery_device(devices) if devices else True
+        devices_by_plant[plant_id] = devices
         coordinators.append(coordinator)
 
     if plant_list and not coordinators:
         raise ConfigEntryNotReady("No plants could be set up; all initial refreshes failed")
 
-    # No Control client: dispatch is not supported over the user-account API in Phase 2.
-    entry.runtime_data = SungrowData(coordinators=coordinators, control=None, devices={})
+    entry.runtime_data = SungrowData(
+        coordinators=coordinators,
+        control=control_service,
+        devices=devices_by_plant,
+    )
 
     console_url = GATEWAY_CONSOLE_URLS.get(entry.data.get(CONF_GATEWAY, ""), DEFAULT_CONSOLE_URL)
     device_registry = dr.async_get(hass)

--- a/custom_components/sungrow/heartbeat.py
+++ b/custom_components/sungrow/heartbeat.py
@@ -96,6 +96,39 @@ def _on_heartbeat_done(
     )
 
 
+async def _heartbeat_loop(control: object, device_uuid: str, interval: int, stop_event: asyncio.Event) -> None:
+    """Run an EMS heartbeat loop on either OAuth ``Control`` or user ``UserControl``.
+
+    OAuth ``Control`` exposes ``heartbeat_loop``; ``UserControl`` (0.14+) shares the same
+    param write surface, so we drive param 10017 via ``async_update_parameters`` (#271).
+    """
+    loop = getattr(control, "heartbeat_loop", None)
+    if callable(loop):
+        await loop(device_uuid, interval, stop_event)
+        return
+
+    # UserControl (and any duck-typed client with async_update_parameters).
+    from pysolarcloud.control import Control
+
+    update = getattr(control, "async_update_parameters", None)
+    if not callable(update):
+        raise TypeError(f"control client has no heartbeat_loop or async_update_parameters: {type(control)!r}")
+
+    if not 1 <= interval <= 1000:
+        raise ValueError("heartbeat interval must be between 1 and 1000 seconds")
+    wire = Control.encode_parameter("external_ems_heartbeat", interval)
+    while not stop_event.is_set():
+        try:
+            await update(device_uuid, {"external_ems_heartbeat": wire})
+        except Exception as err:  # pylint: disable=broad-except
+            _LOGGER.warning("EMS heartbeat failed for %s: %s", device_uuid, err)
+        try:
+            await asyncio.wait_for(stop_event.wait(), timeout=interval)
+        except TimeoutError:
+            continue
+        return
+
+
 async def async_start_heartbeat(
     hass: HomeAssistant, entry: SungrowConfigEntry, plant_id: str, device_uuid: str, interval: int
 ) -> None:
@@ -112,7 +145,7 @@ async def async_start_heartbeat(
     # Tracked by the config entry so HA cancels it automatically on unload.
     task = entry.async_create_background_task(
         hass,
-        control.heartbeat_loop(device_uuid, interval, stop_event),
+        _heartbeat_loop(control, device_uuid, interval, stop_event),
         name=f"sungrow-heartbeat-{plant_id}",
     )
     # Surface an unexpected exit (the #231 silent-death bug) as a Repair. A requested

--- a/custom_components/sungrow/number.py
+++ b/custom_components/sungrow/number.py
@@ -16,7 +16,7 @@ from homeassistant.helpers.update_coordinator import CoordinatorEntity
 from pysolarcloud import PySolarCloudException
 from pysolarcloud.control import Control
 
-from . import build_device_info, select_dispatch_device
+from . import DispatchControl, build_device_info, select_dispatch_device
 from .const import DOMAIN
 from .coordinator import SungrowPlantCoordinator
 
@@ -170,13 +170,15 @@ DISPATCH_NUMBERS: dict[str, dict[str, Any]] = {
 _RATED_POWER_PARAMS = frozenset({"charge_discharge_power", "feed_in_limitation_value"})
 
 
-def _build_numbers(coordinator: SungrowPlantCoordinator, control: Control) -> list[NumberEntity]:
+def _build_numbers(coordinator: SungrowPlantCoordinator, control: DispatchControl | None) -> list[NumberEntity]:
     """Build the dispatch number entities for a coordinator's target device.
 
     Returns an empty list when no dispatch-capable device is present. Reads the
     coordinator's live device list so a dispatchable device that appears after
     setup gets its controls at runtime (dynamic-devices).
     """
+    if control is None:
+        return []
     # Skip entirely if the device reported that it doesn't accept parameter writes.
     if not coordinator.dispatch_update_supported:
         return []
@@ -243,7 +245,7 @@ class SungrowDispatchNumber(CoordinatorEntity[SungrowPlantCoordinator], RestoreN
     def __init__(
         self,
         coordinator: SungrowPlantCoordinator,
-        control: Control,
+        control: DispatchControl,
         device: dict[str, Any],
         param: str,
         meta: dict[str, Any],

--- a/custom_components/sungrow/select.py
+++ b/custom_components/sungrow/select.py
@@ -19,7 +19,13 @@ from homeassistant.helpers.update_coordinator import CoordinatorEntity
 from pysolarcloud import PySolarCloudException
 from pysolarcloud.control import Control
 
-from . import async_start_heartbeat, async_stop_heartbeat, build_device_info, select_dispatch_device
+from . import (
+    DispatchControl,
+    async_start_heartbeat,
+    async_stop_heartbeat,
+    build_device_info,
+    select_dispatch_device,
+)
 from .const import DOMAIN
 from .coordinator import SungrowPlantCoordinator
 
@@ -125,13 +131,15 @@ DISPATCH_SELECTS: dict[str, dict[str, Any]] = {
 }
 
 
-def _build_selects(coordinator: SungrowPlantCoordinator, control: Control) -> list[SelectEntity]:
+def _build_selects(coordinator: SungrowPlantCoordinator, control: DispatchControl | None) -> list[SelectEntity]:
     """Build the dispatch select entities for a coordinator's target device.
 
     Returns an empty list when no dispatch-capable device is present. Reads the
     coordinator's live device list so a dispatchable device that appears after
     setup gets its controls at runtime (dynamic-devices).
     """
+    if control is None:
+        return []
     # Skip entirely if the device reported that it doesn't accept parameter writes.
     if not coordinator.dispatch_update_supported:
         return []
@@ -186,7 +194,7 @@ class SungrowDispatchSelect(CoordinatorEntity[SungrowPlantCoordinator], RestoreE
     def __init__(
         self,
         coordinator: SungrowPlantCoordinator,
-        control: Control,
+        control: DispatchControl,
         device: dict[str, Any],
         param: str,
         meta: dict[str, Any],

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -162,8 +162,9 @@ via the unofficial app/web API. If setup (or reauth) fails:
 - **Confirm the credentials** are exactly what works in the official app (no stray spaces).
 - If it worked before and suddenly fails, the unofficial API may have changed — the
   transport is experimental. The developer **Cloud-only** transport is the robust option.
-- This transport is **read-only** and surfaces plant-level data only; for dispatch/control
-  or per-device sensors, use the developer Cloud-only transport.
+- Dispatch (number/select) is available on this transport when the plant’s devices accept
+  parameter writes; battery-only controls still require an ESS/battery device. Prefer the
+  developer Cloud-only transport for the official OpenAPI path and fullest device metrics.
 
 ---
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -22,8 +22,8 @@ inverters** through the **iSolarCloud** cloud API, using the
 - **Auto-discovery** — finds every plant linked to your account, and discovers WiNet-S
   dongles on the network for local Modbus.
 - **User-account login (unofficial)** — connect with your normal iSolarCloud email +
-  password, without registering a developer application. Read-only, experimental — see
-  [Local Modbus & transport modes](local-modbus.md#cloud-user-account-unofficial).
+  password, without registering a developer application (sensors + experimental dispatch) —
+  see [Local Modbus & transport modes](local-modbus.md#cloud-user-account-unofficial).
 - **Rich sensors** — power, energy, battery SOC, and more, with correct device/state classes so
   they work in the Energy dashboard out of the box. See the
   [Model support matrix](model-support.md) for what each inverter family reports.

--- a/docs/local-modbus.md
+++ b/docs/local-modbus.md
@@ -40,7 +40,7 @@ the cloud plant in the device registry (`via_device`) — a soft “related to�
 | Mode | Data source | Cloud account | Control (dispatch) | Best for |
 | --- | --- | --- | --- | --- |
 | **Cloud-only** | iSolarCloud OpenAPI | Developer app (App Key/Secret/ID) | ✅ Yes | Full plant sensors and battery/dispatch controls. |
-| **Cloud (user account)** *(unofficial)* | iSolarCloud app/web API | Just email + password | ❌ Not yet | No developer app — quickest cloud setup. See caveats below. |
+| **Cloud (user account)** *(unofficial)* | iSolarCloud app/web API | Just email + password | ✅ Yes (experimental) | No developer app — sensors + dispatch. See caveats below. |
 | **Modbus-only** *(local)* | Local Modbus only | **Not needed** | ❌ Read-only | Fast local metrics, offline / privacy-first. |
 | **Both** *(two entries)* | Each entry its own source | Cloud entry only | Via **cloud** entry | Compare or use cloud + local side by side. |
 
@@ -53,8 +53,9 @@ If you don't have (or don't want to register) an iSolarCloud **developer applica
 
 Current limitations:
 
-- **Plant-level data only** so far (e.g. current power, daily/total yield, alarm/fault counts) — from the `getPsDetail` endpoint. Per-device and richer measure points may follow.
-- **No dispatch/control** — read-only. Use the developer Cloud-only transport for charge/discharge and other controls.
+- **Plant-level realtime** from `getPsDetail` (power, yield, alarm/fault counts, …). Device discovery is used for dispatch targeting; per-device sensor parity with OAuth may still differ by model.
+- **Dispatch** uses the same number/select entities and safety rails as the developer Cloud transport (battery gating, forced-mode verification, EMS heartbeat). Some EMS modes (e.g. Energy Management Mode on PV-only plants) may report “template not configured” — that is a plant capability limit, not a missing feature.
+- Prefer the developer **Cloud-only** transport when you need the official OpenAPI path or full OAuth device metrics.
 - If login fails with "account or password incorrect", it's most often the **wrong region** — pick the region your account actually uses.
 
 ```mermaid

--- a/docs/model-support.md
+++ b/docs/model-support.md
@@ -49,10 +49,10 @@ being present — the dispatch battery controls are hidden on PV-only plants for
 
 Any model can be connected through one of several transports (see
 [transport modes](local-modbus.md#transport-modes)): the official **developer Cloud** (OAuth,
-full sensors + dispatch), an **unofficial user-account Cloud** login (email/password, read-only
-plant-level data, [experimental](local-modbus.md#cloud-user-account-unofficial)), and **local
-Modbus**. The matrix below describes what a model reports; which of those datapoints you actually
-get also depends on the transport.
+full sensors + dispatch), an **unofficial user-account Cloud** login (email/password, plant
+sensors + experimental dispatch, [details](local-modbus.md#cloud-user-account-unofficial)), and
+**local Modbus**. The matrix below describes what a model reports; which of those datapoints you
+actually get also depends on the transport.
 
 ## Cloud vs local Modbus
 

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -1025,7 +1025,7 @@ async def test_plant_device_registered_as_anchor(hass: HomeAssistant, mock_setup
 
 
 async def test_setup_cloud_user_entry(hass: HomeAssistant):
-    """A cloud_user entry authenticates, discovers plants and sets up one coordinator (#268)."""
+    """A cloud_user entry authenticates, discovers plants, devices, and UserControl (#268/#271)."""
     from custom_components.sungrow.const import (
         CONF_GATEWAY,
         CONF_USER_ACCOUNT,
@@ -1048,13 +1048,59 @@ async def test_setup_cloud_user_entry(hass: HomeAssistant):
     client.async_get_plants = AsyncMock(return_value=[{"ps_id": 5, "ps_name": "Home"}])
     client.async_get_token = AsyncMock(return_value="T")
     client.async_get_plant_detail = AsyncMock(return_value={"curr_power": {"value": "3200", "unit": "W"}})
+    client.async_get_devices = AsyncMock(
+        return_value=[
+            {
+                "uuid": "inv-1",
+                "device_type": 1,
+                "device_name": "Inverter",
+                "device_model_code": "SG3.6RS",
+                "device_sn": "SN1",
+            }
+        ]
+    )
 
-    with patch("custom_components.sungrow.UserAuth", return_value=client):
+    control = MagicMock()
+    control.async_check_update_support = AsyncMock(return_value=True)
+
+    with (
+        patch("custom_components.sungrow.UserAuth", return_value=client),
+        patch("custom_components.sungrow.UserControl", return_value=control),
+    ):
         assert await hass.config_entries.async_setup(entry.entry_id)
         await hass.async_block_till_done()
 
     data = entry.runtime_data
     assert len(data.coordinators) == 1
     assert data.coordinators[0].plant_id == "5"
-    # No dispatch/Control over the user-account API in Phase 2.
-    assert data.control is None
+    # Phase 5: UserControl is attached for dispatch (#271).
+    assert data.control is control
+    assert data.devices["5"][0]["uuid"] == "inv-1"
+    assert data.coordinators[0].dispatch_update_supported is True
+    # PV-only device list → battery-only controls gated off.
+    assert data.coordinators[0].has_battery is False
+    client.async_get_devices.assert_awaited()
+    control.async_check_update_support.assert_awaited()
+
+
+async def test_heartbeat_loop_uses_update_parameters_without_native_loop(hass: HomeAssistant):
+    """UserControl-style clients without heartbeat_loop still keep EMS alive (#271)."""
+    entry = MockConfigEntry(domain=DOMAIN, data={"tokens": {}})
+    entry.add_to_hass(hass)
+    # spec= so getattr(..., "heartbeat_loop", None) falls through to update_parameters path.
+    control = MagicMock(spec=["async_update_parameters"])
+    control.async_update_parameters = AsyncMock(return_value=[])
+    entry.runtime_data = SungrowData(coordinators=[], control=control, devices={})
+
+    await async_start_heartbeat(hass, entry, "plant-1", "dev-1", interval=1)
+    # Let the background task run one heartbeat write.
+    for _ in range(20):
+        if control.async_update_parameters.await_count:
+            break
+        await asyncio.sleep(0)
+    await async_stop_heartbeat(hass, entry, "plant-1")
+    await hass.async_block_till_done()
+
+    assert control.async_update_parameters.await_count >= 1
+    payload = control.async_update_parameters.await_args.args[1]
+    assert "external_ems_heartbeat" in payload


### PR DESCRIPTION
## Summary

Phase 5b of the user-account transport epic (#271): expose the same dispatch **number/select** entities on `cloud_user` that OAuth already has, using `pysolarcloud.UserControl` (0.14.0).

### Changes
- **`_async_setup_cloud_user`**: create `UserControl`, fetch plant devices, set `dispatch_update_supported` / `has_battery`, store control on runtime data
- **Platforms**: `CLOUD_USER_PLATFORMS` → sensor + number + select
- **Typing**: `DispatchControl = Control | UserControl` for entities
- **Heartbeat**: if the client has no `heartbeat_loop` (UserControl), write EMS param 10017 via `async_update_parameters` so force charge/discharge keepalives work

### Safety (unchanged rails)
- Battery-only controls gated on ESS/battery device presence
- Fail-open dispatch support check
- Existing select verification / auto-revert / Repairs still apply

### Test plan
- [x] Full suite: 660 passed
- [x] mypy + ruff clean
- [x] cloud_user setup asserts UserControl + devices
- [x] heartbeat fallback without native `heartbeat_loop`

Closes #271