### PR TITLE
feat(modbus): local active-power control via ModbusControl (#220)

### DIFF
--- a/custom_components/sungrow/__init__.py
+++ b/custom_components/sungrow/__init__.py
@@ -79,11 +79,15 @@ from .oauth_view import SungrowAuthCallbackView
 from .services import async_setup_services
 
 PLATFORMS: list[Platform] = [Platform.BINARY_SENSOR, Platform.NUMBER, Platform.SELECT, Platform.SENSOR]
-# A cloud-free Modbus-only entry has no cloud device status or dispatch, but it does
-# get a local connectivity binary sensor (#159). Setup and unload MUST use the same
-# list — unloading a platform that was never set up fails the unload, which breaks the
-# options-change reload and takes every entity unavailable.
-MODBUS_ONLY_PLATFORMS: list[Platform] = [Platform.BINARY_SENSOR, Platform.SENSOR]
+# Modbus-only: sensors + connectivity binary sensor + local active-power controls (#220).
+# Setup and unload MUST use the same list — unloading a platform that was never set up
+# fails the unload, which breaks options-change reload.
+MODBUS_ONLY_PLATFORMS: list[Platform] = [
+    Platform.BINARY_SENSOR,
+    Platform.NUMBER,
+    Platform.SELECT,
+    Platform.SENSOR,
+]
 # cloud_user has sensors plus dispatch (UserControl over the app/web API, #271). No
 # binary sensors (device fault/connectivity come from the OAuth device list shape).
 CLOUD_USER_PLATFORMS: list[Platform] = [Platform.NUMBER, Platform.SELECT, Platform.SENSOR]
@@ -107,7 +111,9 @@ SETUP_TIMEOUT = 60
 _LOGGER = logging.getLogger(__name__)
 
 
-# Dispatch client: OAuth ``Control`` or user-account ``UserControl`` (#271).
+# Dispatch client: OAuth ``Control``, user-account ``UserControl`` (#271), or local
+# ``ModbusControl`` (#220). Imported lazily in setup for ModbusControl to avoid
+# circular imports at module load.
 type DispatchControl = Control | UserControl
 
 
@@ -116,8 +122,8 @@ class SungrowData:
     """Runtime data stored on the config entry (``entry.runtime_data``)."""
 
     coordinators: list[SungrowPlantCoordinator]
-    # None for a Modbus-only (cloud-free) entry, which has no dispatch/control (#159).
-    # OAuth entries use ``Control``; cloud_user uses ``UserControl`` (#271).
+    # OAuth: ``Control``; cloud_user: ``UserControl`` (#271); modbus_only: ``ModbusControl``
+    # when holding maps are available (#220); None only if local control cannot attach.
     control: DispatchControl | None
     devices: dict[str, list[dict[str, Any]]]
     # plant_id -> (stop_event, task) for the running EMS heartbeat loops.
@@ -272,6 +278,9 @@ async def _async_setup_modbus_only(hass: HomeAssistant, entry: SungrowConfigEntr
     coordinator = SungrowPlantCoordinator(hass, entry, None, serial, local_name, [inverter])
     coordinator.via_plant_id = via_plant_id
     coordinator.local_configuration_url = winet_url
+    # Local entries never expose battery EMS controls until hybrid holding maps ship (#220).
+    # Hiding battery_only entities avoids charge/discharge footguns on PV-only string units.
+    coordinator.has_battery = False
     try:
         await coordinator.async_config_entry_first_refresh()
     except Exception:
@@ -280,12 +289,34 @@ async def _async_setup_modbus_only(hass: HomeAssistant, entry: SungrowConfigEntr
         coordinator.close_modbus()
         raise
 
-    entry.runtime_data = SungrowData(coordinators=[coordinator], control=None, devices={serial: [inverter]})
+    control: DispatchControl | None = None
+    modbus_client = getattr(coordinator, "_modbus_client", None)
+    if modbus_client is not None:
+        from .modbus_control import ModbusControl
+
+        modbus_control = ModbusControl(modbus_client, family=getattr(modbus_client, "model", None))
+        if modbus_control.supported_parameters:
+            # Probe once; fail-open to True only if the map is non-empty and readable.
+            try:
+                coordinator.dispatch_update_supported = await modbus_control.async_check_update_support(
+                    str(inverter["uuid"])
+                )
+            except Exception as err:  # pylint: disable=broad-except
+                _LOGGER.debug("Modbus control support probe failed: %s", err)
+                coordinator.dispatch_update_supported = False
+            if coordinator.dispatch_update_supported:
+                control = modbus_control  # type: ignore[assignment]
+            else:
+                _LOGGER.info(
+                    "Local Modbus control map not readable on %s; dispatch entities disabled",
+                    host or serial,
+                )
+
+    entry.runtime_data = SungrowData(coordinators=[coordinator], control=control, devices={serial: [inverter]})
     # Local Modbus sensors now live on the single inverter device (which is nested under
     # a matching cloud plant when one exists). Remove any legacy synthetic local plant
     # anchor left over from earlier builds so the UI does not show two plant devices.
     _remove_synthetic_local_plant_device(hass, entry, serial)
-    # Only the sensor platform: a Modbus-only entry has no cloud device status or dispatch.
     await hass.config_entries.async_forward_entry_setups(entry, _entry_platforms(entry))
 
     # If no cloud plant was found at setup time, the local entry may have set up before

--- a/custom_components/sungrow/modbus.py
+++ b/custom_components/sungrow/modbus.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 import asyncio
 import contextlib
 import logging
+from collections.abc import Awaitable, Callable
 from typing import Any
 
 from pymodbus.client import AsyncModbusTcpClient
@@ -176,24 +177,63 @@ class SungrowModbusClient:
         self._client = self._new_tcp_client()
 
     async def _read_input(self, address: int, count: int) -> list[int]:
-        """Read a contiguous input-register block, reconnecting once on connection loss.
+        """Read a contiguous input-register block, reconnecting once on connection loss."""
+        return await self._transact_registers(
+            "input",
+            address,
+            count,
+            lambda: self._client.read_input_registers(address, count=count, device_id=self.unit),
+        )
+
+    async def async_read_holding(self, address: int, count: int = 1) -> list[int]:
+        """Read holding registers (FC3) for config/control probes and future #220 writes."""
+        async with self._lock:
+            return await self._transact_registers(
+                "holding",
+                address,
+                count,
+                lambda: self._client.read_holding_registers(address, count=count, device_id=self.unit),
+            )
+
+    async def async_write_holding(self, address: int, value: int) -> None:
+        """Write a single holding register (FC6).
+
+        Callers must enforce family maps and the write denylist; this method only
+        performs the transport. Serialised with the same lock as reads.
+        """
+        if not 0 <= int(value) <= 0xFFFF:
+            raise SungrowModbusError(f"Holding write value out of U16 range: {value}")
+
+        async def _do_write() -> Any:
+            return await self._client.write_register(address, int(value), device_id=self.unit)
+
+        async with self._lock:
+            await self._transact_registers("holding_write", address, 1, _do_write, expect_registers=False)
+
+    async def _transact_registers(
+        self,
+        kind: str,
+        address: int,
+        count: int,
+        operation: Callable[[], Awaitable[Any]],
+        *,
+        expect_registers: bool = True,
+    ) -> Any:
+        """Run a Modbus operation with one reconnect+retry on connection loss.
 
         WiNet-S sockets drop after idle, options reload, or a mid-poll error. A stale
         ``connected`` flag or a closed transport that never recovers from ``connect()``
-        produces ``ConnectionException: Not connected[...]`` on every subsequent setup
-        retry until the client is recreated.
+        produces ``ConnectionException: Not connected[...]`` until the client is recreated.
         """
         last_error: SungrowModbusError | None = None
         for attempt in range(_READ_ATTEMPTS):
             try:
                 await self._async_ensure_connected()
-                result = await self._client.read_input_registers(address, count=count, device_id=self.unit)
-                if result.isError():
-                    msg = f"Modbus read at {address} (count {count}) failed: {result}"
+                result = await operation()
+                if hasattr(result, "isError") and result.isError():
+                    msg = f"Modbus {kind} at {address} (count {count}) failed: {result}"
                     # Illegal address is permanent for this block — do not retry.
                     if _is_exception_code(str(result), 2):
-                        # Drop the socket so a later block starts clean, but do not
-                        # burn a reconnect attempt on a firmware map gap.
                         self._recreate_client()
                         raise SungrowModbusError(msg)
                     last_error = SungrowModbusError(msg)
@@ -202,11 +242,13 @@ class SungrowModbusClient:
                         continue
                     self._recreate_client()
                     raise last_error
-                return list(result.registers)
+                if expect_registers:
+                    return list(result.registers)
+                return result
             except SungrowModbusError:
                 raise
             except (ConnectionException, ModbusException, OSError, TimeoutError) as err:
-                last_error = SungrowModbusError(f"Modbus read at {address} (count {count}) failed: {err}")
+                last_error = SungrowModbusError(f"Modbus {kind} at {address} (count {count}) failed: {err}")
                 if attempt + 1 < _READ_ATTEMPTS:
                     _LOGGER.debug(
                         "Modbus connection error on %s:%s (attempt %s); reconnecting: %s",
@@ -220,9 +262,8 @@ class SungrowModbusClient:
                 self._recreate_client()
                 raise last_error from err
             except Exception as err:  # pylint: disable=broad-except
-                # Unexpected pymodbus failures: still drop the socket so the next poll heals.
                 self._recreate_client()
-                raise SungrowModbusError(f"Modbus read at {address} (count {count}) failed: {err}") from err
+                raise SungrowModbusError(f"Modbus {kind} at {address} (count {count}) failed: {err}") from err
         assert last_error is not None
         raise last_error
 

--- a/custom_components/sungrow/modbus.py
+++ b/custom_components/sungrow/modbus.py
@@ -178,7 +178,7 @@ class SungrowModbusClient:
 
     async def _read_input(self, address: int, count: int) -> list[int]:
         """Read a contiguous input-register block, reconnecting once on connection loss."""
-        return await self._transact_registers(
+        return await self._transact_read(
             "input",
             address,
             count,
@@ -188,7 +188,7 @@ class SungrowModbusClient:
     async def async_read_holding(self, address: int, count: int = 1) -> list[int]:
         """Read holding registers (FC3) for config/control probes and future #220 writes."""
         async with self._lock:
-            return await self._transact_registers(
+            return await self._transact_read(
                 "holding",
                 address,
                 count,
@@ -208,16 +208,37 @@ class SungrowModbusClient:
             return await self._client.write_register(address, int(value), device_id=self.unit)
 
         async with self._lock:
-            await self._transact_registers("holding_write", address, 1, _do_write, expect_registers=False)
+            await self._transact_write("holding_write", address, _do_write)
 
-    async def _transact_registers(
+    async def _transact_read(
         self,
         kind: str,
         address: int,
         count: int,
         operation: Callable[[], Awaitable[Any]],
-        *,
-        expect_registers: bool = True,
+    ) -> list[int]:
+        """Run a register read with one reconnect+retry; return raw 16-bit values."""
+        result = await self._transact(kind, address, count, operation)
+        registers = getattr(result, "registers", None)
+        if registers is None:
+            raise SungrowModbusError(f"Modbus {kind} at {address} returned no registers: {result}")
+        return [int(r) for r in registers]
+
+    async def _transact_write(
+        self,
+        kind: str,
+        address: int,
+        operation: Callable[[], Awaitable[Any]],
+    ) -> None:
+        """Run a single-register write with one reconnect+retry."""
+        await self._transact(kind, address, 1, operation)
+
+    async def _transact(
+        self,
+        kind: str,
+        address: int,
+        count: int,
+        operation: Callable[[], Awaitable[Any]],
     ) -> Any:
         """Run a Modbus operation with one reconnect+retry on connection loss.
 
@@ -242,8 +263,6 @@ class SungrowModbusClient:
                         continue
                     self._recreate_client()
                     raise last_error
-                if expect_registers:
-                    return list(result.registers)
                 return result
             except SungrowModbusError:
                 raise

--- a/custom_components/sungrow/modbus_control.py
+++ b/custom_components/sungrow/modbus_control.py
@@ -1,0 +1,130 @@
+"""Local Modbus dispatch control via WiNet-S holding registers (#220).
+
+Duck-types the same surface as ``Control`` / ``UserControl`` so number/select
+entities can write without a cloud account. Phase 1 maps only validated SG-RS
+active-power holdings (wire 5006/5007); unmapped params raise clearly.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from .modbus import SungrowModbusClient, SungrowModbusError
+from .modbus_registers import (
+    HOLDING_CONTROL_MAPS,
+    HOLDING_WRITE_DENYLIST_WIRE,
+    HoldingControlPoint,
+)
+
+_LOGGER = logging.getLogger(__name__)
+
+
+class ModbusControlError(Exception):
+    """A local Modbus control read or write failed."""
+
+
+class ModbusControl:
+    """Dispatch client backed by family-gated holding-register maps."""
+
+    def __init__(self, client: SungrowModbusClient, *, family: str | None = None) -> None:
+        self._client = client
+        self.family = family or client.model or "sg_rs"
+        points = HOLDING_CONTROL_MAPS.get(self.family, ())
+        self._by_param: dict[str, HoldingControlPoint] = {p.param: p for p in points}
+        self._by_code: dict[str, HoldingControlPoint] = {p.param_code: p for p in points if p.param_code is not None}
+        # Entity builders use this to hide unmapped cloud controls on local entries.
+        self.supported_parameters: frozenset[str] = frozenset(self._by_param)
+
+    def _resolve(self, name_or_code: str) -> HoldingControlPoint:
+        key = str(name_or_code)
+        point = self._by_param.get(key) or self._by_code.get(key)
+        if point is None:
+            raise ModbusControlError(f"Parameter {key!r} is not available over local Modbus on family {self.family!r}")
+        if point.wire_address in HOLDING_WRITE_DENYLIST_WIRE:
+            raise ModbusControlError(f"Parameter {key!r} maps to denylisted wire {point.wire_address}")
+        return point
+
+    async def async_check_update_support(self, device_uuid: str) -> bool:
+        """Return True when the primary holding control map is readable."""
+        if not self._by_param:
+            return False
+        # Prefer ratio register; fall back to any mapped point.
+        probe = self._by_param.get("active_power_limit_ratio") or next(iter(self._by_param.values()))
+        try:
+            await self._client.async_read_holding(probe.wire_address, 1)
+        except SungrowModbusError as err:
+            _LOGGER.debug("Modbus control support check failed for %s: %s", device_uuid, err)
+            return False
+        return True
+
+    async def async_read_parameters(
+        self, device_uuid: str, param_list: list[str] | None = None
+    ) -> list[dict[str, Any]]:
+        """Read mapped holdings; returns cloud-shaped readout dicts."""
+        names = list(param_list) if param_list is not None else list(self._by_param)
+        out: list[dict[str, Any]] = []
+        for name in names:
+            point = self._resolve(name)
+            try:
+                regs = await self._client.async_read_holding(point.wire_address, 1)
+            except SungrowModbusError as err:
+                raise ModbusControlError(f"Read {point.param} failed: {err}") from err
+            raw = int(regs[0])
+            out.append(
+                {
+                    "id": point.param_code or point.param,
+                    "code": point.param,
+                    "name": point.description,
+                    "value": str(raw),
+                    "unit": "",
+                    "precision": None,
+                }
+            )
+        return out
+
+    async def async_update_parameters(self, device_uuid: str, param_values: dict[str, Any]) -> list[dict[str, Any]]:
+        """Write cloud-encoded parameter values to holding registers with read-back."""
+        out: list[dict[str, Any]] = []
+        for name, value in param_values.items():
+            point = self._resolve(str(name))
+            try:
+                wire = int(str(value).strip())
+            except (TypeError, ValueError) as err:
+                raise ModbusControlError(f"Invalid wire value for {point.param}: {value!r}") from err
+            if not 0 <= wire <= 0xFFFF:
+                raise ModbusControlError(f"Wire value out of U16 range for {point.param}: {wire}")
+            try:
+                await self._client.async_write_holding(point.wire_address, wire)
+                verify = await self._client.async_read_holding(point.wire_address, 1)
+            except SungrowModbusError as err:
+                raise ModbusControlError(f"Write {point.param} failed: {err}") from err
+            vraw = int(verify[0])
+            if vraw != wire:
+                raise ModbusControlError(f"Write {point.param} read-back mismatch: wrote {wire}, read {vraw}")
+            _LOGGER.debug(
+                "Modbus wrote %s=%s to %s wire %s (device %s)",
+                point.param,
+                wire,
+                self.family,
+                point.wire_address,
+                device_uuid,
+            )
+            out.append(
+                {
+                    "id": point.param_code or point.param,
+                    "code": point.param,
+                    "name": point.description,
+                    "value": str(vraw),
+                    "unit": "",
+                    "precision": None,
+                }
+            )
+        return out
+
+    async def async_set_parameter(self, device_uuid: str, name: str, value: object) -> list[dict[str, Any]]:
+        """Encode via cloud Control specs then write (for callers that pass display values)."""
+        from pysolarcloud.control import Control
+
+        wire = Control.encode_parameter(name, value)
+        return await self.async_update_parameters(device_uuid, {name: wire})

--- a/custom_components/sungrow/modbus_control_probe.py
+++ b/custom_components/sungrow/modbus_control_probe.py
@@ -1,0 +1,222 @@
+"""Live probe helpers for local Modbus holding-register control (#220 spike).
+
+Read-only by default. Writes require ``SUNGROW_MODBUS_WRITE_OK=1`` and only target
+explicit write candidates (never the denylist). Results classify as supported /
+read_only / unsupported / inconclusive so #220 can go/no-go before HA wiring.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from dataclasses import dataclass
+from typing import Any, Protocol
+
+from .modbus import SungrowModbusError
+from .modbus_registers import (
+    HOLDING_WRITE_DENYLIST_WIRE,
+    SG_RS_HOLDING_PROBE_POINTS,
+    HoldingProbePoint,
+)
+
+_LOGGER = logging.getLogger(__name__)
+
+WRITE_OK_ENV = "SUNGROW_MODBUS_WRITE_OK"
+
+
+class HoldingClient(Protocol):
+    """Minimal client surface used by the probe (production or mock)."""
+
+    async def async_read_holding(self, address: int, count: int = 1) -> list[int]: ...
+
+    async def async_write_holding(self, address: int, value: int) -> None: ...
+
+
+@dataclass(frozen=True)
+class HoldingProbeResult:
+    """One probe observation for a holding register."""
+
+    name: str
+    wire_address: int
+    kind: str  # "read" | "write_noop" | "write_denied"
+    ok: bool
+    raw: int | None
+    detail: str
+
+
+def writes_allowed() -> bool:
+    """True when the environment explicitly permits a live holding write."""
+    return os.environ.get(WRITE_OK_ENV, "").strip() == "1"
+
+
+def classify_holding_probe_results(results: list[HoldingProbeResult]) -> str:
+    """Classify spike outcome for #220 go/no-go.
+
+    - ``supported``: at least one write candidate was written and read back
+    - ``read_only``: write candidates readable but writes skipped or failed
+    - ``unsupported``: no probe point readable
+    - ``inconclusive``: empty results or only connection-level failures
+    """
+    if not results:
+        return "inconclusive"
+
+    reads = [r for r in results if r.kind == "read"]
+    writes = [r for r in results if r.kind == "write_noop"]
+    ok_reads = [r for r in reads if r.ok]
+    ok_writes = [r for r in writes if r.ok]
+
+    if ok_writes:
+        return "supported"
+    if ok_reads:
+        # Readable but no successful write (gated off or write failed).
+        return "read_only"
+    # All failed — distinguish total connection death from illegal addresses.
+    if all("connect" in r.detail.lower() or "not connected" in r.detail.lower() for r in results):
+        return "inconclusive"
+    if any(r.ok for r in results):
+        return "read_only"
+    return "unsupported"
+
+
+def _is_denied(address: int) -> bool:
+    return address in HOLDING_WRITE_DENYLIST_WIRE
+
+
+async def probe_holding_points(
+    client: HoldingClient,
+    points: tuple[HoldingProbePoint, ...] | None = None,
+    *,
+    allow_write: bool | None = None,
+) -> list[HoldingProbeResult]:
+    """Read candidate holdings; optionally no-op rewrite write candidates.
+
+    When ``allow_write`` is None, defers to :func:`writes_allowed`. Writes always
+    re-apply the **current** raw value (no-op) and refuse denylisted addresses.
+    """
+    targets = points if points is not None else SG_RS_HOLDING_PROBE_POINTS
+    do_write = writes_allowed() if allow_write is None else allow_write
+    out: list[HoldingProbeResult] = []
+
+    for point in targets:
+        try:
+            regs = await client.async_read_holding(point.wire_address, 1)
+            raw = int(regs[0])
+            out.append(
+                HoldingProbeResult(
+                    name=point.name,
+                    wire_address=point.wire_address,
+                    kind="read",
+                    ok=True,
+                    raw=raw,
+                    detail=f"raw={raw}",
+                )
+            )
+        except SungrowModbusError as err:
+            out.append(
+                HoldingProbeResult(
+                    name=point.name,
+                    wire_address=point.wire_address,
+                    kind="read",
+                    ok=False,
+                    raw=None,
+                    detail=str(err),
+                )
+            )
+            continue
+        except Exception as err:  # pylint: disable=broad-except
+            out.append(
+                HoldingProbeResult(
+                    name=point.name,
+                    wire_address=point.wire_address,
+                    kind="read",
+                    ok=False,
+                    raw=None,
+                    detail=f"exception={type(err).__name__}: {err}",
+                )
+            )
+            continue
+
+        if not point.write_candidate:
+            continue
+        if not do_write:
+            out.append(
+                HoldingProbeResult(
+                    name=point.name,
+                    wire_address=point.wire_address,
+                    kind="write_denied",
+                    ok=False,
+                    raw=raw,
+                    detail=f"write skipped ({WRITE_OK_ENV}!=1)",
+                )
+            )
+            continue
+        if _is_denied(point.wire_address):
+            out.append(
+                HoldingProbeResult(
+                    name=point.name,
+                    wire_address=point.wire_address,
+                    kind="write_denied",
+                    ok=False,
+                    raw=raw,
+                    detail="address on HOLDING_WRITE_DENYLIST_WIRE",
+                )
+            )
+            continue
+
+        try:
+            await client.async_write_holding(point.wire_address, raw)
+            verify = await client.async_read_holding(point.wire_address, 1)
+            vraw = int(verify[0])
+            ok = vraw == raw
+            out.append(
+                HoldingProbeResult(
+                    name=point.name,
+                    wire_address=point.wire_address,
+                    kind="write_noop",
+                    ok=ok,
+                    raw=vraw,
+                    detail=f"noop write raw={raw} readback={vraw}",
+                )
+            )
+        except SungrowModbusError as err:
+            out.append(
+                HoldingProbeResult(
+                    name=point.name,
+                    wire_address=point.wire_address,
+                    kind="write_noop",
+                    ok=False,
+                    raw=raw,
+                    detail=str(err),
+                )
+            )
+        except Exception as err:  # pylint: disable=broad-except
+            out.append(
+                HoldingProbeResult(
+                    name=point.name,
+                    wire_address=point.wire_address,
+                    kind="write_noop",
+                    ok=False,
+                    raw=raw,
+                    detail=f"exception={type(err).__name__}: {err}",
+                )
+            )
+
+    return out
+
+
+def format_probe_summary(results: list[HoldingProbeResult], classification: str) -> dict[str, Any]:
+    """JSON-serialisable summary for issue comments / diagnostics (no secrets)."""
+    return {
+        "classification": classification,
+        "results": [
+            {
+                "name": r.name,
+                "wire_address": r.wire_address,
+                "kind": r.kind,
+                "ok": r.ok,
+                "raw": r.raw,
+                "detail": r.detail,
+            }
+            for r in results
+        ],
+    }

--- a/custom_components/sungrow/modbus_registers.py
+++ b/custom_components/sungrow/modbus_registers.py
@@ -20,6 +20,75 @@ from typing import Any
 # Modbus function codes.
 FUNC_INPUT = 4  # read input registers (readings)
 FUNC_HOLDING = 3  # read holding registers (config/control)
+FUNC_WRITE_SINGLE = 6  # write single holding register
+
+
+# ---------------------------------------------------------------------------
+# #220 local control spike — holding candidates (wire addresses = doc − 1)
+# ---------------------------------------------------------------------------
+# Community/protocol maps (SunGather string protocol + hybrid SH docs). Phase-0
+# only *probes* these; production writes wait on live SG-RS confirmation.
+# Never write start/stop (wire 5005) or hybrid EMS (13049+) on a string inverter
+# without a separate validated map.
+
+
+@dataclass(frozen=True)
+class HoldingProbePoint:
+    """One holding register considered for local control probing (#220)."""
+
+    name: str
+    wire_address: int
+    description: str
+    family: str  # "sg_rs" | "sh_rt" | "probe_negative"
+    scale: float = 1.0
+    unit: str | None = None
+    # If True, the live probe may attempt a gated no-op / restore write.
+    write_candidate: bool = False
+
+
+# Active power limit on string inverters (doc 5007 enable / 5008 ratio → wire −1).
+SG_RS_ACTIVE_POWER_LIMIT_ENABLE = HoldingProbePoint(
+    name="active_power_limit_enable",
+    wire_address=5006,
+    description="Active power limitation switch (0xAA enable / 0x55 disable)",
+    family="sg_rs",
+    write_candidate=False,  # enabling can curtail; probe read-only first
+)
+SG_RS_ACTIVE_POWER_LIMIT_RATIO = HoldingProbePoint(
+    name="active_power_limit_ratio",
+    wire_address=5007,
+    description="Active power limit ratio (0.1 % units; 1000 = 100%)",
+    family="sg_rs",
+    scale=0.1,
+    unit="%",
+    write_candidate=True,
+)
+
+# Hybrid EMS block — expected illegal/unsupported on pure SG-RS (negative control).
+SH_EMS_MODE = HoldingProbePoint(
+    name="energy_management_mode",
+    wire_address=13049,
+    description="Hybrid EMS mode (doc 13050); SH-only negative probe on SG-RS",
+    family="probe_negative",
+    write_candidate=False,
+)
+
+# Absolute no-write list for the spike (and Phase-1 SG-RS control).
+HOLDING_WRITE_DENYLIST_WIRE: frozenset[int] = frozenset(
+    {
+        5005,  # start/stop (0xCF/0xCE)
+        13049,  # EMS mode
+        13050,  # charge/discharge command
+        13051,  # charge/discharge power
+        13079,  # external EMS heartbeat
+    }
+)
+
+SG_RS_HOLDING_PROBE_POINTS: tuple[HoldingProbePoint, ...] = (
+    SG_RS_ACTIVE_POWER_LIMIT_ENABLE,
+    SG_RS_ACTIVE_POWER_LIMIT_RATIO,
+    SH_EMS_MODE,
+)
 
 # Sentinel values a register can return when the point is not supported by the
 # attached hardware/firmware.

--- a/custom_components/sungrow/modbus_registers.py
+++ b/custom_components/sungrow/modbus_registers.py
@@ -24,12 +24,11 @@ FUNC_WRITE_SINGLE = 6  # write single holding register
 
 
 # ---------------------------------------------------------------------------
-# #220 local control spike — holding candidates (wire addresses = doc − 1)
+# #220 local control — holding maps (wire addresses = doc − 1)
 # ---------------------------------------------------------------------------
-# Community/protocol maps (SunGather string protocol + hybrid SH docs). Phase-0
-# only *probes* these; production writes wait on live SG-RS confirmation.
-# Never write start/stop (wire 5005) or hybrid EMS (13049+) on a string inverter
-# without a separate validated map.
+# Validated live on SG3.6RS + WiNet-S (2026-07-18): wire 5006=0xAA enable,
+# 5007=1000 (100%), FC6 no-op write+readback ok; hybrid EMS 13049 unsupported.
+# Never write start/stop (wire 5005) or hybrid EMS without a separate SH map.
 
 
 @dataclass(frozen=True)
@@ -46,13 +45,29 @@ class HoldingProbePoint:
     write_candidate: bool = False
 
 
+@dataclass(frozen=True)
+class HoldingControlPoint:
+    """Production holding register mapped to a cloud dispatch parameter name (#220).
+
+    Values written via ``async_update_parameters`` are already cloud-encoded strings
+    (e.g. active power ratio 100% → ``"1000"``, enable → ``"170"``). The holding
+    path stores that integer in a single U16 register.
+    """
+
+    param: str
+    wire_address: int
+    description: str
+    # Cloud Appendix-10 param_code when known (for read-back id field).
+    param_code: str | None = None
+
+
 # Active power limit on string inverters (doc 5007 enable / 5008 ratio → wire −1).
 SG_RS_ACTIVE_POWER_LIMIT_ENABLE = HoldingProbePoint(
     name="active_power_limit_enable",
     wire_address=5006,
     description="Active power limitation switch (0xAA enable / 0x55 disable)",
     family="sg_rs",
-    write_candidate=False,  # enabling can curtail; probe read-only first
+    write_candidate=False,
 )
 SG_RS_ACTIVE_POWER_LIMIT_RATIO = HoldingProbePoint(
     name="active_power_limit_ratio",
@@ -73,7 +88,7 @@ SH_EMS_MODE = HoldingProbePoint(
     write_candidate=False,
 )
 
-# Absolute no-write list for the spike (and Phase-1 SG-RS control).
+# Absolute no-write list for the spike and production SG-RS control.
 HOLDING_WRITE_DENYLIST_WIRE: frozenset[int] = frozenset(
     {
         5005,  # start/stop (0xCF/0xCE)
@@ -89,6 +104,28 @@ SG_RS_HOLDING_PROBE_POINTS: tuple[HoldingProbePoint, ...] = (
     SG_RS_ACTIVE_POWER_LIMIT_RATIO,
     SH_EMS_MODE,
 )
+
+# Cloud param names → holding wires for ModbusControl (family-keyed).
+SG_RS_HOLDING_CONTROL_POINTS: tuple[HoldingControlPoint, ...] = (
+    HoldingControlPoint(
+        param="limited_power_switch",
+        wire_address=5006,
+        description="Active power limitation enable (0xAA/0x55 = 170/85)",
+        param_code="10007",
+    ),
+    HoldingControlPoint(
+        param="active_power_limit_ratio",
+        wire_address=5007,
+        description="Active power limit ratio (0.1 %; 1000 = 100%)",
+        param_code="10008",
+    ),
+)
+
+HOLDING_CONTROL_MAPS: dict[str, tuple[HoldingControlPoint, ...]] = {
+    "sg_rs": SG_RS_HOLDING_CONTROL_POINTS,
+    # Three-phase string maps share the low holding block on community maps.
+    "sg_rt": SG_RS_HOLDING_CONTROL_POINTS,
+}
 
 # Sentinel values a register can return when the point is not supported by the
 # attached hardware/firmware.

--- a/custom_components/sungrow/number.py
+++ b/custom_components/sungrow/number.py
@@ -19,6 +19,7 @@ from pysolarcloud.control import Control
 from . import DispatchControl, build_device_info, select_dispatch_device
 from .const import DOMAIN
 from .coordinator import SungrowPlantCoordinator
+from .modbus_control import ModbusControlError
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -191,10 +192,16 @@ def _build_numbers(coordinator: SungrowPlantCoordinator, control: DispatchContro
     # Size the power sliders to the device's rated power when it can be derived
     # from the model code; otherwise use the conservative default.
     max_power = rated_power_w(target) or DEFAULT_MAX_DISPATCH_POWER
+    # Local ModbusControl only maps a subset of Appendix-10 params (#220).
+    # Require a real collection so MagicMock control clients in tests are unaffected.
+    raw_supported = getattr(control, "supported_parameters", None)
+    supported = raw_supported if isinstance(raw_supported, (set, frozenset)) else None
     entities: list[NumberEntity] = []
     for param, meta in DISPATCH_NUMBERS.items():
         # Hide battery-only controls on PV-only plants — see #148.
         if meta.get("battery_only") and not coordinator.has_battery:
+            continue
+        if supported is not None and param not in supported:
             continue
         if param in _RATED_POWER_PARAMS and max_power != meta["native_max_value"]:
             meta = {**meta, "native_max_value": max_power}
@@ -288,7 +295,7 @@ class SungrowDispatchNumber(CoordinatorEntity[SungrowPlantCoordinator], RestoreN
         wire_value = Control.encode_parameter(self.param, value)
         try:
             await self.control.async_update_parameters(self.device_uuid, {self.param: wire_value})
-        except PySolarCloudException as err:
+        except (PySolarCloudException, ModbusControlError) as err:
             raise HomeAssistantError(
                 translation_domain=DOMAIN,
                 translation_key="dispatch_write_failed",

--- a/custom_components/sungrow/select.py
+++ b/custom_components/sungrow/select.py
@@ -28,6 +28,7 @@ from . import (
 )
 from .const import DOMAIN
 from .coordinator import SungrowPlantCoordinator
+from .modbus_control import ModbusControlError
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -150,10 +151,13 @@ def _build_selects(coordinator: SungrowPlantCoordinator, control: DispatchContro
     if not target.get("uuid"):
         return []
     # Hide battery-only controls on PV-only plants — see #148.
+    # Local ModbusControl only maps a subset of Appendix-10 params (#220).
+    raw_supported = getattr(control, "supported_parameters", None)
+    supported = raw_supported if isinstance(raw_supported, (set, frozenset)) else None
     return [
         SungrowDispatchSelect(coordinator, control, target, param, meta)
         for param, meta in DISPATCH_SELECTS.items()
-        if coordinator.has_battery or not meta.get("battery_only")
+        if (coordinator.has_battery or not meta.get("battery_only")) and (supported is None or param in supported)
     ]
 
 
@@ -395,7 +399,7 @@ class SungrowDispatchSelect(CoordinatorEntity[SungrowPlantCoordinator], RestoreE
         _LOGGER.debug("Setting %s to %s (%s) for %s", self.param, option, payload, self.device_uuid)
         try:
             await self.control.async_update_parameters(self.device_uuid, payload)
-        except PySolarCloudException as err:
+        except (PySolarCloudException, ModbusControlError) as err:
             raise HomeAssistantError(
                 translation_domain=DOMAIN,
                 translation_key="dispatch_write_failed",

--- a/docs/local-modbus.md
+++ b/docs/local-modbus.md
@@ -45,8 +45,8 @@ the cloud plant in the device registry (`via_device`) — a soft “related to�
 | --- | --- | --- | --- | --- |
 | **Cloud-only** | iSolarCloud OpenAPI | Developer app (App Key/Secret/ID) | ✅ Yes | Full plant sensors and battery/dispatch controls. |
 | **Cloud (user account)** *(unofficial)* | iSolarCloud app/web API | Just email + password | ✅ Yes (experimental) | No developer app — sensors + dispatch. See caveats below. |
-| **Modbus-only** *(local)* | Local Modbus only | **Not needed** | ❌ Read-only | Fast local metrics, offline / privacy-first. |
-| **Both** *(two entries)* | Each entry its own source | Cloud entry only | Via **cloud** entry | Compare or use cloud + local side by side. |
+| **Modbus-only** *(local)* | Local Modbus only | **Not needed** | ✅ Active power limit (SG string) | Fast local metrics + limited local control; offline / privacy-first. |
+| **Both** *(two entries)* | Each entry its own source | Cloud entry only | Full dispatch via **cloud**; local active-power on local entry | Compare or use cloud + local side by side. |
 
 ### Cloud user account (unofficial)
 
@@ -121,8 +121,21 @@ entry **derives** calendar-day yield from lifetime `total_yield` (baseline store
 Cloud daily yield remains whatever iSolarCloud reports — they can differ; that is expected
 with two independent sources.
 
+## Local control (active power limit)
+
+On **SG string** local entries (validated on SG3.6RS), the integration can write
+WiNet-S **holding registers** for:
+
+- **Limited power switch** (enable/disable active power limiting)
+- **Active power limit ratio** (% of rated, 0–100%)
+
+These use the same number/select entities as cloud dispatch. Battery EMS
+(charge/discharge, SOC, heartbeat) is **not** available over local Modbus on
+string inverters — use a **cloud** entry for hybrid/battery control
+([#220](https://github.com/KRoperUK/sungrow-hass/issues/220)).
+
 ## Current limitations
 
-- **SG-RS register map** only (see issues above for other models).
-- **Read-only** — charge/dispatch stays on the cloud API when you have a cloud entry.
+- **SG-RS / SG-RT** holding control is limited to active-power limiting for now.
+- Hybrid EMS / battery dispatch over Modbus is not implemented yet.
 - Local and cloud **do not share** entities; configure Energy/dashboards explicitly.

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -139,7 +139,7 @@ async def test_async_unload_entry(hass: HomeAssistant, mock_setup_auth, mock_pla
 
 
 async def test_setup_modbus_only_entry(hass: HomeAssistant):
-    """A Modbus-only entry sets up cloud-free: one coordinator, no cloud/dispatch, sensors only."""
+    """A Modbus-only entry sets up cloud-free with local active-power control (#220)."""
     entry = MockConfigEntry(
         domain=DOMAIN,
         data={
@@ -154,9 +154,13 @@ async def test_setup_modbus_only_entry(hass: HomeAssistant):
     entry.add_to_hass(hass)
 
     client = MagicMock()
+    client.model = "sg_rs"
     client.async_read_realtime = AsyncMock(
         return_value={"grid_frequency": {"code": "grid_frequency", "value": 49.9, "unit": "Hz", "source": "modbus"}}
     )
+    # Holding support probe for ModbusControl (#220).
+    client.async_read_holding = AsyncMock(return_value=[1000])
+    client.async_write_holding = AsyncMock()
     with patch("custom_components.sungrow.modbus.SungrowModbusClient", return_value=client):
         assert await hass.config_entries.async_setup(entry.entry_id)
         await hass.async_block_till_done()
@@ -164,15 +168,19 @@ async def test_setup_modbus_only_entry(hass: HomeAssistant):
     assert entry.state is ConfigEntryState.LOADED
     data = entry.runtime_data
     assert len(data.coordinators) == 1
-    # No cloud service and no dispatch controller on a Modbus-only entry.
+    # No cloud service; local ModbusControl for active-power params.
     assert data.coordinators[0].plants_service is None
-    assert data.control is None
+    assert data.control is not None
+    assert data.coordinators[0].has_battery is False
+    assert data.coordinators[0].dispatch_update_supported is True
     # The local client supplied the realtime data.
     assert data.coordinators[0].data["grid_frequency"]["value"] == 49.9
+    # Active power limit number should exist; battery mode select must not.
+    assert hass.states.get("number.sg3_6rs_local_active_power_limit_ratio") is not None or any(
+        s.entity_id.startswith("number.") and "active_power" in s.entity_id for s in hass.states.async_all("number")
+    )
+    assert not any("battery_mode" in s.entity_id for s in hass.states.async_all("select"))
 
-    # A Modbus-only entry must unload ONLY the platform it set up (sensor). Unloading
-    # number/select/binary_sensor — never forwarded — fails the unload in production,
-    # which breaks the options-change reload and takes every entity unavailable.
     orig = hass.config_entries.async_unload_platforms
     seen: dict[str, list[Platform]] = {}
 
@@ -183,7 +191,7 @@ async def test_setup_modbus_only_entry(hass: HomeAssistant):
     with patch.object(hass.config_entries, "async_unload_platforms", side_effect=_spy):
         assert await hass.config_entries.async_unload(entry.entry_id)
         await hass.async_block_till_done()
-    assert seen["platforms"] == [Platform.BINARY_SENSOR, Platform.SENSOR]
+    assert seen["platforms"] == [Platform.BINARY_SENSOR, Platform.NUMBER, Platform.SELECT, Platform.SENSOR]
     assert entry.state is ConfigEntryState.NOT_LOADED
     # WiNet-S single-connection slot must be released on unload (options reload heal).
     client.close.assert_called()

--- a/tests/test_modbus_control.py
+++ b/tests/test_modbus_control.py
@@ -1,0 +1,82 @@
+"""Unit tests for ModbusControl (#220 Phase 1)."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from custom_components.sungrow.modbus_control import ModbusControl, ModbusControlError
+
+
+def _client(*, family: str = "sg_rs") -> MagicMock:
+    client = MagicMock()
+    client.model = family
+    client.async_read_holding = AsyncMock(return_value=[1000])
+    client.async_write_holding = AsyncMock()
+    return client
+
+
+async def test_supported_parameters_for_sg_rs():
+    control = ModbusControl(_client(), family="sg_rs")
+    assert "active_power_limit_ratio" in control.supported_parameters
+    assert "limited_power_switch" in control.supported_parameters
+    assert "energy_management_mode" not in control.supported_parameters
+
+
+async def test_check_update_support_reads_ratio():
+    client = _client()
+    control = ModbusControl(client, family="sg_rs")
+    assert await control.async_check_update_support("sn_inv") is True
+    client.async_read_holding.assert_awaited()
+
+
+async def test_check_update_support_false_on_read_error():
+    from custom_components.sungrow.modbus import SungrowModbusError
+
+    client = _client()
+    client.async_read_holding = AsyncMock(side_effect=SungrowModbusError("exception_code=2"))
+    control = ModbusControl(client, family="sg_rs")
+    assert await control.async_check_update_support("sn_inv") is False
+
+
+async def test_update_writes_and_verifies():
+    client = _client()
+    client.async_read_holding = AsyncMock(return_value=[900])
+    control = ModbusControl(client, family="sg_rs")
+    out = await control.async_update_parameters("sn_inv", {"active_power_limit_ratio": "900"})
+    client.async_write_holding.assert_awaited_once_with(5007, 900)
+    assert out[0]["code"] == "active_power_limit_ratio"
+    assert out[0]["value"] == "900"
+
+
+async def test_update_rejects_unknown_param():
+    control = ModbusControl(_client(), family="sg_rs")
+    with pytest.raises(ModbusControlError, match="not available"):
+        await control.async_update_parameters("sn_inv", {"energy_management_mode": "2"})
+
+
+async def test_update_rejects_readback_mismatch():
+    client = _client()
+    client.async_write_holding = AsyncMock()
+    client.async_read_holding = AsyncMock(return_value=[1])  # not what we wrote
+    control = ModbusControl(client, family="sg_rs")
+    with pytest.raises(ModbusControlError, match="read-back mismatch"):
+        await control.async_update_parameters("sn_inv", {"active_power_limit_ratio": "900"})
+
+
+async def test_read_parameters_shape():
+    client = _client()
+    client.async_read_holding = AsyncMock(return_value=[170])
+    control = ModbusControl(client, family="sg_rs")
+    rows = await control.async_read_parameters("sn_inv", ["limited_power_switch"])
+    assert rows[0]["id"] == "10007"
+    assert rows[0]["code"] == "limited_power_switch"
+    assert rows[0]["value"] == "170"
+
+
+async def test_empty_family_has_no_support():
+    client = _client(family="unknown_family")
+    control = ModbusControl(client, family="unknown_family")
+    assert control.supported_parameters == frozenset()
+    assert await control.async_check_update_support("x") is False

--- a/tests/test_modbus_control_probe.py
+++ b/tests/test_modbus_control_probe.py
@@ -1,0 +1,181 @@
+"""Unit tests for the #220 Modbus holding-control spike."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from custom_components.sungrow.modbus import SungrowModbusClient, SungrowModbusError
+from custom_components.sungrow.modbus_control_probe import (
+    WRITE_OK_ENV,
+    HoldingProbeResult,
+    classify_holding_probe_results,
+    format_probe_summary,
+    probe_holding_points,
+    writes_allowed,
+)
+from custom_components.sungrow.modbus_registers import (
+    HOLDING_WRITE_DENYLIST_WIRE,
+    SG_RS_ACTIVE_POWER_LIMIT_RATIO,
+    SG_RS_HOLDING_PROBE_POINTS,
+    HoldingProbePoint,
+)
+
+
+def test_write_denylist_includes_start_stop_and_ems():
+    """Spike must never target start/stop or hybrid EMS wires."""
+    assert 5005 in HOLDING_WRITE_DENYLIST_WIRE
+    assert 13049 in HOLDING_WRITE_DENYLIST_WIRE
+
+
+def test_classify_supported_when_noop_write_ok():
+    results = [
+        HoldingProbeResult("ratio", 5007, "read", True, 1000, "raw=1000"),
+        HoldingProbeResult("ratio", 5007, "write_noop", True, 1000, "noop ok"),
+    ]
+    assert classify_holding_probe_results(results) == "supported"
+
+
+def test_classify_read_only_when_write_gated_off():
+    results = [
+        HoldingProbeResult("ratio", 5007, "read", True, 1000, "raw=1000"),
+        HoldingProbeResult("ratio", 5007, "write_denied", False, 1000, "gated"),
+    ]
+    assert classify_holding_probe_results(results) == "read_only"
+
+
+def test_classify_unsupported_when_all_reads_fail_non_connect():
+    results = [
+        HoldingProbeResult("a", 1, "read", False, None, "exception_code=2"),
+        HoldingProbeResult("b", 2, "read", False, None, "exception_code=2"),
+    ]
+    assert classify_holding_probe_results(results) == "unsupported"
+
+
+def test_classify_inconclusive_on_connect_failures():
+    results = [
+        HoldingProbeResult("a", 1, "read", False, None, "Could not connect to host"),
+    ]
+    assert classify_holding_probe_results(results) == "inconclusive"
+
+
+def test_writes_allowed_requires_exact_env(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.delenv(WRITE_OK_ENV, raising=False)
+    assert writes_allowed() is False
+    monkeypatch.setenv(WRITE_OK_ENV, "1")
+    assert writes_allowed() is True
+    monkeypatch.setenv(WRITE_OK_ENV, "yes")
+    assert writes_allowed() is False
+
+
+async def test_probe_read_only_by_default():
+    """Without write gate, readable write-candidates are recorded as write_denied."""
+    client = MagicMock()
+    client.async_read_holding = AsyncMock(return_value=[1000])
+    client.async_write_holding = AsyncMock()
+    point = HoldingProbePoint(
+        name="ratio",
+        wire_address=5007,
+        description="test",
+        family="sg_rs",
+        write_candidate=True,
+    )
+    results = await probe_holding_points(client, (point,), allow_write=False)
+    assert results[0].kind == "read" and results[0].ok
+    assert results[1].kind == "write_denied"
+    client.async_write_holding.assert_not_awaited()
+
+
+async def test_probe_noop_write_when_allowed():
+    client = MagicMock()
+    client.async_read_holding = AsyncMock(side_effect=[[990], [990]])
+    client.async_write_holding = AsyncMock()
+    point = HoldingProbePoint(
+        name="ratio",
+        wire_address=5007,
+        description="test",
+        family="sg_rs",
+        write_candidate=True,
+    )
+    results = await probe_holding_points(client, (point,), allow_write=True)
+    assert any(r.kind == "write_noop" and r.ok for r in results)
+    client.async_write_holding.assert_awaited_once_with(5007, 990)
+
+
+async def test_probe_refuses_denylisted_write_candidate():
+    """Even if marked write_candidate, denylist blocks the write."""
+    client = MagicMock()
+    client.async_read_holding = AsyncMock(return_value=[0])
+    client.async_write_holding = AsyncMock()
+    point = HoldingProbePoint(
+        name="ems",
+        wire_address=13049,
+        description="denied",
+        family="probe_negative",
+        write_candidate=True,
+    )
+    results = await probe_holding_points(client, (point,), allow_write=True)
+    assert any(r.kind == "write_denied" and "DENYLIST" in r.detail for r in results)
+    client.async_write_holding.assert_not_awaited()
+
+
+async def test_probe_records_read_failure():
+    client = MagicMock()
+    client.async_read_holding = AsyncMock(side_effect=SungrowModbusError("exception_code=2"))
+    point = SG_RS_ACTIVE_POWER_LIMIT_RATIO
+    results = await probe_holding_points(client, (point,), allow_write=False)
+    assert len(results) == 1
+    assert results[0].ok is False
+
+
+def test_format_probe_summary_shape():
+    results = [HoldingProbeResult("ratio", 5007, "read", True, 1000, "raw=1000")]
+    summary = format_probe_summary(results, "read_only")
+    assert summary["classification"] == "read_only"
+    assert summary["results"][0]["wire_address"] == 5007
+
+
+async def test_client_read_holding_uses_fc3_path():
+    """async_read_holding calls read_holding_registers under the reconnect wrapper."""
+    inner = MagicMock()
+    inner.connected = True
+    ok = MagicMock()
+    ok.isError.return_value = False
+    ok.registers = [1000]
+    inner.read_holding_registers = AsyncMock(return_value=ok)
+    inner.close = MagicMock()
+    with patch("custom_components.sungrow.modbus.AsyncModbusTcpClient", return_value=inner):
+        client = SungrowModbusClient("10.0.0.1")
+        regs = await client.async_read_holding(5007, 1)
+    assert regs == [1000]
+    inner.read_holding_registers.assert_awaited_once()
+
+
+async def test_client_write_holding_rejects_out_of_range():
+    with patch("custom_components.sungrow.modbus.AsyncModbusTcpClient"):
+        client = SungrowModbusClient("10.0.0.1")
+        with pytest.raises(SungrowModbusError, match="U16"):
+            await client.async_write_holding(5007, 0x10000)
+
+
+async def test_client_write_holding_calls_write_register():
+    inner = MagicMock()
+    inner.connected = True
+    ok = MagicMock()
+    ok.isError.return_value = False
+    inner.write_register = AsyncMock(return_value=ok)
+    inner.close = MagicMock()
+    with patch("custom_components.sungrow.modbus.AsyncModbusTcpClient", return_value=inner):
+        client = SungrowModbusClient("10.0.0.1")
+        await client.async_write_holding(5007, 1000)
+    inner.write_register.assert_awaited_once()
+    args, kwargs = inner.write_register.await_args
+    assert args[0] == 5007
+    assert args[1] == 1000
+
+
+def test_default_probe_points_cover_sg_and_negative():
+    names = {p.name for p in SG_RS_HOLDING_PROBE_POINTS}
+    assert "active_power_limit_ratio" in names
+    assert "energy_management_mode" in names

--- a/tests/test_modbus_control_probe_live.py
+++ b/tests/test_modbus_control_probe_live.py
@@ -1,0 +1,65 @@
+"""Live holding-register probe against a real WiNet-S (#220 spike).
+
+Run (read-only)::
+
+    SUNGROW_MODBUS_HOST=192.168.x.x pytest -m live tests/test_modbus_control_probe_live.py -v
+
+Optional no-op write of the current active-power ratio (restores same value)::
+
+    SUNGROW_MODBUS_HOST=192.168.x.x SUNGROW_MODBUS_WRITE_OK=1 \\
+      pytest -m live tests/test_modbus_control_probe_live.py -v
+
+Never set WRITE_OK unless you accept a single FC6 to the ratio register only.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+
+import pytest
+
+from custom_components.sungrow.modbus import SungrowModbusClient
+from custom_components.sungrow.modbus_control_probe import (
+    classify_holding_probe_results,
+    format_probe_summary,
+    probe_holding_points,
+)
+
+pytestmark = pytest.mark.live
+
+
+@pytest.fixture
+def modbus_host() -> str:
+    host = os.environ.get("SUNGROW_MODBUS_HOST", "").strip()
+    if not host:
+        pytest.skip("SUNGROW_MODBUS_HOST not set")
+    return host
+
+
+@pytest.fixture
+def modbus_port() -> int:
+    return int(os.environ.get("SUNGROW_MODBUS_PORT", "502"))
+
+
+@pytest.fixture
+def modbus_unit() -> int:
+    return int(os.environ.get("SUNGROW_MODBUS_UNIT", "1"))
+
+
+async def test_live_holding_probe_sg_rs(modbus_host: str, modbus_port: int, modbus_unit: int):
+    """Probe SG-RS active-power holdings + hybrid EMS negative control on live hardware."""
+    client = SungrowModbusClient(modbus_host, port=modbus_port, unit=modbus_unit, model="sg_rs")
+    try:
+        results = await probe_holding_points(client)
+    finally:
+        client.close()
+
+    classification = classify_holding_probe_results(results)
+    summary = format_probe_summary(results, classification)
+    # Visible in pytest -s / CI logs for pasting onto #220.
+    print("\n#220 holding probe summary:\n" + json.dumps(summary, indent=2))
+
+    assert classification in {"supported", "read_only", "unsupported", "inconclusive"}
+    # Soft expectation: at least attempt all default points.
+    assert len(results) >= 3


### PR DESCRIPTION
## Summary

Implements [#220](https://github.com/KRoperUK/sungrow-hass/issues/220) Phase 0+1 after a **live SG3.6RS probe** on dell-serve (`supported`):

### Probe (Phase 0)
- FC3/FC6 helpers + gated live probe
- Wire 5006=0xAA, 5007=1000, no-op write ok; EMS 13049 unsupported

### Control (Phase 1)
- \`ModbusControl\` duck-types cloud dispatch (\`async_update_parameters\` / read / support check)
- SG-RS map: \`limited_power_switch\` (5006), \`active_power_limit_ratio\` (5007)
- modbus_only loads NUMBER + SELECT
- \`has_battery=False\` → no charge/discharge/SOC on local string
- Write path verifies holding read-back
- Docs updated

### Not in this PR
- Hybrid EMS / battery / export holdings
- Cloud entry using Modbus for control

## Type of change

- [x] New feature

## Checklist

- [x] ruff / pytest (690 passed)

## Test plan

- [ ] Install PR build on dell-serve
- [ ] Local entry shows limited power switch + active power limit ratio
- [ ] No battery mode select on local entry
- [ ] Change ratio 100→99→100; confirm write and generation behaviour