### PR TITLE
feat(modbus): expand family auto-detect for SH hybrids (#219)

### DIFF
--- a/custom_components/sungrow/modbus.py
+++ b/custom_components/sungrow/modbus.py
@@ -25,6 +25,7 @@ from .modbus_registers import (
     decode_registers,
     family_for_device_type_code,
 )
+from .model_capabilities import ModelFamily, resolve_model_family
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -122,6 +123,9 @@ class SungrowModbusClient:
         if self._family_detected:
             return
         self._family_detected = True
+        # Prefer a known device-type code; else resolve the configured model string
+        # (e.g. SH10RT-20 → sh_rt) when it already names a register map (#219).
+        configured = self.model
         try:
             async with self._lock:
                 registers = await self._read_input(4999, 1)
@@ -131,9 +135,14 @@ class SungrowModbusClient:
                 _LOGGER.debug("Device-type code %s mapped to Modbus family %s", code, family)
                 self.model = family
                 return
-            _LOGGER.debug("Unknown device-type code %s; keeping configured model %s", code, self.model)
+            _LOGGER.debug("Unknown device-type code %s; trying model string %s", code, configured)
         except Exception as err:  # pylint: disable=broad-except
-            _LOGGER.debug("Could not auto-detect Modbus family: %s", err)
+            _LOGGER.debug("Could not auto-detect Modbus family from register: %s", err)
+
+        resolved = resolve_model_family(configured)
+        if resolved is not ModelFamily.UNKNOWN and resolved.value in REGISTER_MAPS:
+            _LOGGER.debug("Model string %s resolved to Modbus family %s", configured, resolved.value)
+            self.model = resolved.value
 
     async def _read_input(self, address: int, count: int) -> list[int]:
         """Read a contiguous input-register block, connecting/reconnecting as needed."""

--- a/custom_components/sungrow/modbus_registers.py
+++ b/custom_components/sungrow/modbus_registers.py
@@ -159,18 +159,63 @@ SH_RT_INPUT_POINTS: tuple[ModbusPoint, ...] = (
 )
 
 # Register maps keyed by inverter family.
+# SG three-phase string inverters share the low-block layout with SG-RS (phase B/C
+# present when not NAN); hybrid SH-RS/RT share the expanded SH map (MIT mkaiser).
 REGISTER_MAPS: dict[str, tuple[ModbusPoint, ...]] = {
     "sg_rs": SG_RS_INPUT_POINTS,
+    "sg_rt": SG_RS_INPUT_POINTS,  # three-phase string — same low-block layout (#219)
     "sh_rt": SH_RT_INPUT_POINTS,
     "sh_rs": SH_RT_INPUT_POINTS,  # SH-RS shares the same input-register layout
 }
 
 # Map device-type codes reported in register 5000 to a register-map family.
-# Derived from Sungrow docs and cross-referenced with the mkaiser SHx mapping.
-# Unknown codes fall back to the configured model string.
+# SH codes from the mkaiser SHx YAML (MIT) device-type map; SG-RS validated live.
+# Unknown codes fall back to the configured model string / model_capabilities.
 DEVICE_TYPE_CODE_TO_FAMILY: dict[int, str] = {
     # SG-RS string inverters (single-phase, e.g. SG3.6RS)
-    9732: "sg_rs",
+    9732: "sg_rs",  # 0x2604
+    # SH single-phase hybrid (0x0Dxx) — mkaiser device-type map
+    3331: "sh_rs",  # SH5K-V13 (0x0D03)
+    3334: "sh_rs",  # SH3K6 (0x0D06)
+    3335: "sh_rs",  # SH4K6 (0x0D07)
+    3337: "sh_rs",  # SH5K-20 (0x0D09)
+    3338: "sh_rs",  # SH3K6-30 (0x0D0A)
+    3339: "sh_rs",  # SH4K6-30 (0x0D0B)
+    3340: "sh_rs",  # SH5K-30 (0x0D0C)
+    3341: "sh_rs",  # SH3.6RS (0x0D0D)
+    3343: "sh_rs",  # SH5.0RS (0x0D0F)
+    3344: "sh_rs",  # SH6.0RS (0x0D10)
+    3351: "sh_rs",  # SH3.0RS (0x0D17)
+    3352: "sh_rs",  # SH4.0RS (0x0D18)
+    3354: "sh_rs",  # SH8.0RS (0x0D1A)
+    3355: "sh_rs",  # SH10RS (0x0D1B)
+    3367: "sh_rs",  # MG5RL (0x0D27)
+    3368: "sh_rs",  # MG6RL (0x0D28)
+    # SH three-phase hybrid (0x0Exx)
+    3584: "sh_rt",  # SH5.0RT (0x0E00)
+    3585: "sh_rt",  # SH6.0RT (0x0E01)
+    3586: "sh_rt",  # SH8.0RT (0x0E02)
+    3587: "sh_rt",  # SH10RT (0x0E03)
+    3592: "sh_rt",  # SH5.0RT-V122 (0x0E08)
+    3593: "sh_rt",  # SH6.0RT-V122 (0x0E09)
+    3594: "sh_rt",  # SH8.0RT-V122 (0x0E0A)
+    3595: "sh_rt",  # SH10RT-V122 (0x0E0B)
+    3596: "sh_rt",  # SH5.0RT-V112 (0x0E0C)
+    3597: "sh_rt",  # SH6.0RT-V112 (0x0E0D)
+    3598: "sh_rt",  # SH8.0RT-V112 (0x0E0E)
+    3599: "sh_rt",  # SH10RT-V112 (0x0E0F)
+    3600: "sh_rt",  # SH5.0RT-20 (0x0E10)
+    3601: "sh_rt",  # SH6.0RT-20 (0x0E11)
+    3602: "sh_rt",  # SH8.0RT-20 (0x0E12)
+    3603: "sh_rt",  # SH10RT-20 (0x0E13)
+    3616: "sh_rt",  # SH5T (0x0E20)
+    3617: "sh_rt",  # SH6T (0x0E21)
+    3618: "sh_rt",  # SH8T (0x0E22)
+    3619: "sh_rt",  # SH10T (0x0E23)
+    3620: "sh_rt",  # SH12T (0x0E24)
+    3621: "sh_rt",  # SH15T (0x0E25)
+    3622: "sh_rt",  # SH20T (0x0E26)
+    3624: "sh_rt",  # SH25T (0x0E28)
 }
 
 

--- a/tests/test_modbus.py
+++ b/tests/test_modbus.py
@@ -10,6 +10,7 @@ from custom_components.sungrow.modbus_registers import (
     DAILY_YIELD_DIAG_COUNT,
     DAILY_YIELD_DIAG_START,
     DEVICE_TYPE_CODE_TO_FAMILY,
+    REGISTER_MAPS,
     SG_RS_INPUT_POINTS,
     SH_RT_INPUT_POINTS,
     ModbusPoint,
@@ -139,12 +140,23 @@ def test_family_for_device_type_code_maps_known_codes():
     """Known device-type codes resolve to a register-map family."""
     for code, family in DEVICE_TYPE_CODE_TO_FAMILY.items():
         assert family_for_device_type_code(code) == family
+    # Spot-check SH hybrids from the mkaiser device-type map (#219).
+    assert family_for_device_type_code(0x0E03) == "sh_rt"  # SH10RT
+    assert family_for_device_type_code(0x0D0F) == "sh_rs"  # SH5.0RS
+    assert family_for_device_type_code(9732) == "sg_rs"
 
 
 def test_family_for_device_type_code_returns_none_for_unknown():
     """Unknown codes return None so callers can fall back."""
     assert family_for_device_type_code(99999) is None
     assert family_for_device_type_code(None) is None
+
+
+def test_register_maps_cover_all_model_families():
+    """Every ModelFamily that has a map key is registered (#219)."""
+    assert set(REGISTER_MAPS) >= {"sg_rs", "sg_rt", "sh_rs", "sh_rt"}
+    assert REGISTER_MAPS["sg_rt"] is REGISTER_MAPS["sg_rs"]
+    assert REGISTER_MAPS["sh_rs"] is REGISTER_MAPS["sh_rt"]
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Partial progress on **#219** (extend Modbus maps beyond SG-RS).

### Changes
- Expand `DEVICE_TYPE_CODE_TO_FAMILY` with SH single-phase (`sh_rs`) and three-phase (`sh_rt`) codes from the mkaiser SHx MIT device-type map (e.g. SH10RT, SH5.0RS, SH20T, …)
- Register `sg_rt` map (three-phase string) sharing the SG-RS low-block layout
- When type code is unknown, resolve family from the configured model string via `model_capabilities`

### Still open on #219
- Distinct three-phase **SG** commercial maps (if layout diverges from SG-RS)
- Separate battery/meter device maps when not embedded on hybrid
- Live validation dumps per family

## Test plan
- [x] test_modbus + model_capabilities green
- [x] ruff + mypy

Refs #219