### PR TITLE
feat(modbus): add string data_type for firmware/serial identity registers

### DIFF
--- a/custom_components/sungrow/measure_points_data.py
+++ b/custom_components/sungrow/measure_points_data.py
@@ -826,6 +826,12 @@ CODE_ALIASES: dict[str, str] = {
     # instead of the fallback title-cased "Running State Raw" / "Device Type Code".
     "running_state_raw": "Inverter State",
     "device_type_code": "Device Model",
+    # Local Modbus identity strings (#323): pretty labels for the ASCII fields
+    # the inverter/comm-module/battery expose over Modbus.
+    "inverter_serial": "Serial Number",
+    "inverter_firmware_version": "Firmware Version",
+    "communication_module_firmware_version": "Communication Module Firmware",
+    "battery_firmware_version": "Battery Firmware Version",
     # Per-device diagnostic codes whose acronyms/initialisms the generic
     # title-caser would mangle ("Mppt1", "Wlan", "Afci", "Dc", "Id").
     "mppt1_voltage": "MPPT1 Voltage",

--- a/custom_components/sungrow/modbus_registers.py
+++ b/custom_components/sungrow/modbus_registers.py
@@ -241,14 +241,21 @@ class ModbusPoint:
 
     ``address`` is the on-the-wire register address (documented number - 1).
     ``code`` matches the cloud transport's measure-point code so both sources feed
-    the same entity. ``data_type`` is one of ``u16``/``s16``/``u32``/``s32``;
-    32-bit types consume two registers (low word first). The displayed value is the
-    raw register value multiplied by ``scale``.
+    the same entity. ``data_type`` is one of ``u16``/``s16``/``u32``/``s32``/``string``;
+    32-bit types consume two registers (low word first), string types consume
+    ``length`` registers with two ASCII bytes per register (high byte first).
+    The displayed value is the raw register value multiplied by ``scale`` (numeric)
+    or the decoded UTF-8 text (string).
+
+    ``length`` is the width in 16-bit registers for a ``string`` point; ignored for
+    numeric types. Set it to match the documented Sungrow field width (serial
+    number = 10 registers, firmware version = 15 registers).
 
     ``nan_value`` is the raw sentinel that means "not available on this hardware"
     (e.g. 0xFFFF for an MPPT that the inverter does not have). When the raw value
     equals this sentinel the point is omitted, so unsupported registers do not
-    surface as bogus sensors.
+    surface as bogus sensors. For string points, an empty decoded string counts as
+    "not available" too.
 
     ``omit_zero`` drops a raw zero when the firmware reports 0 instead of the NAN
     sentinel for an absent channel (e.g. phase B/C voltage and MPPT3 on SG3.6RS).
@@ -263,10 +270,19 @@ class ModbusPoint:
     unit: str | None = None
     nan_value: int | None = None
     omit_zero: bool = False
+    length: int = 0
 
     @property
     def register_count(self) -> int:
-        """Number of 16-bit registers this point occupies (1 or 2)."""
+        """Number of 16-bit registers this point occupies.
+
+        Numeric types are one register (u16/s16) or two (u32/s32); string types
+        take ``length`` registers packing two ASCII bytes each.
+        """
+        if self.data_type == "string":
+            if self.length <= 0:
+                raise ValueError(f"string point {self.code!r} needs length > 0")
+            return self.length
         return 2 if self.data_type in ("u32", "s32") else 1
 
 
@@ -276,6 +292,10 @@ class ModbusPoint:
 # Register definitions validated against a live SG3.6RS; additional common
 # single/three-phase string points from the mkaiser SHx mapping (see module doc).
 SG_RS_INPUT_POINTS: tuple[ModbusPoint, ...] = (
+    # Sungrow packs the unit's serial in 10 registers of ASCII starting at wire
+    # 4989 (doc 4990). Present on every family we've validated; low-address so
+    # it merges into the first block.
+    ModbusPoint(4989, "inverter_serial", "string", 1, None, length=10),
     ModbusPoint(4999, "device_type_code", "u16", 1, None),
     ModbusPoint(5002, "daily_yield", "u16", 0.1, "kWh"),
     ModbusPoint(5003, "total_yield", "u32", 1, "kWh"),
@@ -303,6 +323,8 @@ SG_RS_INPUT_POINTS: tuple[ModbusPoint, ...] = (
 # Derived from the mkaiser SHx YAML mapping (MIT license) with on-the-wire
 # addresses and low-word-first 32-bit decoding.
 SH_RT_INPUT_POINTS: tuple[ModbusPoint, ...] = (
+    # Serial number — 10 registers of ASCII (see SG-RS map).
+    ModbusPoint(4989, "inverter_serial", "string", 1, None, length=10),
     ModbusPoint(4999, "device_type_code", "u16", 1, None),
     ModbusPoint(5002, "daily_pv_gen_battery_discharge", "u16", 0.1, "kWh"),
     ModbusPoint(5003, "total_pv_gen_battery_discharge", "u32", 0.1, "kWh"),
@@ -375,6 +397,14 @@ SH_RT_INPUT_POINTS: tuple[ModbusPoint, ...] = (
     ModbusPoint(13040, "total_battery_charge", "u32", 0.1, "kWh"),
     ModbusPoint(13044, "daily_exported_energy", "u16", 0.1, "kWh", nan_value=NAN_U16),
     ModbusPoint(13045, "total_exported_energy", "u32", 0.1, "kWh", nan_value=NAN_U16),
+    # Firmware version strings (15 registers each, doc registers 13250 / 13265 /
+    # 13280). Per mkaiser these are supported on SH*T hybrids and MG hybrid
+    # models but not on the SH single-phase RS family; the decoder returns
+    # nothing when the register is empty / zero-padded, so entities go
+    # unavailable rather than showing garbage on unsupported models (#323).
+    ModbusPoint(13249, "inverter_firmware_version", "string", 1, None, length=15),
+    ModbusPoint(13264, "communication_module_firmware_version", "string", 1, None, length=15),
+    ModbusPoint(13279, "battery_firmware_version", "string", 1, None, length=15),
 )
 
 # Register maps keyed by inverter family.
@@ -602,6 +632,19 @@ MODBUS_ENUM_MAPS: dict[str, dict[int, str]] = {
 }
 
 
+# Point codes that identify the inverter / installation rather than measure state.
+# The sensor platform categorises them as Diagnostic so they don't clutter the
+# main dashboard (#323).
+LOCAL_IDENTITY_CODES: frozenset[str] = frozenset(
+    {
+        "inverter_serial",
+        "inverter_firmware_version",
+        "communication_module_firmware_version",
+        "battery_firmware_version",
+    }
+)
+
+
 # ---------------------------------------------------------------------------
 # power_flow_status bitfield decode (#326)
 # ---------------------------------------------------------------------------
@@ -651,6 +694,19 @@ def decode_registers(
         offset = point.address - block_start
         if offset < 0 or offset + point.register_count > len(registers):
             continue
+        if point.data_type == "string":
+            text = _decode_string(registers, offset, point.length)
+            # Empty / all-NUL strings mean the register isn't populated on this
+            # firmware — surface nothing rather than an empty diagnostic sensor.
+            if not text:
+                continue
+            out[point.code] = {
+                "code": point.code,
+                "value": text,
+                "unit": None,
+                "source": "modbus",
+            }
+            continue
         raw = _combine(registers, offset, point.data_type)
         if point.nan_value is not None and raw == point.nan_value:
             continue
@@ -676,6 +732,25 @@ def _combine(registers: list[int], offset: int, data_type: str) -> int:
     if data_type in ("s16", "s32") and value >= (1 << (bits - 1)):
         value -= 1 << bits
     return value
+
+
+def _decode_string(registers: list[int], offset: int, length: int) -> str:
+    """Decode ``length`` consecutive registers as a big-endian ASCII string.
+
+    Sungrow packs two ASCII bytes per register with the high byte first
+    (register 0x5341 -> "SA"). Trailing NUL padding is stripped, and any embedded
+    control chars are dropped so a partially-populated field returns clean text.
+    Undecodable bytes are silently ignored — support snapshots need firmware/serial
+    values to *round-trip* even when a byte is corrupted by an intermediate proxy.
+    """
+    raw = bytearray()
+    for i in range(length):
+        reg = registers[offset + i] & 0xFFFF
+        raw.append((reg >> 8) & 0xFF)
+        raw.append(reg & 0xFF)
+    text = raw.decode("ascii", errors="ignore").rstrip("\x00").strip()
+    # Strip any remaining control chars (some firmware zero-pads mid-string).
+    return "".join(ch for ch in text if ch.isprintable() or ch.isspace()).strip()
 
 
 def block_bounds(points: tuple[ModbusPoint, ...]) -> tuple[int, int]:

--- a/custom_components/sungrow/sensor.py
+++ b/custom_components/sungrow/sensor.py
@@ -31,6 +31,7 @@ from .measure_points import (
     resolve_enum_value,
     resolve_name,
 )
+from .modbus_registers import LOCAL_IDENTITY_CODES
 
 # Sensors are read-only and updated in bulk by the coordinator, so no per-entity
 # write parallelism limit is needed.
@@ -45,6 +46,7 @@ _DIAGNOSTIC_CODES = (
     | frozenset(ESS_MPPT_DIAGNOSTIC_POINTS.values())
     | BATTERY_DIAGNOSTIC_CODES
     | frozenset(COMM_MODULE_POINTS.values())
+    | LOCAL_IDENTITY_CODES
 )
 
 # Sentinel unit: tariff sensors take their unit from the plant's currency at runtime.
@@ -355,8 +357,10 @@ class SungrowSensor(CoordinatorEntity, SensorEntity):
         if point_code in _INTEGER_COUNT_CODES:
             self._attr_suggested_display_precision = 0
 
-        # Local Modbus device-type register is useful for map selection, not the main UI.
-        if point_code == "device_type_code":
+        # Local Modbus device-type register + identity strings (serial number,
+        # firmware versions) are useful for triage, not the main UI. Keep them
+        # under the device page's Diagnostic section.
+        if point_code == "device_type_code" or point_code in LOCAL_IDENTITY_CODES:
             self._attr_entity_category = EntityCategory.DIAGNOSTIC
 
     def _current_point(self) -> dict[str, Any] | None:

--- a/tests/test_modbus.py
+++ b/tests/test_modbus.py
@@ -64,6 +64,117 @@ def test_decode_omits_nan_sentinel_values():
     assert "absent" not in out
 
 
+# ---------------------------------------------------------------------------
+# String data_type support (#323)
+# ---------------------------------------------------------------------------
+# Sungrow packs ASCII fields (serial number, firmware version) in consecutive
+# registers with two bytes per register, high byte first. The decoder must
+# reconstruct the string, strip trailing NUL padding, and treat a fully empty
+# field as "not populated" so unsupported firmwares don't produce empty sensors.
+
+
+def test_string_point_register_count_uses_length():
+    """A string ModbusPoint spans ``length`` registers, not the numeric-type fallback."""
+    point = ModbusPoint(4989, "inverter_serial", "string", 1, None, length=10)
+    assert point.register_count == 10
+
+
+def test_string_point_rejects_zero_length():
+    """A string with no declared length is a configuration error, not silent success."""
+    point = ModbusPoint(4989, "bad", "string", 1, None)  # length defaults to 0
+    with pytest.raises(ValueError, match="length"):
+        _ = point.register_count
+
+
+def test_decode_string_reads_big_endian_ascii():
+    """Two ASCII bytes per register, high byte first — the mkaiser/Sungrow convention."""
+    point = ModbusPoint(0, "inverter_serial", "string", 1, None, length=5)
+    # 'A'=0x41, 'B'=0x42, ...
+    registers = [0x4142, 0x4344, 0x4546, 0x4748, 0x494A]
+    out = decode_registers((point,), 0, registers)
+    assert out["inverter_serial"]["value"] == "ABCDEFGHIJ"
+    # Strings are unitless and still tagged source=modbus.
+    assert out["inverter_serial"]["unit"] is None
+    assert out["inverter_serial"]["source"] == "modbus"
+
+
+def test_decode_string_strips_trailing_nul_padding():
+    """Sungrow pads short serials with NUL — never leak them into HA."""
+    point = ModbusPoint(0, "inverter_serial", "string", 1, None, length=4)
+    # "A12" + trailing NULs across two registers.
+    registers = [0x4131, 0x3200, 0x0000, 0x0000]  # "A", "1", "2", NUL...
+    out = decode_registers((point,), 0, registers)
+    assert out["inverter_serial"]["value"] == "A12"
+
+
+def test_decode_string_omitted_when_all_nul():
+    """A fully NUL / empty field means the firmware doesn't expose the point."""
+    point = ModbusPoint(0, "battery_firmware_version", "string", 1, None, length=4)
+    registers = [0x0000] * 4
+    out = decode_registers((point,), 0, registers)
+    assert "battery_firmware_version" not in out
+
+
+def test_decode_string_strips_non_printable_control_bytes():
+    """Some firmwares leak zero-padding mid-string; those bytes get dropped cleanly."""
+    point = ModbusPoint(0, "inverter_firmware_version", "string", 1, None, length=3)
+    # "V1" + NUL + more real chars + NUL, imitating a corrupted mid-string zero.
+    registers = [0x5631, 0x0056, 0x3200]  # 'V','1',NUL,'V','2',NUL
+    out = decode_registers((point,), 0, registers)
+    # Interior NULs are stripped; the printable characters remain.
+    assert out["inverter_firmware_version"]["value"] == "V1V2"
+
+
+def test_decode_string_survives_undecodable_bytes():
+    """Non-ASCII bytes are silently dropped (support snapshots must still round-trip)."""
+    point = ModbusPoint(0, "inverter_serial", "string", 1, None, length=3)
+    # 0xFF is not valid ASCII; the decoder should ignore it, not raise.
+    registers = [0x4142, 0xFFFF, 0x4344]  # "AB", <invalid>, "CD"
+    out = decode_registers((point,), 0, registers)
+    assert out["inverter_serial"]["value"] == "ABCD"
+
+
+def test_decode_string_and_numeric_share_a_block():
+    """A string point and neighbouring numeric points decode together in one block."""
+    points = (
+        ModbusPoint(0, "inverter_serial", "string", 1, None, length=3),
+        ModbusPoint(4, "device_type_code", "u16", 1, None),
+    )
+    registers = [0x5347, 0x2D33, 0x2E36, 0, 3355]  # "SG-3.6" + padding + 3355
+    out = decode_registers(points, 0, registers)
+    assert out["inverter_serial"]["value"] == "SG-3.6"
+    assert out["device_type_code"]["value"] == 3355
+
+
+def test_block_partitions_counts_string_length_for_cap():
+    """A 15-register string is charged 15 registers against the 125-cap accounting."""
+    points = (
+        ModbusPoint(1000, "big_string", "string", 1, None, length=15),
+        ModbusPoint(1020, "neighbour", "u16", 1),
+    )
+    # With a 10-register cap the string alone exceeds the cap — verify the
+    # partitioner then breaks between the two points rather than merging.
+    blocks = block_partitions(points, max_block_size=10)
+    assert all(count <= 15 for _, count in blocks), blocks  # cap is clamped up to point size
+    # Two distinct blocks because the neighbour doesn't fit in the same read.
+    assert len(blocks) == 2
+    # But it MUST fit in the standard 100-register cap.
+    blocks_default = block_partitions(points)
+    assert len(blocks_default) == 1
+    assert blocks_default[0][1] == 21  # 15 (string) + 5 (gap) + 1 (u16)
+
+
+def test_block_bounds_includes_full_string_span():
+    """block_bounds reports the trailing register of a string point too."""
+    points = (
+        ModbusPoint(4989, "inverter_serial", "string", 1, None, length=10),
+        ModbusPoint(5030, "total_active_power", "s32", 1, "W"),
+    )
+    start, count = block_bounds(points)
+    assert start == 4989
+    assert start + count == 5032  # s32 ends at 5030+2
+
+
 def test_block_bounds_covers_all_points_in_one_read():
     """block_bounds spans from the lowest address to past the highest (incl. 32-bit width)."""
     points = (
@@ -103,15 +214,19 @@ def test_sh_rt_map_partitions_stay_under_modbus_count_cap():
 
     Before this fix, points 4999..5241 collapsed into a single 243-register block
     that pymodbus refuses to send (spec cap = 125). Every block must now fit and
-    the low PV/mppt/AC section must still start at register 4999.
+    the map must still cover the full register range from the serial-number
+    block up past the high hybrid registers.
     """
     blocks = block_partitions(SH_RT_INPUT_POINTS)
     # Every read must be within the Modbus function-4 protocol limit.
     assert blocks, "expected at least one block"
     assert all(count <= 125 for _, count in blocks), blocks
-    # Low PV/AC block still starts at the device-type register.
-    assert blocks[0][0] == 4999
+    # First block starts at or before the device-type register 4999 (the serial
+    # at 4989 pulls the block start down when local identity strings are mapped).
+    assert blocks[0][0] <= 4999
     # Full range still covered: last block must reach the high hybrid registers.
+    # 13279 + 15 = 13294 for the battery firmware string, or 13047 for the last
+    # numeric point on models that don't expose the firmware strings.
     assert max(start + count for start, count in blocks) >= 13046
 
 


### PR DESCRIPTION
Closes #323. Follow-up to #319 / #325 / #328.

## What

Sungrow packs the inverter serial and per-subsystem firmware versions in ASCII across 10 or 15 consecutive Modbus registers. Our `ModbusPoint` only supported `u16 / s16 / u32 / s32`, so those identity fields were completely unreachable over local Modbus.

This PR adds `"string"` as a first-class data type and wires four identity/firmware fields into the maps:

| Wire addr | Registers | Code | Map |
|---|---|---|---|
| 4989 | 10 | `inverter_serial` | SG-RS + SH-RT (present on every family) |
| 13249 | 15 | `inverter_firmware_version` | SH-RT only |
| 13264 | 15 | `communication_module_firmware_version` | SH-RT only |
| 13279 | 15 | `battery_firmware_version` | SH-RT only |

The last three are hybrid-only per mkaiser — SH single-phase RS and MG5-6RL don't expose them. Empty/NUL fields are omitted, so unsupported inverters see no entity rather than "unknown".

## Infrastructure changes

- `ModbusPoint` grows a `length` field (register width for strings) and raises `ValueError` on `length=0` at `register_count` time — a construction bug, not a silent decode failure.
- `_decode_string` packs **two ASCII bytes per register, high byte first** (mkaiser/Sungrow convention). Strips trailing NUL padding + interior non-printable control bytes; silently ignores undecodable bytes so support snapshots round-trip even through a proxy that mangles a byte.
- `decode_registers` branches on `data_type` — strings go through the new decoder, numerics stay on the existing `_combine` path unchanged.
- `block_partitions` accounting already went through `register_count`, so a 15-register string correctly charges 15 registers against the 125-per-read cap. Verified with a targeted test that a string wider than a caller-supplied cap forces a split.

## Sensor plumbing

- New `LOCAL_IDENTITY_CODES` frozenset exported from `modbus_registers`.
- `sensor.py`:
  - Unions `LOCAL_IDENTITY_CODES` into `_DIAGNOSTIC_CODES`.
  - Adds the codes to the plant-level `EntityCategory.DIAGNOSTIC` branch alongside `device_type_code`.
- `CODE_ALIASES` gets friendly labels (Serial Number / Firmware Version / Communication Module Firmware / Battery Firmware Version).
- No sensor-value changes needed — the existing "no device_class + no state_class → `str(val)`" path handles strings correctly.

## Real-world block partitioning

After this PR, the SH-RT map produces **7 reads**, the SG-RS map **1 read**, every one under 125 registers:

```
SH-RT: [(4989, 47), (5114, 2), (5213, 29), (5600, 39), (5722, 24), (12999, 48), (13249, 45)]
SG-RS: [(4989, 47)]
```

## Tests

- **register_count** uses `length` for strings; **raises `ValueError`** on `length=0`.
- **Big-endian ASCII round-trip** — high byte first, two bytes per register.
- **Trailing NUL padding stripped** from short serials.
- **All-NUL field is omitted** — the register isn't populated, so no entity.
- **Non-printable control bytes stripped mid-string.**
- **Undecodable bytes** silently ignored (support snapshots must round-trip).
- **Mixed string + numeric** points decode together from one block.
- **`block_partitions`** charges string length against the 125 cap and splits when a string alone exceeds a caller cap; `block_bounds` includes the trailing register of a string.
- Existing SH-RT partition test updated: `blocks[0][0] <= 4999` now (the serial at 4989 pulls the first block start down).

## Not in this PR

- **Property-based coverage for strings.** The Hypothesis strategy in `test_modbus_properties.py` deliberately keeps its `data_type` set to `("u16", "s16", "u32", "s32")`. Adding a strings variant needs a companion length generator; worth a follow-up if hypothesis coverage on strings becomes valuable.
- **`device_info` wiring.** The serial is now decoded but not yet promoted to the HA device registry's `serial_number` field. That's a coordinator/device_helpers change — separate follow-up.

## Attribution

Register addresses, widths, and the two-bytes-per-register ASCII convention transcribed from mkaiser's [SHx Modbus YAML](https://github.com/mkaiser/Sungrow-SHx-Inverter-Modbus-Home-Assistant/blob/main/modbus_sungrow.yaml) (MIT).

## Verification

- `pytest tests/`: 727 passed, 4 deselected (10 new)
- `ruff check` / `ruff format --check`: clean
- `mypy`: no issues found in 27 source files
- Local `python -c` sanity check on real-world block partitions: SG-RS = 1 read, SH-RT = 7 reads, all ≤ 125 registers.