### PR TITLE
fix(modbus): omit phantom via_device when no cloud plant

### DIFF
--- a/custom_components/sungrow/__init__.py
+++ b/custom_components/sungrow/__init__.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import logging
 from collections.abc import Iterator
 from dataclasses import dataclass, field
@@ -264,7 +265,9 @@ async def _async_setup_modbus_only(hass: HomeAssistant, entry: SungrowConfigEntr
     host = str(entry.options.get(CONF_MODBUS_HOST) or entry.data.get(CONF_MODBUS_HOST) or "")
     winet_url = f"http://{host}" if host else None
     cloud_plant_id = find_related_cloud_plant_id(hass, serial)
-    via_plant_id = cloud_plant_id or serial
+    # Only nest under a *real* cloud plant device. Falling back to ``serial`` invented a
+    # via_device parent that does not exist and trips HA 2025.12 warnings (live SG3.6RS).
+    via_plant_id = cloud_plant_id
 
     # One inverter device. Distinct identifiers so the plant and inverter don't collide.
     inverter = {
@@ -333,7 +336,16 @@ async def _async_setup_modbus_only(hass: HomeAssistant, entry: SungrowConfigEntr
         if hass.is_running:
             entry.async_on_unload(async_call_later(hass, 5, _async_recheck_nesting))
         else:
-            entry.async_on_unload(hass.bus.async_listen_once(EVENT_HOMEASSISTANT_STARTED, _async_recheck_nesting))
+            # listen_once auto-removes after fire; wrap so unload after start does not
+            # raise "Unable to remove unknown job listener" (seen on dell-serve reloads).
+            remove = hass.bus.async_listen_once(EVENT_HOMEASSISTANT_STARTED, _async_recheck_nesting)
+
+            @callback
+            def _cancel_recheck() -> None:
+                with contextlib.suppress(ValueError, KeyError, TypeError):
+                    remove()
+
+            entry.async_on_unload(_cancel_recheck)
 
     return True
 

--- a/custom_components/sungrow/binary_sensor.py
+++ b/custom_components/sungrow/binary_sensor.py
@@ -217,12 +217,13 @@ class SungrowModbusConnectivityBinarySensor(CoordinatorEntity[SungrowPlantCoordi
         super().__init__(coordinator)
         self.device_uuid = str(device["uuid"])
         self._attr_unique_id = f"{coordinator.plant_id}_{self.device_uuid}_online"
+        local_url = getattr(coordinator, "local_configuration_url", None)
         self._attr_device_info = build_device_info(
             device,
             coordinator.plant_id,
             fallback_name=coordinator.plant_name,
             via_plant_id=getattr(coordinator, "via_plant_id", None),
-            configuration_url=getattr(coordinator, "local_configuration_url", None),
+            configuration_url=local_url if isinstance(local_url, str) else None,
         )
 
     @property

--- a/custom_components/sungrow/device_helpers.py
+++ b/custom_components/sungrow/device_helpers.py
@@ -57,12 +57,18 @@ def resolve_point_device(point_code: str, devices: list[dict[str, Any]]) -> dict
     return matches[0] if len(matches) == 1 else None
 
 
+# Sentinel: omit ``via_plant_id`` to nest under ``plant_id`` (cloud default). Pass
+# ``via_plant_id=None`` explicitly for a local Modbus inverter with no cloud plant so
+# we do **not** invent a non-existent parent (HA 2025.12 warns / breaks).
+_VIA_PLANT_UNSET: object = object()
+
+
 def build_device_info(
     device: dict[str, Any],
     plant_id: str,
     *,
     fallback_name: str | None = None,
-    via_plant_id: str | None = None,
+    via_plant_id: str | None | object = _VIA_PLANT_UNSET,
     configuration_url: str | None = None,
 ) -> DeviceInfo:
     """Build a device-registry entry for a physical device, nested under its plant.
@@ -73,17 +79,23 @@ def build_device_info(
     via ``via_device``. The uuid is stringified so the identifier matches
     ``_known_device_ids`` (which keys on ``str(uuid)``) and the device isn't pruned.
 
-    ``via_plant_id`` overrides the parent plant identifier (used by a local Modbus
-    inverter that nests under a matching cloud plant without merging data).
+    ``via_plant_id`` overrides the parent plant identifier (local Modbus nesting under a
+    matching cloud plant). Pass ``None`` to leave the device un-nested when no plant
+    parent exists yet — never point ``via_device`` at a missing identifier.
     """
+    if via_plant_id is _VIA_PLANT_UNSET:
+        parent_id: str | None = plant_id
+    else:
+        parent_id = via_plant_id  # type: ignore[assignment]
     info = DeviceInfo(
         identifiers={(DOMAIN, str(device["uuid"]))},
         name=device.get("device_name") or device.get("device_model_name") or fallback_name,
         manufacturer=device.get("factory_name") or "Sungrow",
         model=device.get("device_model_code") or device.get("device_model_name"),
         serial_number=device.get("device_sn"),
-        via_device=(DOMAIN, via_plant_id or plant_id),
     )
+    if parent_id is not None:
+        info["via_device"] = (DOMAIN, parent_id)
     if configuration_url:
         info["configuration_url"] = configuration_url
     return info

--- a/custom_components/sungrow/number.py
+++ b/custom_components/sungrow/number.py
@@ -265,9 +265,21 @@ class SungrowDispatchNumber(CoordinatorEntity[SungrowPlantCoordinator], RestoreN
         # Entity name comes from translations (entity.number.<param>.name).
         self._attr_translation_key = param
         self._attr_unique_id = f"{coordinator.plant_id}_{self.device_uuid}_{param}"
-        # Nest the dispatch device under the plant device the sensors created,
-        # enriched with the model/serial the cloud reports.
-        self._attr_device_info = build_device_info(device, coordinator.plant_id, fallback_name=coordinator.plant_name)
+        # Cloud: default via_device = plant_id. Local Modbus: nest only under a real cloud
+        # plant (via_plant_id set); otherwise omit parent (via_plant_id=None).
+        local_url = getattr(coordinator, "local_configuration_url", None)
+        if isinstance(local_url, str):
+            self._attr_device_info = build_device_info(
+                device,
+                coordinator.plant_id,
+                fallback_name=coordinator.plant_name,
+                via_plant_id=getattr(coordinator, "via_plant_id", None),
+                configuration_url=local_url or None,
+            )
+        else:
+            self._attr_device_info = build_device_info(
+                device, coordinator.plant_id, fallback_name=coordinator.plant_name
+            )
         self._attr_device_class = meta.get("device_class")
         self._attr_native_unit_of_measurement = meta.get("native_unit_of_measurement")
         self._attr_native_min_value = meta["native_min_value"]

--- a/custom_components/sungrow/select.py
+++ b/custom_components/sungrow/select.py
@@ -214,9 +214,20 @@ class SungrowDispatchSelect(CoordinatorEntity[SungrowPlantCoordinator], RestoreE
         # Entity name comes from translations (entity.select.<param>.name).
         self._attr_translation_key = param
         self._attr_unique_id = f"{coordinator.plant_id}_{self.device_uuid}_{param}"
-        # Nest the dispatch device under the plant device the sensors created,
-        # enriched with the model/serial the cloud reports.
-        self._attr_device_info = build_device_info(device, coordinator.plant_id, fallback_name=coordinator.plant_name)
+        # Cloud: nest under plant_id. Local Modbus: only under a real cloud plant.
+        local_url = getattr(coordinator, "local_configuration_url", None)
+        if isinstance(local_url, str):
+            self._attr_device_info = build_device_info(
+                device,
+                coordinator.plant_id,
+                fallback_name=coordinator.plant_name,
+                via_plant_id=getattr(coordinator, "via_plant_id", None),
+                configuration_url=local_url or None,
+            )
+        else:
+            self._attr_device_info = build_device_info(
+                device, coordinator.plant_id, fallback_name=coordinator.plant_name
+            )
         self._attr_options = list(self.options_map.keys())
         self._attr_entity_category = meta.get("entity_category")
         # Auto-revert timer for forced Charge/Discharge (#157). Only the command select

--- a/custom_components/sungrow/sensor.py
+++ b/custom_components/sungrow/sensor.py
@@ -253,8 +253,11 @@ class SungrowSensor(CoordinatorEntity, SensorEntity):
         # device of the mapped type; otherwise keep it on the plant device (#158). The
         # unique_id above is unchanged, so HA re-parents the entity without renaming it.
         device = resolve_point_device(point_code, getattr(coordinator, "devices", None) or [])
-        via_plant_id = getattr(coordinator, "via_plant_id", None)
         local_url = getattr(coordinator, "local_configuration_url", None)
+        # Only local Modbus sets via_plant_id (cloud plant id or None). Cloud leaves it
+        # unset so build_device_info defaults via_device to plant_id.
+        is_local = isinstance(local_url, str)
+        via_plant_id = getattr(coordinator, "via_plant_id", None) if is_local else None
 
         # A Modbus-only entry represents a single inverter; plant-level points that are
         # not otherwise mapped should live on that inverter device so no orphaned local
@@ -267,15 +270,22 @@ class SungrowSensor(CoordinatorEntity, SensorEntity):
                 device = inverters[0]
 
         if device is not None:
-            self._attr_device_info = build_device_info(
-                device,
-                plant_id,
-                fallback_name=plant_name,
-                via_plant_id=via_plant_id,
-                configuration_url=local_url,
-            )
+            if is_local:
+                self._attr_device_info = build_device_info(
+                    device,
+                    plant_id,
+                    fallback_name=plant_name,
+                    via_plant_id=via_plant_id,
+                    configuration_url=local_url or None,
+                )
+            else:
+                self._attr_device_info = build_device_info(device, plant_id, fallback_name=plant_name)
         else:
-            self._attr_device_info = build_plant_device_info(via_plant_id or plant_id, plant_name, console_url)
+            self._attr_device_info = build_plant_device_info(
+                (via_plant_id or plant_id) if is_local else plant_id,
+                plant_name,
+                console_url,
+            )
         self._apply_point_metadata(point_code, init_data, plant_name)
 
     def _apply_point_metadata(self, point_code: str, init_data: dict[str, Any], label: str) -> None:
@@ -429,13 +439,17 @@ class SungrowDeviceSensor(SungrowSensor):
         device_name = device.get("device_name") or device.get("device_model_name") or coordinator.plant_name
         self._attr_unique_id = f"{self.plant_id}_{self.device_uuid}_{point_code}"
         # Enrich the device card with the model/serial the cloud reports.
-        self._attr_device_info = build_device_info(
-            device,
-            self.plant_id,
-            fallback_name=coordinator.plant_name,
-            via_plant_id=getattr(coordinator, "via_plant_id", None),
-            configuration_url=getattr(coordinator, "local_configuration_url", None),
-        )
+        local_url = getattr(coordinator, "local_configuration_url", None)
+        if isinstance(local_url, str):
+            self._attr_device_info = build_device_info(
+                device,
+                self.plant_id,
+                fallback_name=coordinator.plant_name,
+                via_plant_id=getattr(coordinator, "via_plant_id", None),
+                configuration_url=local_url or None,
+            )
+        else:
+            self._attr_device_info = build_device_info(device, self.plant_id, fallback_name=coordinator.plant_name)
         self._apply_point_metadata(point_code, init_data, device_name)
         # Inverter internals (operating status, MPPT, DC power, device type, ...) are diagnostics.
         if point_code in _DIAGNOSTIC_CODES or point_code == "device_type_code":

--- a/tests/test_device_helpers.py
+++ b/tests/test_device_helpers.py
@@ -1,0 +1,36 @@
+"""Tests for device_helpers nesting helpers."""
+
+from custom_components.sungrow.const import DOMAIN
+from custom_components.sungrow.device_helpers import build_device_info
+
+
+def test_build_device_info_defaults_via_to_plant_id():
+    """Cloud path: omitting via_plant_id nests under plant_id."""
+    info = build_device_info(
+        {"uuid": "inv-1", "device_name": "Inv", "device_model_code": "SG3.6RS", "device_sn": "S1"},
+        "plant-1",
+    )
+    assert info["via_device"] == (DOMAIN, "plant-1")
+
+
+def test_build_device_info_explicit_via_plant_id():
+    """Local nested under cloud plant uses the override parent."""
+    info = build_device_info(
+        {"uuid": "inv-1", "device_name": "Inv"},
+        "serial",
+        via_plant_id="plant-99",
+    )
+    assert info["via_device"] == (DOMAIN, "plant-99")
+
+
+def test_build_device_info_none_via_omits_parent():
+    """Explicit via_plant_id=None leaves the device un-nested (no phantom parent)."""
+    info = build_device_info(
+        {"uuid": "serial_inv", "device_name": "SG3.6RS (local)", "device_sn": "serial"},
+        "serial",
+        via_plant_id=None,
+        configuration_url="http://192.168.1.93",
+    )
+    assert "via_device" not in info
+    assert info["configuration_url"] == "http://192.168.1.93"
+    assert info["identifiers"] == {(DOMAIN, "serial_inv")}

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -274,6 +274,13 @@ async def test_setup_modbus_only_nests_under_cloud_plant(hass: HomeAssistant):
     # No synthetic local plant device is created when nesting under a cloud plant.
     registry = dr.async_get(hass)
     assert registry.async_get_device(identifiers={(DOMAIN, "SNLINK")}) is None
+    # Local inverter nests under the real cloud plant.
+    inv = registry.async_get_device(identifiers={(DOMAIN, "SNLINK_inv")})
+    assert inv is not None
+    assert inv.via_device_id is not None
+    parent = registry.async_get(inv.via_device_id)
+    assert parent is not None
+    assert (DOMAIN, "plant-99") in parent.identifiers
 
 
 async def test_setup_modbus_only_cleans_stale_local_plant_when_cloud_present(hass: HomeAssistant):
@@ -361,9 +368,13 @@ async def test_setup_modbus_only_reloads_when_cloud_plant_appears_after_startup(
         assert await hass.config_entries.async_setup(entry.entry_id)
         await hass.async_block_till_done()
 
-    # No cloud plant yet, so no synthetic local plant device is created.
+    # No cloud plant yet: no synthetic plant, and inverter is un-nested (no bogus via_device).
     registry = dr.async_get(hass)
     assert registry.async_get_device(identifiers={(DOMAIN, "SNLINK")}) is None
+    inv = registry.async_get_device(identifiers={(DOMAIN, "SNLINK_inv")})
+    assert inv is not None
+    assert inv.via_device_id is None
+    assert entry.runtime_data.coordinators[0].via_plant_id is None
 
     # Now the cloud entry/device appears before HA finishes startup.
     cloud = MockConfigEntry(domain=DOMAIN, data=MOCK_CONFIG_DATA.copy(), unique_id="cloud_app")


### PR DESCRIPTION
## Summary

Follow-up nits from live #315 validation (no release cut).

1. **Phantom `via_device`** — local Modbus used `via_device=(domain, serial)` when no cloud plant existed. That parent device is never registered → HA warning (live SG3.6RS) and breakage in 2025.12. Now:
   - `via_plant_id` is only the real cloud plant id (or `None`)
   - `build_device_info(..., via_plant_id=None)` omits `via_device`
   - number/select/sensor/binary local paths pass explicit nesting

2. **Reload listener** — `async_listen_once` + `async_on_unload` raised `Unable to remove unknown job listener` after start; cancel is now best-effort.

## Type of change

- [x] Bug fix

## Checklist

- [x] ruff / mypy / pytest
- [ ] No release (per request)

## Test plan

- [ ] Local-only entry: no via_device warning in logs for SG3.6RS (local)
- [ ] Local + cloud plant: inverter still nests under cloud plant