### PR TITLE
fix(modbus): cap read blocks at Modbus 125-register protocol limit

### DIFF
--- a/custom_components/sungrow/modbus_registers.py
+++ b/custom_components/sungrow/modbus_registers.py
@@ -393,26 +393,51 @@ def block_bounds(points: tuple[ModbusPoint, ...]) -> tuple[int, int]:
     return start, end - start
 
 
-def block_partitions(points: tuple[ModbusPoint, ...], max_gap: int = 256) -> list[tuple[int, int]]:
-    """Split ``points`` into contiguous read blocks separated by gaps > ``max_gap``.
+# Modbus function 4 (read input registers) is capped by the protocol at 125
+# registers per request. pymodbus enforces this client-side and the WiNet-S
+# dongle is happier with even smaller reads; the default keeps some headroom.
+# See issue #318 — the SH-RT/SH-RS map collapsed 4999..5241 into a single
+# 243-register block and pymodbus rejected the request with
+# ``1 < count 243 < 125 !`` before it ever hit the wire.
+MODBUS_MAX_READ_COUNT = 125
+DEFAULT_MAX_BLOCK_SIZE = 100
 
-    Modbus limits the number of registers per read; reading one huge block from
-    4999 to 13045 would fail. This partitions the map into nearby groups so each
-    read stays small and efficient.
+
+def block_partitions(
+    points: tuple[ModbusPoint, ...],
+    max_gap: int = 256,
+    max_block_size: int = DEFAULT_MAX_BLOCK_SIZE,
+) -> list[tuple[int, int]]:
+    """Split ``points`` into contiguous read blocks small enough for one Modbus read.
+
+    Modbus limits the number of registers per read (spec max = 125, and WiNet-S
+    dongles are happier with less). This partitions the map so each block:
+
+    * is separated from the next by more than ``max_gap`` registers, and
+    * never exceeds ``max_block_size`` registers (defaults to
+      :data:`DEFAULT_MAX_BLOCK_SIZE`, leaving headroom under the 125 hard cap).
+
+    Reading one huge block from 4999 to 13045 would fail; this yields a handful
+    of small reads instead. ``max_block_size`` is clamped to
+    :data:`MODBUS_MAX_READ_COUNT` because pymodbus rejects anything larger.
     """
     if not points:
         return []
+    cap = min(max_block_size, MODBUS_MAX_READ_COUNT)
     sorted_points = sorted(points, key=lambda p: p.address)
     blocks: list[tuple[int, int]] = []
     block_start = sorted_points[0].address
     block_end = sorted_points[0].address + sorted_points[0].register_count
     for point in sorted_points[1:]:
-        if point.address > block_end + max_gap:
+        point_end = point.address + point.register_count
+        would_exceed_cap = (point_end - block_start) > cap
+        gap_too_wide = point.address > block_end + max_gap
+        if gap_too_wide or would_exceed_cap:
             blocks.append((block_start, block_end - block_start))
             block_start = point.address
-            block_end = point.address + point.register_count
+            block_end = point_end
         else:
-            block_end = max(block_end, point.address + point.register_count)
+            block_end = max(block_end, point_end)
     blocks.append((block_start, block_end - block_start))
     return blocks
 

--- a/tests/test_modbus.py
+++ b/tests/test_modbus.py
@@ -98,13 +98,123 @@ def test_block_partitions_keeps_nearby_points_together():
     assert blocks == [(10, 7)]
 
 
-def test_sh_rt_map_partitions_around_large_gaps():
-    """The SH-RT map is split around gaps > 256 registers."""
+def test_sh_rt_map_partitions_stay_under_modbus_count_cap():
+    """The SH-RT map partitions into reads small enough for a single Modbus request (#318).
+
+    Before this fix, points 4999..5241 collapsed into a single 243-register block
+    that pymodbus refuses to send (spec cap = 125). Every block must now fit and
+    the low PV/mppt/AC section must still start at register 4999.
+    """
     blocks = block_partitions(SH_RT_INPUT_POINTS)
-    assert len(blocks) == 3
+    # Every read must be within the Modbus function-4 protocol limit.
+    assert blocks, "expected at least one block"
+    assert all(count <= 125 for _, count in blocks), blocks
+    # Low PV/AC block still starts at the device-type register.
     assert blocks[0][0] == 4999
-    assert blocks[1][0] == 5600
-    assert blocks[2][0] == 12999
+    # Full range still covered: last block must reach the high hybrid registers.
+    assert max(start + count for start, count in blocks) >= 13046
+
+
+def test_block_partitions_enforces_max_block_size():
+    """A cluster larger than ``max_block_size`` is split into multiple reads."""
+    # 200 contiguous u16 points would be one block by gap alone, but must be
+    # split when ``max_block_size`` is enforced.
+    points = tuple(ModbusPoint(1000 + i, f"p{i}", "u16", 1) for i in range(200))
+    blocks = block_partitions(points, max_block_size=100)
+    assert len(blocks) >= 2
+    assert all(count <= 100 for _, count in blocks)
+    # No point is dropped: registers [1000, 1200) are all covered.
+    covered = {addr for start, count in blocks for addr in range(start, start + count)}
+    assert covered == {1000 + i for i in range(200)}
+
+
+def test_block_partitions_clamps_to_modbus_protocol_max():
+    """``max_block_size`` cannot exceed the 125-register Modbus function-4 cap."""
+    # Ask for a huge cap; the function must still keep every block <= 125.
+    points = tuple(ModbusPoint(1000 + i, f"p{i}", "u16", 1) for i in range(300))
+    blocks = block_partitions(points, max_block_size=10_000)
+    assert all(count <= 125 for _, count in blocks), blocks
+
+
+# ---------------------------------------------------------------------------
+# Register-map safety (regression guard for #318)
+# ---------------------------------------------------------------------------
+# These tests are parametrized over every family in ``REGISTER_MAPS`` so a new
+# map added later cannot silently reintroduce the 243-register block that
+# pymodbus refuses to send. If someone extends SH-RT with points that widen the
+# 4999..5241 cluster past 125 again, the guard here trips before it ever hits
+# a user's WiNet-S.
+
+
+@pytest.mark.parametrize("family", sorted(REGISTER_MAPS.keys()))
+def test_every_register_map_partitions_within_modbus_cap(family):
+    """Every family's map splits into reads that fit a single Modbus request (#318)."""
+    points = REGISTER_MAPS[family]
+    blocks = block_partitions(points)
+    for start, count in blocks:
+        assert 1 <= count <= 125, f"{family}: block {(start, count)} exceeds Modbus cap"
+
+
+@pytest.mark.parametrize("family", sorted(REGISTER_MAPS.keys()))
+def test_every_register_map_point_is_covered_by_a_block(family):
+    """Partitioning never drops a point: each address range sits inside one block (#318)."""
+    points = REGISTER_MAPS[family]
+    blocks = block_partitions(points)
+    for point in points:
+        point_end = point.address + point.register_count
+        covered = any(start <= point.address and point_end <= start + count for start, count in blocks)
+        assert covered, f"{family}: point {point.code}@{point.address} not covered by any block"
+
+
+def _capped_modbus_client_cls(*, cap: int = 125):
+    """Fake pymodbus client that mirrors the real 125-register-per-request cap.
+
+    Any read whose ``count`` exceeds ``cap`` is returned as an error response with
+    the exact message shape pymodbus surfaces (``1 < count N < 125 !``), so the
+    end-to-end test reproduces the failure users hit in #318 rather than silently
+    passing when a map explodes.
+    """
+    inner = MagicMock()
+    inner.connected = True
+    inner.connect = AsyncMock(return_value=True)
+    inner.close = MagicMock()
+    inner.requested = []
+
+    async def _read(address, count, device_id):
+        inner.requested.append((address, count))
+        result = MagicMock()
+        if count > cap:
+            result.isError.return_value = True
+            result.__str__ = lambda _s: f"1 < count {count} < {cap} !"
+        else:
+            result.isError.return_value = False
+            result.registers = [0] * count
+        return result
+
+    inner.read_input_registers = AsyncMock(side_effect=_read)
+    cls = MagicMock(return_value=inner)
+    return cls, inner
+
+
+@pytest.mark.parametrize("family", sorted(REGISTER_MAPS.keys()))
+async def test_read_realtime_never_asks_pymodbus_for_more_than_the_cap(family):
+    """End-to-end: reading each family never triggers pymodbus's 125-register rejection (#318).
+
+    This is the regression that would have caught the SH10RS crash before release:
+    on the buggy code path the SH-RT/SH-RS map produced a 243-register read that
+    a cap-enforcing fake pymodbus rejects with ``1 < count 243 < 125 !`` — exactly
+    the error users reported.
+    """
+    cls, inner = _capped_modbus_client_cls(cap=125)
+    with patch("custom_components.sungrow.modbus.AsyncModbusTcpClient", cls):
+        client = SungrowModbusClient("10.0.0.1", model=family)
+        _skip_family_detect(client)
+        # Should not raise: every block read must fit under 125 registers.
+        await client.async_read_realtime()
+    assert inner.requested, f"{family}: expected at least one read"
+    assert all(count <= 125 for _, count in inner.requested), (
+        f"{family}: pymodbus would reject reads {[c for _, c in inner.requested if c > 125]}"
+    )
 
 
 def test_sg_rs_low_block_decodes_a_realistic_frame():

--- a/tests/test_modbus_properties.py
+++ b/tests/test_modbus_properties.py
@@ -1,0 +1,82 @@
+"""Property-based tests for the local Modbus register partitioner (#318).
+
+The partitioner turns a sparse register map into a small number of contiguous
+reads. Two invariants must hold for *any* possible map — not just the ones we
+ship today — so a future family added by community contribution cannot
+reintroduce the 243-register block that pymodbus rejects with
+``1 < count 243 < 125 !``:
+
+1. Every emitted block fits within the Modbus function-4 protocol cap
+   (:data:`MODBUS_MAX_READ_COUNT` = 125).
+2. Every input point is covered by exactly one block — the partitioner
+   never silently drops a register.
+"""
+
+from __future__ import annotations
+
+from hypothesis import given, settings
+from hypothesis import strategies as st
+
+from custom_components.sungrow.modbus_registers import (
+    MODBUS_MAX_READ_COUNT,
+    ModbusPoint,
+    block_partitions,
+)
+
+# u16/s16 occupy 1 register, u32/s32 occupy 2. Restricting the address range
+# well below 65535 keeps u32 points from running off the end of the space.
+_DATA_TYPES = ("u16", "s16", "u32", "s32")
+
+
+@st.composite
+def _modbus_points(draw):
+    """A small, well-formed set of ModbusPoints with unique addresses."""
+    addresses = draw(
+        st.lists(
+            st.integers(min_value=0, max_value=60_000),
+            min_size=1,
+            max_size=120,
+            unique=True,
+        )
+    )
+    return tuple(ModbusPoint(address, f"p_{address}", draw(st.sampled_from(_DATA_TYPES)), 1) for address in addresses)
+
+
+@given(points=_modbus_points())
+@settings(max_examples=200, deadline=None)
+def test_block_partitions_never_exceeds_modbus_cap(points):
+    """No emitted block can be larger than the Modbus per-request register cap."""
+    blocks = block_partitions(points)
+    for start, count in blocks:
+        assert 1 <= count <= MODBUS_MAX_READ_COUNT, f"block ({start}, {count}) exceeds Modbus cap"
+
+
+@given(points=_modbus_points())
+@settings(max_examples=200, deadline=None)
+def test_block_partitions_covers_every_point(points):
+    """Every input point's register range lies fully inside exactly one block."""
+    blocks = block_partitions(points)
+    for point in points:
+        point_end = point.address + point.register_count
+        covering = [(s, c) for s, c in blocks if s <= point.address and point_end <= s + c]
+        assert len(covering) == 1, f"point {point.code}@{point.address} covered by {covering}"
+
+
+@given(
+    points=_modbus_points(),
+    # min=2 because a single u32 point is irreducibly 2 registers wide and no
+    # partitioner can shrink it below that; useful real-world caps are 100..125.
+    cap=st.integers(min_value=2, max_value=500),
+)
+@settings(max_examples=100, deadline=None)
+def test_block_partitions_respects_caller_supplied_cap(points, cap):
+    """A caller-supplied ``max_block_size`` is honoured up to the Modbus protocol max.
+
+    ``max_block_size`` is clamped to :data:`MODBUS_MAX_READ_COUNT`, so any block
+    must fit under ``min(cap, MODBUS_MAX_READ_COUNT)`` — never larger, whatever
+    the caller asks for.
+    """
+    effective_cap = min(cap, MODBUS_MAX_READ_COUNT)
+    blocks = block_partitions(points, max_block_size=cap)
+    for start, count in blocks:
+        assert count <= effective_cap, f"block ({start}, {count}) exceeds requested cap {effective_cap}"


### PR DESCRIPTION
Fixes #318. Unblocks the local-Modbus part of #314.

## Root cause

`SH_RT_INPUT_POINTS` has a tight cluster around registers 4999..5241. `block_partitions()` used a gap-only heuristic (`max_gap=256`) with no upper bound on block size, so it produced a **243-register** read for that cluster. pymodbus rejects the request client-side with the exact error users reported:

```
Modbus input at 4999 (count 243) failed: 1 < count 243 < 125 !
```

Function 4 (read input registers) is capped at 125 by the Modbus spec, and WiNet-S is happier with even less. There was also a second latent block of **146** registers at 5600 that would have surfaced next.

Impact on #314: `battery_power` (5213), `meter_active_power` (5600), `load_power` (13007), `export_power_raw` (13009), `battery_level` (13022) are already defined in `SH_RT_INPUT_POINTS`. They only became reachable in 5.6.0 once family detection resolved SH10RS to `sh_rs`, but the 243-count read broke the poll before any of them decoded.

## Fix

Add `max_block_size` (default `100`, hard-clamped to the 125 protocol max) to `block_partitions`. Blocks now break when either the gap threshold is exceeded **or** adding another point would push the read past the cap.

SH-RT/SH-RS map after the fix: 6 small reads (37, 2, 29, 39, 24, 48 registers) instead of one 243-register crash.

## Prevent the class of bug returning

Three layers of defence in tests:

1. **Parametrized structural tests** over every family in `REGISTER_MAPS`, so a new map added later cannot silently reintroduce an over-cap block.
2. **End-to-end** test drives `SungrowModbusClient` against a fake pymodbus that mirrors the real 125-cap rejection, reproducing the exact runtime failure when the code regresses.
3. **Property-based tests** (Hypothesis, 200 examples) prove the invariants hold for arbitrary future maps: every block ≤ 125, every point covered exactly once.

Cross-checked by monkey-patching in the pre-fix partitioner: it produces `[(4999, 243), (5600, 146), (12999, 48)]`, which the new tests flag immediately.

## Verification

- `pytest tests/`: 710 passed, 4 deselected (live-only), 0 failed
- `ruff check` / `ruff format --check`: clean
- `mypy`: no issues found in 27 source files