### PR TITLE
fix(modbus): recreate client and free WiNet-S socket so reloads heal

### DIFF
--- a/custom_components/sungrow/__init__.py
+++ b/custom_components/sungrow/__init__.py
@@ -272,7 +272,13 @@ async def _async_setup_modbus_only(hass: HomeAssistant, entry: SungrowConfigEntr
     coordinator = SungrowPlantCoordinator(hass, entry, None, serial, local_name, [inverter])
     coordinator.via_plant_id = via_plant_id
     coordinator.local_configuration_url = winet_url
-    await coordinator.async_config_entry_first_refresh()
+    try:
+        await coordinator.async_config_entry_first_refresh()
+    except Exception:
+        # Release the WiNet-S socket before HA retries setup; otherwise orphan clients
+        # exhaust the dongle's single-connection slot and reload never recovers.
+        coordinator.close_modbus()
+        raise
 
     entry.runtime_data = SungrowData(coordinators=[coordinator], control=None, devices={serial: [inverter]})
     # Local Modbus sensors now live on the single inverter device (which is nested under
@@ -570,6 +576,11 @@ async def async_unload_entry(hass: HomeAssistant, entry: SungrowConfigEntry) -> 
         for heartbeat in list(heartbeats.values()):
             await _stop_heartbeat(heartbeat)
         heartbeats.clear()
+        # Free the WiNet-S Modbus TCP slot so options reload / reconfigure can reconnect.
+        for coordinator in entry.runtime_data.coordinators:
+            close_modbus = getattr(coordinator, "close_modbus", None)
+            if close_modbus is not None:
+                close_modbus()
     return unloaded
 
 

--- a/custom_components/sungrow/coordinator.py
+++ b/custom_components/sungrow/coordinator.py
@@ -274,6 +274,21 @@ class SungrowPlantCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             model=model,
         )
 
+    def close_modbus(self) -> None:
+        """Release the WiNet-S Modbus TCP session (unload or failed setup).
+
+        WiNet-S typically accepts only one concurrent client. Leaving a socket open
+        after options reload / failed first_refresh causes every subsequent setup to
+        fail with connection errors until HA or the dongle is restarted.
+        """
+        client = self._modbus_client
+        if client is None:
+            return
+        self._modbus_client = None
+        close = getattr(client, "close", None)
+        if close is not None:
+            close()
+
     async def _async_update_data(self) -> dict[str, Any]:
         """Fetch data from the API for this plant."""
         # Cloud-free entries have no Plants service: user-account (app/web) or Modbus.

--- a/custom_components/sungrow/modbus.py
+++ b/custom_components/sungrow/modbus.py
@@ -11,10 +11,12 @@ sources feed the same entities.
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import logging
 from typing import Any
 
 from pymodbus.client import AsyncModbusTcpClient
+from pymodbus.exceptions import ConnectionException, ModbusException
 
 from .modbus_registers import (
     DAILY_YIELD_DIAG_COUNT,
@@ -32,6 +34,8 @@ _LOGGER = logging.getLogger(__name__)
 DEFAULT_PORT = 502
 DEFAULT_UNIT = 1
 CONNECT_TIMEOUT = 5
+# One reconnect+retry after a dropped WiNet-S socket (common after options reload).
+_READ_ATTEMPTS = 2
 
 
 class SungrowModbusError(Exception):
@@ -54,7 +58,7 @@ class SungrowModbusClient:
         self.port = port
         self.unit = unit
         self.model = model
-        self._client = AsyncModbusTcpClient(host, port=port, timeout=CONNECT_TIMEOUT)
+        self._client = self._new_tcp_client()
         # Serialise reads onto the single connection the WiNet-S expects.
         self._lock = asyncio.Lock()
         self._family_detected = False
@@ -63,6 +67,9 @@ class SungrowModbusClient:
             "skipped_blocks": [],
             "last_error": None,
         }
+
+    def _new_tcp_client(self) -> AsyncModbusTcpClient:
+        return AsyncModbusTcpClient(self.host, port=self.port, timeout=CONNECT_TIMEOUT)
 
     async def async_read_realtime(self) -> dict[str, dict[str, Any]]:
         """Read and decode the model's realtime input registers.
@@ -144,23 +151,107 @@ class SungrowModbusClient:
             _LOGGER.debug("Model string %s resolved to Modbus family %s", configured, resolved.value)
             self.model = resolved.value
 
-    async def _read_input(self, address: int, count: int) -> list[int]:
-        """Read a contiguous input-register block, connecting/reconnecting as needed."""
-        if not self._client.connected and not await self._client.connect():
+    async def _async_ensure_connected(self) -> None:
+        """Connect if needed; recreate the TCP client when a prior session is dead."""
+        if self._client.connected:
+            return
+        if await self._client.connect():
+            return
+        # pymodbus can leave a closed client in a state where connect() never recovers;
+        # drop it and open a fresh socket (observed after options reload / diag dump).
+        _LOGGER.debug("Modbus connect failed for %s:%s; recreating client", self.host, self.port)
+        self._recreate_client()
+        if not await self._client.connect():
             raise SungrowModbusError(f"Could not connect to {self.host}:{self.port}")
-        result = await self._client.read_input_registers(address, count=count, device_id=self.unit)
-        if result.isError():
-            # Drop the connection so the next read reconnects cleanly.
+
+    def _recreate_client(self) -> None:
+        """Close the socket and replace the pymodbus client.
+
+        Always construct a new client: after ``close()`` some pymodbus builds still report
+        ``connected=True``, which would skip reconnect forever and leave setup stuck on
+        ``Not connected`` after options reload (e.g. toggling the daily-yield diagnostic).
+        """
+        with contextlib.suppress(Exception):
             self._client.close()
-            raise SungrowModbusError(f"Modbus read at {address} (count {count}) failed: {result}")
-        return list(result.registers)
+        self._client = self._new_tcp_client()
+
+    async def _read_input(self, address: int, count: int) -> list[int]:
+        """Read a contiguous input-register block, reconnecting once on connection loss.
+
+        WiNet-S sockets drop after idle, options reload, or a mid-poll error. A stale
+        ``connected`` flag or a closed transport that never recovers from ``connect()``
+        produces ``ConnectionException: Not connected[...]`` on every subsequent setup
+        retry until the client is recreated.
+        """
+        last_error: SungrowModbusError | None = None
+        for attempt in range(_READ_ATTEMPTS):
+            try:
+                await self._async_ensure_connected()
+                result = await self._client.read_input_registers(address, count=count, device_id=self.unit)
+                if result.isError():
+                    msg = f"Modbus read at {address} (count {count}) failed: {result}"
+                    # Illegal address is permanent for this block — do not retry.
+                    if _is_exception_code(str(result), 2):
+                        # Drop the socket so a later block starts clean, but do not
+                        # burn a reconnect attempt on a firmware map gap.
+                        self._recreate_client()
+                        raise SungrowModbusError(msg)
+                    last_error = SungrowModbusError(msg)
+                    if attempt + 1 < _READ_ATTEMPTS and _is_connection_error(str(result)):
+                        self._recreate_client()
+                        continue
+                    self._recreate_client()
+                    raise last_error
+                return list(result.registers)
+            except SungrowModbusError:
+                raise
+            except (ConnectionException, ModbusException, OSError, TimeoutError) as err:
+                last_error = SungrowModbusError(f"Modbus read at {address} (count {count}) failed: {err}")
+                if attempt + 1 < _READ_ATTEMPTS:
+                    _LOGGER.debug(
+                        "Modbus connection error on %s:%s (attempt %s); reconnecting: %s",
+                        self.host,
+                        self.port,
+                        attempt + 1,
+                        err,
+                    )
+                    self._recreate_client()
+                    continue
+                self._recreate_client()
+                raise last_error from err
+            except Exception as err:  # pylint: disable=broad-except
+                # Unexpected pymodbus failures: still drop the socket so the next poll heals.
+                self._recreate_client()
+                raise SungrowModbusError(f"Modbus read at {address} (count {count}) failed: {err}") from err
+        assert last_error is not None
+        raise last_error
 
     def close(self) -> None:
-        """Close the underlying connection."""
-        self._client.close()
+        """Close the underlying connection (entry unload / failed setup cleanup)."""
+        self._recreate_client()
+
+
+def _is_exception_code(message: str, code: int) -> bool:
+    return f"exception_code={code}" in message
 
 
 def _is_unsupported_address(err: SungrowModbusError) -> bool:
     """Return True when ``err`` is a Modbus 'Illegal Data Address' exception."""
-    # pymodbus renders ExceptionResponse with exception_code=2 in its repr.
-    return "exception_code=2" in str(err)
+    return _is_exception_code(str(err), 2)
+
+
+def _is_connection_error(message: str) -> bool:
+    """Return True when a failure looks like a dropped TCP session."""
+    lower = message.lower()
+    return any(
+        token in lower
+        for token in (
+            "not connected",
+            "connection",
+            "broken pipe",
+            "connection reset",
+            "timed out",
+            "timeout",
+            "eof",
+        )
+    )

--- a/custom_components/sungrow/modbus_registers.py
+++ b/custom_components/sungrow/modbus_registers.py
@@ -42,6 +42,11 @@ class ModbusPoint:
     (e.g. 0xFFFF for an MPPT that the inverter does not have). When the raw value
     equals this sentinel the point is omitted, so unsupported registers do not
     surface as bogus sensors.
+
+    ``omit_zero`` drops a raw zero when the firmware reports 0 instead of the NAN
+    sentinel for an absent channel (e.g. phase B/C voltage and MPPT3 on SG3.6RS).
+    Do not set this on points where zero is a legitimate night-time reading with a
+    live sibling channel (e.g. MPPT1 current at 0 A while voltage is non-zero).
     """
 
     address: int
@@ -50,6 +55,7 @@ class ModbusPoint:
     scale: float
     unit: str | None = None
     nan_value: int | None = None
+    omit_zero: bool = False
 
     @property
     def register_count(self) -> int:
@@ -71,13 +77,15 @@ SG_RS_INPUT_POINTS: tuple[ModbusPoint, ...] = (
     ModbusPoint(5011, "mppt1_current", "u16", 0.1, "A"),
     ModbusPoint(5012, "mppt2_voltage", "u16", 0.1, "V"),
     ModbusPoint(5013, "mppt2_current", "u16", 0.1, "A"),
-    # MPPT3 present on some multi-tracker string inverters; NAN when unsupported (#219).
-    ModbusPoint(5014, "mppt3_voltage", "u16", 0.1, "V", nan_value=NAN_U16),
-    ModbusPoint(5015, "mppt3_current", "u16", 0.1, "A", nan_value=NAN_U16),
+    # MPPT3 present on some multi-tracker string inverters; omit when firmware
+    # returns 0 / 0xFFFF on 2-tracker models such as SG3.6RS.
+    ModbusPoint(5014, "mppt3_voltage", "u16", 0.1, "V", nan_value=NAN_U16, omit_zero=True),
+    ModbusPoint(5015, "mppt3_current", "u16", 0.1, "A", nan_value=NAN_U16, omit_zero=True),
     ModbusPoint(5016, "total_dc_power", "u32", 1, "W"),
     ModbusPoint(5018, "phase_a_voltage", "u16", 0.1, "V"),
-    ModbusPoint(5019, "phase_b_voltage", "u16", 0.1, "V", nan_value=NAN_U16),
-    ModbusPoint(5020, "phase_c_voltage", "u16", 0.1, "V", nan_value=NAN_U16),
+    # Single-phase inverters often report B/C as 0 rather than 0xFFFF.
+    ModbusPoint(5019, "phase_b_voltage", "u16", 0.1, "V", nan_value=NAN_U16, omit_zero=True),
+    ModbusPoint(5020, "phase_c_voltage", "u16", 0.1, "V", nan_value=NAN_U16, omit_zero=True),
     ModbusPoint(5030, "total_active_power", "s32", 1, "W"),
     ModbusPoint(5032, "reactive_power", "s32", 1, "W", nan_value=NAN_S32),
     ModbusPoint(5034, "power_factor", "s16", 0.001, None, nan_value=NAN_S16),
@@ -96,18 +104,18 @@ SH_RT_INPUT_POINTS: tuple[ModbusPoint, ...] = (
     ModbusPoint(5011, "mppt1_current", "u16", 0.1, "A"),
     ModbusPoint(5012, "mppt2_voltage", "u16", 0.1, "V"),
     ModbusPoint(5013, "mppt2_current", "u16", 0.1, "A"),
-    ModbusPoint(5014, "mppt3_voltage", "u16", 0.1, "V", nan_value=NAN_U16),
-    ModbusPoint(5015, "mppt3_current", "u16", 0.1, "A", nan_value=NAN_U16),
+    ModbusPoint(5014, "mppt3_voltage", "u16", 0.1, "V", nan_value=NAN_U16, omit_zero=True),
+    ModbusPoint(5015, "mppt3_current", "u16", 0.1, "A", nan_value=NAN_U16, omit_zero=True),
     ModbusPoint(5016, "total_dc_power", "u32", 1, "W"),
     ModbusPoint(5018, "phase_a_voltage", "u16", 0.1, "V"),
-    ModbusPoint(5019, "phase_b_voltage", "u16", 0.1, "V", nan_value=NAN_U16),
-    ModbusPoint(5020, "phase_c_voltage", "u16", 0.1, "V", nan_value=NAN_U16),
+    ModbusPoint(5019, "phase_b_voltage", "u16", 0.1, "V", nan_value=NAN_U16, omit_zero=True),
+    ModbusPoint(5020, "phase_c_voltage", "u16", 0.1, "V", nan_value=NAN_U16, omit_zero=True),
     ModbusPoint(5030, "total_active_power", "s32", 1, "W"),
     ModbusPoint(5032, "reactive_power", "s32", 1, "W", nan_value=NAN_S32),
     ModbusPoint(5034, "power_factor", "s16", 0.001, None, nan_value=NAN_S16),
     ModbusPoint(5035, "grid_frequency", "u16", 0.1, "Hz"),
-    ModbusPoint(5114, "mppt4_voltage", "u16", 0.1, "V", nan_value=NAN_U16),
-    ModbusPoint(5115, "mppt4_current", "u16", 0.1, "A", nan_value=NAN_U16),
+    ModbusPoint(5114, "mppt4_voltage", "u16", 0.1, "V", nan_value=NAN_U16, omit_zero=True),
+    ModbusPoint(5115, "mppt4_current", "u16", 0.1, "A", nan_value=NAN_U16, omit_zero=True),
     ModbusPoint(5213, "battery_power", "s32", 1, "W", nan_value=NAN_S32),
     # Preferred grid-frequency register on hybrids (mkaiser/SHx scale 0.01 Hz).
     ModbusPoint(5241, "grid_frequency", "u16", 0.01, "Hz"),
@@ -247,6 +255,8 @@ def decode_registers(
             continue
         raw = _combine(registers, offset, point.data_type)
         if point.nan_value is not None and raw == point.nan_value:
+            continue
+        if point.omit_zero and raw == 0:
             continue
         out[point.code] = {
             "code": point.code,

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -1,7 +1,7 @@
 """Tests for the Sungrow data update coordinator."""
 
 import asyncio
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from homeassistant.core import HomeAssistant
@@ -936,6 +936,29 @@ def test_no_modbus_client_when_host_blank():
         )
         is None
     )
+
+
+async def test_close_modbus_releases_client(hass: HomeAssistant):
+    """close_modbus closes the underlying client and clears the coordinator handle."""
+    from custom_components.sungrow.const import CONF_MODEL
+
+    entry = _make_entry(
+        data={
+            CONF_TRANSPORT: TRANSPORT_MODBUS_ONLY,
+            CONF_MODBUS_HOST: "10.0.0.5",
+            CONF_MODEL: "SG3.6RS",
+        }
+    )
+    mock_client = MagicMock()
+    with patch("custom_components.sungrow.modbus.SungrowModbusClient", return_value=mock_client):
+        coordinator = SungrowPlantCoordinator(hass, entry, None, "p1", "Plant", [])
+    client = MagicMock()
+    coordinator._modbus_client = client  # noqa: SLF001
+    coordinator.close_modbus()
+    client.close.assert_called_once()
+    assert coordinator._modbus_client is None  # noqa: SLF001
+    # Idempotent when already closed.
+    coordinator.close_modbus()
 
 
 async def test_modbus_debug_daily_yield_gated(hass: HomeAssistant):

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -185,6 +185,34 @@ async def test_setup_modbus_only_entry(hass: HomeAssistant):
         await hass.async_block_till_done()
     assert seen["platforms"] == [Platform.BINARY_SENSOR, Platform.SENSOR]
     assert entry.state is ConfigEntryState.NOT_LOADED
+    # WiNet-S single-connection slot must be released on unload (options reload heal).
+    client.close.assert_called()
+
+
+async def test_setup_modbus_only_closes_client_when_first_refresh_fails(hass: HomeAssistant):
+    """Failed first_refresh must close the Modbus client so HA retries can reconnect."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={
+            CONF_TRANSPORT: TRANSPORT_MODBUS_ONLY,
+            CONF_SERIAL: "SNFAIL",
+            CONF_MODEL: "SG3.6RS",
+            CONF_MODBUS_HOST: "10.0.0.9",
+        },
+        options={CONF_SCAN_INTERVAL: 30},
+        unique_id="modbus_SNFAIL",
+    )
+    entry.add_to_hass(hass)
+
+    client = MagicMock()
+    client.async_read_realtime = AsyncMock(side_effect=OSError("Not connected"))
+    client.close = MagicMock()
+    with patch("custom_components.sungrow.modbus.SungrowModbusClient", return_value=client):
+        assert not await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+
+    assert entry.state is not ConfigEntryState.LOADED
+    client.close.assert_called()
 
 
 async def test_setup_modbus_only_nests_under_cloud_plant(hass: HomeAssistant):

--- a/tests/test_modbus.py
+++ b/tests/test_modbus.py
@@ -222,13 +222,53 @@ async def test_read_connects_when_not_connected():
 
 
 async def test_connect_failure_raises():
-    """A failed connect raises SungrowModbusError."""
+    """A failed connect raises SungrowModbusError after a recreate attempt."""
     cls, _ = _mock_client_cls([], connected=False, connect_ok=False)
     with (
         patch("custom_components.sungrow.modbus.AsyncModbusTcpClient", cls),
         pytest.raises(SungrowModbusError, match="Could not connect"),
     ):
         await SungrowModbusClient("10.0.0.1").async_read_realtime()
+
+
+async def test_connect_failure_recreates_and_succeeds():
+    """When the first connect() fails, a fresh client is opened and the read continues."""
+    low_points = tuple(p for p in SG_RS_INPUT_POINTS if p.address < 6000)
+    start, count = block_bounds(low_points)
+    regs = [0] * count
+    regs[5035 - start] = 501
+
+    dead = MagicMock()
+    dead.connected = False
+    dead.connect = AsyncMock(return_value=False)
+    dead.close = MagicMock()
+
+    healthy = MagicMock()
+    healthy.connected = False
+    healthy.connect = AsyncMock(return_value=True)
+    healthy.close = MagicMock()
+    ok = MagicMock()
+    ok.isError.return_value = False
+    ok.registers = regs
+    healthy.read_input_registers = AsyncMock(return_value=ok)
+
+    # __init__ builds dead; ensure_connected recreates → healthy.
+    cls = MagicMock(side_effect=[dead, healthy])
+    with patch("custom_components.sungrow.modbus.AsyncModbusTcpClient", cls):
+        client = SungrowModbusClient("10.0.0.1")
+        _skip_family_detect(client)
+        client.model = "_test_connect_heal"
+        with patch.dict(
+            "custom_components.sungrow.modbus.REGISTER_MAPS",
+            {"_test_connect_heal": low_points},
+            clear=False,
+        ):
+            data = await client.async_read_realtime()
+    assert data["grid_frequency"]["value"] == 50.1
+    dead.connect.assert_awaited()
+    dead.close.assert_called()
+    healthy.connect.assert_awaited()
+    healthy.read_input_registers.assert_awaited()
 
 
 async def test_read_error_raises_and_drops_connection():
@@ -247,7 +287,102 @@ async def test_read_error_raises_and_drops_connection():
             clear=False,
         ):
             await client.async_read_realtime()
-    inner.close.assert_called_once()
+    # Permanent (non-connection) protocol error still force-disconnects once.
+    assert inner.close.call_count >= 1
+
+
+async def test_not_connected_error_reconnects_and_succeeds():
+    """A mid-session 'Not connected' error recreates the client and retries once."""
+    from pymodbus.exceptions import ConnectionException
+
+    low_points = tuple(p for p in SG_RS_INPUT_POINTS if p.address < 6000)
+    start, count = block_bounds(low_points)
+    regs = [0] * count
+    regs[5035 - start] = 499
+
+    first = MagicMock()
+    first.connected = True
+    first.connect = AsyncMock(return_value=True)
+    first.close = MagicMock()
+    first.read_input_registers = AsyncMock(side_effect=ConnectionException("Not connected[AsyncModbusTcpClient]"))
+
+    second = MagicMock()
+    second.connected = False
+    second.connect = AsyncMock(return_value=True)
+    second.close = MagicMock()
+    ok = MagicMock()
+    ok.isError.return_value = False
+    ok.registers = regs
+    second.read_input_registers = AsyncMock(return_value=ok)
+
+    cls = MagicMock(side_effect=[first, second])
+    with patch("custom_components.sungrow.modbus.AsyncModbusTcpClient", cls):
+        client = SungrowModbusClient("10.0.0.1")
+        _skip_family_detect(client)
+        client.model = "_test_reconnect"
+        # Replace the client created in __init__ with our first mock.
+        client._client = first  # noqa: SLF001
+        with patch.dict(
+            "custom_components.sungrow.modbus.REGISTER_MAPS",
+            {"_test_reconnect": low_points},
+            clear=False,
+        ):
+            data = await client.async_read_realtime()
+    assert data["grid_frequency"]["value"] == 49.9
+    first.close.assert_called()
+    second.connect.assert_awaited()
+    second.read_input_registers.assert_awaited()
+
+
+async def test_stale_connected_flag_still_reconnects_after_failure():
+    """After a connection failure the next poll can open a fresh socket."""
+    from pymodbus.exceptions import ConnectionException
+
+    low_points = tuple(p for p in SG_RS_INPUT_POINTS if p.address < 6000)
+    start, count = block_bounds(low_points)
+    regs = [0] * count
+    regs[5035 - start] = 500
+
+    dead = MagicMock()
+    dead.connected = True  # stale flag: thinks it's up
+    dead.connect = AsyncMock(return_value=True)
+    dead.close = MagicMock()
+    dead.read_input_registers = AsyncMock(side_effect=ConnectionException("Not connected[x]"))
+
+    healthy = MagicMock()
+    healthy.connected = False
+    healthy.connect = AsyncMock(return_value=True)
+    healthy.close = MagicMock()
+    ok = MagicMock()
+    ok.isError.return_value = False
+    ok.registers = regs
+    healthy.read_input_registers = AsyncMock(return_value=ok)
+
+    # __init__ constructs once; recreate after the failed read constructs ``healthy``.
+    cls = MagicMock(side_effect=[MagicMock(), healthy])
+    with patch("custom_components.sungrow.modbus.AsyncModbusTcpClient", cls):
+        client = SungrowModbusClient("192.168.1.93")
+        _skip_family_detect(client)
+        client.model = "_test_stale"
+        client._client = dead  # noqa: SLF001
+        with patch.dict(
+            "custom_components.sungrow.modbus.REGISTER_MAPS",
+            {"_test_stale": low_points},
+            clear=False,
+        ):
+            data = await client.async_read_realtime()
+    assert data["grid_frequency"]["value"] == 50.0
+
+
+def test_decode_omits_zero_optional_channels():
+    """Optional phase/MPPT channels that report 0 are omitted (unavailable in HA)."""
+    points = (
+        ModbusPoint(0, "phase_b_voltage", "u16", 0.1, "V", nan_value=0xFFFF, omit_zero=True),
+        ModbusPoint(1, "mppt1_current", "u16", 0.1, "A"),  # zero is legitimate at night
+    )
+    out = decode_registers(points, 0, [0, 0])
+    assert "phase_b_voltage" not in out
+    assert out["mppt1_current"]["value"] == 0.0
 
 
 async def test_unsupported_address_block_is_skipped_but_other_blocks_return_data():


### PR DESCRIPTION
## Summary

Local Modbus entries could stay broken after toggling options (including the daily-yield diagnostic dump) even when the option was turned back off.

**Root causes**
1. **Stale pymodbus client** — after a dropped WiNet-S socket, `connected` could stay true or `connect()` never recovered, so every poll/setup raised `ConnectionException: Not connected`.
2. **Socket not released on unload / failed setup** — WiNet-S typically allows only one Modbus TCP client. Options reload left the old session open, so the new entry setup could not connect.

**Fixes**
- Recreate `AsyncModbusTcpClient` on connection loss and retry the read once.
- Always replace the client after `close()` so a stale `connected` flag cannot skip reconnect.
- Close the Modbus client on config-entry unload and when first_refresh fails (so HA retries heal).
- Polish: omit raw `0` on optional phase B/C and MPPT3/4 channels (`omit_zero`) so SG3.6RS-class firmware does not surface bogus sensors.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change
- [ ] Documentation / chore

## Checklist

- [x] `ruff check custom_components/` passes
- [x] `ruff format --check custom_components/` passes
- [x] `pytest` passes and new/changed behaviour is covered by tests
- [ ] I have updated documentation where relevant

## Test plan

- [ ] On dell-serve (SG3.6RS local entry): reload local entry / reinstall this branch
- [ ] Confirm local sensors update
- [ ] Toggle daily_yield diagnostic on, then off — entry should reload and stay LOADED
- [ ] Optional: phase B/C / MPPT3 stay unavailable (not 0.0) on single-phase 2-tracker