### PR TITLE
feat(modbus): expand device_type_code coverage to full SG-RS/SG-RT/MG lineup

### DIFF
--- a/custom_components/sungrow/modbus_registers.py
+++ b/custom_components/sungrow/modbus_registers.py
@@ -290,8 +290,28 @@ REGISTER_MAPS: dict[str, tuple[ModbusPoint, ...]] = {
 # SH codes from the mkaiser SHx YAML (MIT) device-type map; SG-RS validated live.
 # Unknown codes fall back to the configured model string / model_capabilities.
 DEVICE_TYPE_CODE_TO_FAMILY: dict[int, str] = {
-    # SG-RS string inverters (single-phase, e.g. SG3.6RS)
-    9732: "sg_rs",  # 0x2604
+    # SG-RS single-phase string inverters (0x2603..0x2609). Codes for the full
+    # SG-RS residential lineup cross-referenced against Sungrow datasheets in
+    # the TCzerny/ha-modbus-manager templates (#330).
+    9731: "sg_rs",  # SG3.0RS (0x2603)
+    9732: "sg_rs",  # SG3.6RS (0x2604) — validated live
+    9733: "sg_rs",  # SG4.0RS (0x2605)
+    9734: "sg_rs",  # SG5.0RS (0x2606)
+    9735: "sg_rs",  # SG6.0RS (0x2607)
+    9736: "sg_rs",  # SG8.0RS (0x2608)
+    9737: "sg_rs",  # SG10RS  (0x2609)
+    # SG-RT three-phase string inverters (0x2430..0x243E). Reuse the sg_rt map
+    # which shares the SG-RS low-block layout (#219).
+    9264: "sg_rt",  # SG5.0RT  (0x2430)
+    9265: "sg_rt",  # SG6.0RT  (0x2431)
+    9266: "sg_rt",  # SG8.0RT  (0x2432)
+    9267: "sg_rt",  # SG10RT   (0x2433)
+    9268: "sg_rt",  # SG12RT   (0x2434)
+    9269: "sg_rt",  # SG15RT   (0x2435)
+    9271: "sg_rt",  # SG20RT   (0x2437)
+    9276: "sg_rt",  # SG7.0RT  (0x243C)
+    9277: "sg_rt",  # SG3.0RT  (0x243D)
+    9278: "sg_rt",  # SG4.0RT  (0x243E)
     # SH single-phase hybrid (0x0Dxx) — mkaiser device-type map
     3331: "sh_rs",  # SH5K-V13 (0x0D03)
     3334: "sh_rs",  # SH3K6 (0x0D06)
@@ -309,6 +329,8 @@ DEVICE_TYPE_CODE_TO_FAMILY: dict[int, str] = {
     3355: "sh_rs",  # SH10RS (0x0D1B)
     3367: "sh_rs",  # MG5RL (0x0D27)
     3368: "sh_rs",  # MG6RL (0x0D28)
+    3369: "sh_rs",  # MG8RL (0x0D29)
+    3370: "sh_rs",  # MG10RL (0x0D2A)
     # SH three-phase hybrid (0x0Exx)
     3584: "sh_rt",  # SH5.0RT (0x0E00)
     3585: "sh_rt",  # SH6.0RT (0x0E01)
@@ -397,15 +419,31 @@ RUNNING_STATE_NAMES: dict[int, str] = {
 }
 
 # Device model name (wire register 4999, ``device_type_code``).
-# SH codes from the mkaiser SHx YAML ``sg_device_type`` template map (MIT).
-# The SG string code 9732 (0x2604) is shared across the SG-RS single-phase family
-# (SG3.0RS / SG3.6RS / SG5.0RS all report the same code in field reports); use
-# the generic family name so the sensor's option list doesn't imply a specific
-# wattage that can't be verified from Modbus alone.
+# SH codes from mkaiser's SHx YAML ``sg_device_type`` template map; SG-RS and
+# SG-RT codes and specific model names cross-referenced against the Sungrow
+# datasheets cited inline in TCzerny/ha-modbus-manager's SG dynamic template
+# (#330). Each SG-RS variant reports a distinct code — the previous
+# family-generic name for 9732 was wrong.
 DEVICE_MODEL_NAMES: dict[int, str] = {
-    # SG string inverters — Sungrow does not distinguish specific SG-RS variants
-    # in this register, so the option is family-generic.
-    9732: "SG-RS string inverter",  # 0x2604
+    # SG-RS single-phase string inverters (0x2603..0x2609)
+    9731: "SG3.0RS",
+    9732: "SG3.6RS",
+    9733: "SG4.0RS",
+    9734: "SG5.0RS",
+    9735: "SG6.0RS",
+    9736: "SG8.0RS",
+    9737: "SG10RS",
+    # SG-RT three-phase string inverters (0x2430..0x243E)
+    9264: "SG5.0RT",
+    9265: "SG6.0RT",
+    9266: "SG8.0RT",
+    9267: "SG10RT",
+    9268: "SG12RT",
+    9269: "SG15RT",
+    9271: "SG20RT",
+    9276: "SG7.0RT",
+    9277: "SG3.0RT",
+    9278: "SG4.0RT",
     # SH single-phase hybrid (0x0Dxx)
     3331: "SH5K-V13",
     3334: "SH3K6",
@@ -423,6 +461,8 @@ DEVICE_MODEL_NAMES: dict[int, str] = {
     3355: "SH10RS",
     3367: "MG5RL",
     3368: "MG6RL",
+    3369: "MG8RL",
+    3370: "MG10RL",
     # SH three-phase hybrid (0x0Exx)
     3584: "SH5.0RT",
     3585: "SH6.0RT",

--- a/tests/test_measure_points.py
+++ b/tests/test_measure_points.py
@@ -126,7 +126,10 @@ def test_device_type_code_enum_maps_known_models():
     """Device-type codes resolve to model-family display names."""
     assert mp.resolve_enum_value("device_type_code", 3355) == "SH10RS"
     assert mp.resolve_enum_value("device_type_code", 3603) == "SH10RT-20"
-    assert mp.resolve_enum_value("device_type_code", 9732) == "SG-RS string inverter"
+    assert mp.resolve_enum_value("device_type_code", 9732) == "SG3.6RS"
+    assert mp.resolve_enum_value("device_type_code", 9737) == "SG10RS"
+    assert mp.resolve_enum_value("device_type_code", 9267) == "SG10RT"
+    assert mp.resolve_enum_value("device_type_code", 3370) == "MG10RL"
 
 
 def test_device_type_code_enum_returns_none_for_unknown_code():

--- a/tests/test_modbus.py
+++ b/tests/test_modbus.py
@@ -253,7 +253,16 @@ def test_family_for_device_type_code_maps_known_codes():
     # Spot-check SH hybrids from the mkaiser device-type map (#219).
     assert family_for_device_type_code(0x0E03) == "sh_rt"  # SH10RT
     assert family_for_device_type_code(0x0D0F) == "sh_rs"  # SH5.0RS
-    assert family_for_device_type_code(9732) == "sg_rs"
+    # SG family — every documented SG-RS / SG-RT variant now resolves (#330).
+    assert family_for_device_type_code(0x2603) == "sg_rs"  # SG3.0RS
+    assert family_for_device_type_code(0x2604) == "sg_rs"  # SG3.6RS
+    assert family_for_device_type_code(0x2609) == "sg_rs"  # SG10RS
+    assert family_for_device_type_code(0x2430) == "sg_rt"  # SG5.0RT
+    assert family_for_device_type_code(0x2433) == "sg_rt"  # SG10RT
+    assert family_for_device_type_code(0x2437) == "sg_rt"  # SG20RT
+    # MG hybrids fill out the small-hybrid family (#330).
+    assert family_for_device_type_code(0x0D29) == "sh_rs"  # MG8RL
+    assert family_for_device_type_code(0x0D2A) == "sh_rs"  # MG10RL
 
 
 def test_family_for_device_type_code_returns_none_for_unknown():


### PR DESCRIPTION
Closes #330.

## What

`DEVICE_TYPE_CODE_TO_FAMILY` only recognised `9732` (SG3.6RS). Every other SG string inverter fell through to model-string fallback and showed `Unknown device code: 0xNNNN` on the Device Model enum sensor from #325.

Cross-referencing Sungrow datasheets (via TCzerny/ha-modbus-manager's templates, MIT), added:

**SG-RS** (single-phase, `0x2603–0x2609`): `SG3.0RS`, `SG3.6RS`, `SG4.0RS`, `SG5.0RS`, `SG6.0RS`, `SG8.0RS`, `SG10RS`

**SG-RT** (three-phase, `0x2430–0x243E`): `SG3.0RT`, `SG4.0RT`, `SG5.0RT`, `SG6.0RT`, `SG7.0RT`, `SG8.0RT`, `SG10RT`, `SG12RT`, `SG15RT`, `SG20RT`

**MG hybrid**: `MG8RL` (`0x0D29`) and `MG10RL` (`0x0D2A`)

Also renamed the display name for `9732` from `"SG-RS string inverter"` (added in #325 with the assumption the code was family-generic) to the specific `"SG3.6RS"` — TCzerny's datasheet cross-refs show each SG-RS variant reports a distinct code, so the generic label was inaccurate.

## Impact

- Every SG-RS / SG-RT variant now auto-resolves to the correct register map without depending on a manually-set model string.
- The Device Model diagnostic sensor shows the real model instead of `Unknown device code: 0xNNNN`.
- **No breaking change**: #325 hasn't shipped in a release yet (v5.6.1 is pre-#325), so no user has seen the previous `"SG-RS string inverter"` label.

## Tests

- `test_every_device_type_family_code_has_a_display_name` invariant already enforces that every new family-mapped code has a matching display name — CI provably catches any future gap.
- New spot-checks for `family_for_device_type_code` covering the SG-RS / SG-RT / MG additions.
- Updated `test_device_type_code_enum_maps_known_models` to expect `"SG3.6RS"` for `9732` and adds parametric asserts for `SG10RS`, `SG10RT`, `MG10RL`.

## Live-verified

Ran the probe script against a real SG3.6RS + WiNet-S over SSH tunnel:

```
✓ Family: 'sg_rs'
✓ device_type_code raw: 9732
  ↳ model name (via enum decoder): 'SG3.6RS'
```

## Attribution

Codes and model names transcribed from [TCzerny/ha-modbus-manager](https://github.com/TCzerny/ha-modbus-manager) Sungrow templates (MIT), which cross-reference the Sungrow protocol datasheets cited inline.

## Verification

- `pytest tests/`: 724 passed, 4 deselected
- `ruff check` / `ruff format --check`: clean
- `mypy`: no issues in 27 source files
- Live probe against real hardware ✅