### PR TITLE
feat(modbus): decode power_flow_status bits into per-flow binary sensors

### DIFF
--- a/custom_components/sungrow/binary_sensor.py
+++ b/custom_components/sungrow/binary_sensor.py
@@ -21,6 +21,7 @@ from pysolarcloud.plants import DeviceType
 from . import build_device_info
 from .coordinator import SungrowPlantCoordinator
 from .measure_points import resolve_enum_value
+from .modbus_registers import POWER_FLOW_STATUS_BITS
 
 # Read-only, updated in bulk by the coordinator.
 PARALLEL_UPDATES = 0
@@ -71,9 +72,19 @@ def _build_binary_sensors(coordinator: SungrowPlantCoordinator) -> list[BinarySe
     sensors: list[BinarySensorEntity] = []
     if coordinator.plants_service is None:
         # Modbus-only path: the local inverter's connectivity is driven by the last poll.
+        data = coordinator.data or {}
+        has_power_flow = "power_flow_status" in data
         for device in coordinator.devices:
             if device.get("device_type") == DeviceType.INVERTER and device.get("uuid"):
                 sensors.append(SungrowModbusConnectivityBinarySensor(coordinator, device))
+                # Hybrid families expose power_flow_status; string inverters don't,
+                # so we only create the per-flow binary sensors when the register
+                # is actually present in the coordinator's data (#326).
+                if has_power_flow:
+                    sensors.extend(
+                        SungrowModbusPowerFlowBinarySensor(coordinator, device, bit, key)
+                        for bit, key in POWER_FLOW_STATUS_BITS
+                    )
         return sensors
 
     for device in coordinator.devices:
@@ -243,3 +254,77 @@ class SungrowModbusConnectivityBinarySensor(CoordinatorEntity[SungrowPlantCoordi
         if diag.get("last_error"):
             attrs["last_error"] = diag["last_error"]
         return attrs
+
+
+# Bit-index -> HA device class for the power_flow_status flags. Only two of the
+# five surfaced bits have a natural HA device class; the rest present as plain
+# translated boolean sensors and get their name from strings.json.
+_POWER_FLOW_DEVICE_CLASSES: dict[int, BinarySensorDeviceClass] = {
+    0: BinarySensorDeviceClass.RUNNING,  # PV generating
+    1: BinarySensorDeviceClass.BATTERY_CHARGING,  # Battery charging
+}
+
+
+class SungrowModbusPowerFlowBinarySensor(CoordinatorEntity[SungrowPlantCoordinator], BinarySensorEntity):
+    """A single bit of ``power_flow_status`` exposed as an on/off binary sensor (#326).
+
+    Decoded from wire register 13000, one entity per surfaced bit. This turns
+    the raw bitfield sensor into automation-friendly triggers like
+    ``binary_sensor.battery_charging`` and ``binary_sensor.exporting_power`` so
+    users don't have to write template sensors to make the same decisions the
+    inverter is already publishing.
+    """
+
+    _attr_has_entity_name = True
+
+    def __init__(
+        self,
+        coordinator: SungrowPlantCoordinator,
+        device: dict[str, Any],
+        bit_index: int,
+        translation_key: str,
+    ) -> None:
+        """Initialize a power-flow bit sensor for a local Modbus inverter."""
+        super().__init__(coordinator)
+        self.device_uuid = str(device["uuid"])
+        self._bit_index = bit_index
+        self._attr_translation_key = translation_key
+        self._attr_unique_id = f"{coordinator.plant_id}_{self.device_uuid}_power_flow_{translation_key}"
+        device_class = _POWER_FLOW_DEVICE_CLASSES.get(bit_index)
+        if device_class is not None:
+            self._attr_device_class = device_class
+        local_url = getattr(coordinator, "local_configuration_url", None)
+        self._attr_device_info = build_device_info(
+            device,
+            coordinator.plant_id,
+            fallback_name=coordinator.plant_name,
+            via_plant_id=getattr(coordinator, "via_plant_id", None),
+            configuration_url=local_url if isinstance(local_url, str) else None,
+        )
+
+    def _raw(self) -> int | None:
+        """Return the current ``power_flow_status`` register value, or None if missing."""
+        data = self.coordinator.data or {}
+        point = data.get("power_flow_status")
+        if not isinstance(point, dict):
+            return None
+        val = point.get("value")
+        if val is None:
+            return None
+        try:
+            return int(float(val))
+        except (ValueError, TypeError):
+            return None
+
+    @property
+    def available(self) -> bool:
+        """Unavailable if the last poll failed or ``power_flow_status`` isn't reported."""
+        return super().available and self._raw() is not None
+
+    @property
+    def is_on(self) -> bool | None:
+        """Return whether this power-flow bit is set."""
+        raw = self._raw()
+        if raw is None:
+            return None
+        return bool(raw & (1 << self._bit_index))

--- a/custom_components/sungrow/modbus_registers.py
+++ b/custom_components/sungrow/modbus_registers.py
@@ -461,6 +461,40 @@ MODBUS_ENUM_MAPS: dict[str, dict[int, str]] = {
 }
 
 
+# ---------------------------------------------------------------------------
+# power_flow_status bitfield decode (#326)
+# ---------------------------------------------------------------------------
+# Wire register 13000 (``power_flow_status``) is a u16 bitfield of live-flow
+# flags — "is PV generating?", "is the battery charging?", "are we importing
+# from grid?". Users writing "start EV charging when solar is exporting" or
+# "notify when battery starts discharging" want these as true/false triggers
+# rather than raw bits. Bit meanings from mkaiser SHx template bit decoders
+# (MIT). Reserved bit 6, and bits 3/7 (load-power sign duplicates of
+# ``load_power``) are intentionally omitted — surface via ``load_power``
+# directly if they're wanted.
+
+# (bit_index, translation_key) pairs. The translation key doubles as a stable
+# identifier for the unique_id suffix so entity IDs are portable across
+# translations.
+POWER_FLOW_STATUS_BITS: tuple[tuple[int, str], ...] = (
+    (0, "pv_generating"),
+    (1, "battery_charging"),
+    (2, "battery_discharging"),
+    (4, "exporting_power"),
+    (5, "importing_power"),
+)
+
+
+def decode_power_flow_status(raw: int) -> dict[str, bool]:
+    """Decode a raw ``power_flow_status`` register into named boolean flags.
+
+    ``raw`` is the u16 register value as read from wire register 13000. The
+    returned dict is keyed by the same translation keys the binary sensors use,
+    so callers can look up "is this flag set?" without duplicating bit math.
+    """
+    return {key: bool(raw & (1 << bit)) for bit, key in POWER_FLOW_STATUS_BITS}
+
+
 def decode_registers(
     points: tuple[ModbusPoint, ...], block_start: int, registers: list[int]
 ) -> dict[str, dict[str, Any]]:

--- a/custom_components/sungrow/strings.json
+++ b/custom_components/sungrow/strings.json
@@ -161,6 +161,21 @@
       },
       "device_fault": {
         "name": "Fault"
+      },
+      "pv_generating": {
+        "name": "PV Generating"
+      },
+      "battery_charging": {
+        "name": "Battery Charging"
+      },
+      "battery_discharging": {
+        "name": "Battery Discharging"
+      },
+      "exporting_power": {
+        "name": "Exporting to Grid"
+      },
+      "importing_power": {
+        "name": "Importing from Grid"
       }
     },
     "number": {

--- a/custom_components/sungrow/translations/cy.json
+++ b/custom_components/sungrow/translations/cy.json
@@ -161,6 +161,21 @@
       },
       "device_fault": {
         "name": "Nam"
+      },
+      "pv_generating": {
+        "name": "PV yn cynhyrchu"
+      },
+      "battery_charging": {
+        "name": "Batri yn gwefru"
+      },
+      "battery_discharging": {
+        "name": "Batri yn dadwefru"
+      },
+      "exporting_power": {
+        "name": "Allforio i'r grid"
+      },
+      "importing_power": {
+        "name": "Mewnforio o'r grid"
       }
     },
     "number": {

--- a/custom_components/sungrow/translations/de.json
+++ b/custom_components/sungrow/translations/de.json
@@ -161,6 +161,21 @@
       },
       "device_fault": {
         "name": "Störung"
+      },
+      "pv_generating": {
+        "name": "PV erzeugt"
+      },
+      "battery_charging": {
+        "name": "Batterie lädt"
+      },
+      "battery_discharging": {
+        "name": "Batterie entlädt"
+      },
+      "exporting_power": {
+        "name": "Netzeinspeisung"
+      },
+      "importing_power": {
+        "name": "Netzbezug"
       }
     },
     "number": {

--- a/custom_components/sungrow/translations/en.json
+++ b/custom_components/sungrow/translations/en.json
@@ -161,6 +161,21 @@
       },
       "device_fault": {
         "name": "Fault"
+      },
+      "pv_generating": {
+        "name": "PV Generating"
+      },
+      "battery_charging": {
+        "name": "Battery Charging"
+      },
+      "battery_discharging": {
+        "name": "Battery Discharging"
+      },
+      "exporting_power": {
+        "name": "Exporting to Grid"
+      },
+      "importing_power": {
+        "name": "Importing from Grid"
       }
     },
     "number": {

--- a/custom_components/sungrow/translations/es.json
+++ b/custom_components/sungrow/translations/es.json
@@ -161,6 +161,21 @@
       },
       "device_fault": {
         "name": "Fallo"
+      },
+      "pv_generating": {
+        "name": "FV generando"
+      },
+      "battery_charging": {
+        "name": "Batería cargando"
+      },
+      "battery_discharging": {
+        "name": "Batería descargando"
+      },
+      "exporting_power": {
+        "name": "Exportando a la red"
+      },
+      "importing_power": {
+        "name": "Importando de la red"
       }
     },
     "number": {

--- a/custom_components/sungrow/translations/fr.json
+++ b/custom_components/sungrow/translations/fr.json
@@ -161,6 +161,21 @@
       },
       "device_fault": {
         "name": "Défaut"
+      },
+      "pv_generating": {
+        "name": "PV en production"
+      },
+      "battery_charging": {
+        "name": "Batterie en charge"
+      },
+      "battery_discharging": {
+        "name": "Batterie en décharge"
+      },
+      "exporting_power": {
+        "name": "Injection réseau"
+      },
+      "importing_power": {
+        "name": "Soutirage réseau"
       }
     },
     "number": {

--- a/tests/test_binary_sensor.py
+++ b/tests/test_binary_sensor.py
@@ -1,5 +1,6 @@
 """Tests for the Sungrow binary_sensor platform (device fault, #151)."""
 
+from typing import Any
 from unittest.mock import MagicMock
 
 from homeassistant.components.binary_sensor import BinarySensorDeviceClass
@@ -214,3 +215,156 @@ async def test_modbus_connectivity_binary_sensor(hass: HomeAssistant):
     # Toggle last_update_success
     coordinator.last_update_success = False
     assert conn.is_on is False
+
+
+# ---------------------------------------------------------------------------
+# power_flow_status bitfield -> per-flow binary sensors (#326)
+# ---------------------------------------------------------------------------
+# Wire register 13000 packs "is PV generating / is battery charging / is grid
+# importing / exporting" flags into a single u16. We expose each surfaced bit
+# as its own binary_sensor so users can automate on them directly. Only hybrid
+# (SH-RS/SH-RT) coordinators produce this register — the entities must NOT be
+# created on SG string inverters, and they must go unavailable when the raw
+# value drops out.
+
+
+def _modbus_hybrid_coordinator(power_flow_value: Any) -> Any:
+    """Build a Modbus-only coordinator with an SH inverter + optional power_flow data."""
+    devices = [
+        {
+            "uuid": "inv-1",
+            "device_name": "SH10RT",
+            "device_type": DeviceType.INVERTER,
+            "device_model_code": "SH10RT-20",
+            "device_sn": "SH1",
+            "factory_name": "SUNGROW",
+        }
+    ]
+    coordinator = _coordinator_with(devices)
+    coordinator.plants_service = None
+    coordinator.via_plant_id = None
+    coordinator.local_configuration_url = "http://10.0.0.9"
+    coordinator.modbus_diagnostics = {"device_family": "sh_rt", "skipped_blocks": [], "last_error": None}
+    if power_flow_value is None:
+        coordinator.data = {}
+    else:
+        coordinator.data = {
+            "power_flow_status": {
+                "code": "power_flow_status",
+                "value": power_flow_value,
+                "unit": None,
+                "source": "modbus",
+            }
+        }
+    return coordinator
+
+
+async def test_power_flow_binary_sensors_created_for_hybrid(hass: HomeAssistant):
+    """A hybrid Modbus-only coordinator with power_flow_status yields one sensor per surfaced bit."""
+    from custom_components.sungrow.binary_sensor import SungrowModbusPowerFlowBinarySensor
+    from custom_components.sungrow.modbus_registers import POWER_FLOW_STATUS_BITS
+
+    entry = MockConfigEntry(domain=DOMAIN, data=MOCK_CONFIG_DATA.copy())
+    entry.add_to_hass(hass)
+    coordinator = _modbus_hybrid_coordinator(power_flow_value=0)
+    entry.runtime_data = SungrowData(coordinators=[coordinator], control=None, devices={"12345": coordinator.devices})
+
+    added: list = []
+    await async_setup_entry(hass, entry, lambda entities: added.extend(entities))
+
+    flows = [e for e in added if isinstance(e, SungrowModbusPowerFlowBinarySensor)]
+    assert len(flows) == len(POWER_FLOW_STATUS_BITS)
+    keys = {e._attr_translation_key for e in flows}
+    assert keys == {key for _, key in POWER_FLOW_STATUS_BITS}
+
+
+async def test_power_flow_binary_sensors_not_created_for_string_inverter(hass: HomeAssistant):
+    """SG string inverters don't expose power_flow_status, so no bit sensors are created."""
+    from custom_components.sungrow.binary_sensor import SungrowModbusPowerFlowBinarySensor
+
+    entry = MockConfigEntry(domain=DOMAIN, data=MOCK_CONFIG_DATA.copy())
+    entry.add_to_hass(hass)
+    # Same setup shape as hybrid but no power_flow_status in coordinator data.
+    coordinator = _modbus_hybrid_coordinator(power_flow_value=None)
+    coordinator.modbus_diagnostics["device_family"] = "sg_rs"
+    entry.runtime_data = SungrowData(coordinators=[coordinator], control=None, devices={"12345": coordinator.devices})
+
+    added: list = []
+    await async_setup_entry(hass, entry, lambda entities: added.extend(entities))
+
+    assert not any(isinstance(e, SungrowModbusPowerFlowBinarySensor) for e in added)
+
+
+def test_power_flow_bit_math_matches_documented_mask():
+    """Each bit-sensor's is_on reflects the corresponding bit in the raw register (#326)."""
+    from custom_components.sungrow.binary_sensor import SungrowModbusPowerFlowBinarySensor
+    from custom_components.sungrow.modbus_registers import POWER_FLOW_STATUS_BITS
+
+    # Raw with only bit 1 (Battery Charging) and bit 5 (Importing) set.
+    raw = (1 << 1) | (1 << 5)
+    coordinator = _modbus_hybrid_coordinator(power_flow_value=raw)
+
+    sensors = {
+        key: SungrowModbusPowerFlowBinarySensor(coordinator, coordinator.devices[0], bit, key)
+        for bit, key in POWER_FLOW_STATUS_BITS
+    }
+    assert sensors["battery_charging"].is_on is True
+    assert sensors["importing_power"].is_on is True
+    # Every unset bit reads false, not None.
+    assert sensors["pv_generating"].is_on is False
+    assert sensors["battery_discharging"].is_on is False
+    assert sensors["exporting_power"].is_on is False
+
+
+def test_power_flow_binary_sensor_unavailable_when_register_missing():
+    """When power_flow_status drops out of the poll, every bit sensor is unavailable."""
+    from custom_components.sungrow.binary_sensor import SungrowModbusPowerFlowBinarySensor
+    from custom_components.sungrow.modbus_registers import POWER_FLOW_STATUS_BITS
+
+    coordinator = _modbus_hybrid_coordinator(power_flow_value=None)
+    bit, key = POWER_FLOW_STATUS_BITS[0]
+    sensor = SungrowModbusPowerFlowBinarySensor(coordinator, coordinator.devices[0], bit, key)
+    assert sensor.available is False
+    assert sensor.is_on is None
+
+
+def test_power_flow_binary_sensor_device_classes():
+    """Bit-0 uses RUNNING, bit-1 uses BATTERY_CHARGING; the others rely on translation_key."""
+    from custom_components.sungrow.binary_sensor import SungrowModbusPowerFlowBinarySensor
+    from custom_components.sungrow.modbus_registers import POWER_FLOW_STATUS_BITS
+
+    coordinator = _modbus_hybrid_coordinator(power_flow_value=0)
+    per_key = {
+        key: SungrowModbusPowerFlowBinarySensor(coordinator, coordinator.devices[0], bit, key)
+        for bit, key in POWER_FLOW_STATUS_BITS
+    }
+    assert per_key["pv_generating"]._attr_device_class == BinarySensorDeviceClass.RUNNING
+    assert per_key["battery_charging"]._attr_device_class == BinarySensorDeviceClass.BATTERY_CHARGING
+    for key in ("battery_discharging", "exporting_power", "importing_power"):
+        assert getattr(per_key[key], "_attr_device_class", None) is None
+
+
+def test_power_flow_binary_sensor_handles_string_value():
+    """The raw register may arrive as a string (some transports coerce int to str)."""
+    from custom_components.sungrow.binary_sensor import SungrowModbusPowerFlowBinarySensor
+
+    coordinator = _modbus_hybrid_coordinator(power_flow_value="34")  # bit1 + bit5
+    sensor = SungrowModbusPowerFlowBinarySensor(coordinator, coordinator.devices[0], 5, "importing_power")
+    assert sensor.is_on is True
+
+
+def test_decode_power_flow_status_returns_every_key():
+    """The pure helper mirrors the same bit math the entity uses."""
+    from custom_components.sungrow.modbus_registers import (
+        POWER_FLOW_STATUS_BITS,
+        decode_power_flow_status,
+    )
+
+    flags = decode_power_flow_status(0)
+    assert set(flags) == {key for _, key in POWER_FLOW_STATUS_BITS}
+    assert all(value is False for value in flags.values())
+
+    # A raw value with every surfaced bit set.
+    every_bit = sum(1 << bit for bit, _ in POWER_FLOW_STATUS_BITS)
+    all_on = decode_power_flow_status(every_bit)
+    assert all(value is True for value in all_on.values())


### PR DESCRIPTION
Closes #326. Follow-up to #319 and complements #325.

## What

Wire register 13000 (`power_flow_status`) is a u16 bitfield the SH inverter uses to publish live-flow flags. Today it surfaces as a single opaque integer sensor. Automations like *"start EV charging when solar is exporting"* or *"notify when battery starts discharging"* have to work backwards from `battery_power` sign math or write their own template binary sensors.

This PR turns each surfaced bit into its own on/off binary sensor on the inverter device:

| Bit | Entity | Device class |
|---|---|---|
| 0 | PV Generating | `RUNNING` |
| 1 | Battery Charging | `BATTERY_CHARGING` |
| 2 | Battery Discharging | *(translation_key only)* |
| 4 | Exporting to Grid | *(translation_key only)* |
| 5 | Importing from Grid | *(translation_key only)* |

Bits 3/7 (load-power sign duplicates of the signed `load_power` sensor) and bit 6 (reserved) are intentionally not surfaced. Easy to add if demand comes up.

## How

- **`modbus_registers.py`** — `POWER_FLOW_STATUS_BITS: tuple[tuple[int, str], ...]` (single source of truth for bit → translation_key) plus `decode_power_flow_status()` pure helper for the same math.
- **`binary_sensor.py`** — new `SungrowModbusPowerFlowBinarySensor` class, wired into `_build_binary_sensors` for local Modbus coordinators **only when `power_flow_status` is present in the coordinator's data**. That means:
  - Hybrid families (SH-RS / SH-RT) get the five entities.
  - String families (SG-RS / SG-RT) get no bit sensors at all — no stub entities.
  - The dedup-by-unique-id path in `_add_new_entities` handles re-triggers when the coordinator's first successful poll lands.
- **Translations** for every locale (`strings.json` + `en/de/es/fr/cy`). The existing key-parity test enforces this — non-English strings are my best-effort translations; native speakers can PR refinements.

Availability is tied to `power_flow_status` still being reported, so if a poll ever drops the register, the flags go unavailable instead of showing stale `off`.

## Tests

- **Creation:** hybrid coordinator produces `len(POWER_FLOW_STATUS_BITS)` sensors; string coordinator produces zero.
- **Bit math:** raw with only bits 1 + 5 set → `battery_charging.is_on` and `importing_power.is_on` are `True`; the rest are `False` (not `None`).
- **Availability:** raw missing → `available` is `False`, `is_on` is `None`.
- **Coercion:** string raw values (some transports emit `"34"` not `34`) decode correctly.
- **Device classes:** bit-0 gets `RUNNING`, bit-1 gets `BATTERY_CHARGING`, the rest have no device class.
- **Pure helper:** `decode_power_flow_status` returns every documented key.

## Attribution

Bit meanings and initial translation choices transcribed from mkaiser's [SHx Modbus template bit decoders](https://github.com/mkaiser/Sungrow-SHx-Inverter-Modbus-Home-Assistant/blob/main/modbus_sungrow.yaml) (MIT).

## Verification

- `pytest tests/`: 717 passed, 4 deselected (7 new)
- `ruff check` / `ruff format --check`: clean
- `mypy`: no issues found in 27 source files

## Notes for reviewer

- Non-English translations (`de/es/fr/cy`) are my best-effort per key. If any read awkwardly, replacing them is a one-line change in each locale file — the key-parity test guarantees the structure stays honest.
- No coordinator or measure-point catalog changes; this is purely a new set of binary sensors driven by an already-collected register.