### PR TITLE
feat(modbus): SH hybrid local holding-register control (battery / EMS / export)

### DIFF
--- a/custom_components/sungrow/__init__.py
+++ b/custom_components/sungrow/__init__.py
@@ -281,9 +281,6 @@ async def _async_setup_modbus_only(hass: HomeAssistant, entry: SungrowConfigEntr
     coordinator = SungrowPlantCoordinator(hass, entry, None, serial, local_name, [inverter])
     coordinator.via_plant_id = via_plant_id
     coordinator.local_configuration_url = winet_url
-    # Local entries never expose battery EMS controls until hybrid holding maps ship (#220).
-    # Hiding battery_only entities avoids charge/discharge footguns on PV-only string units.
-    coordinator.has_battery = False
     try:
         await coordinator.async_config_entry_first_refresh()
     except Exception:
@@ -291,6 +288,16 @@ async def _async_setup_modbus_only(hass: HomeAssistant, entry: SungrowConfigEntr
         # exhaust the dongle's single-connection slot and reload never recovers.
         coordinator.close_modbus()
         raise
+    # Derive whether battery-gated dispatch controls should surface from the family
+    # resolved by first_refresh's device-type detection (falling back to the config's
+    # model code). Only SH hybrids have batteries — SG string inverters must stay
+    # gated off to avoid the charge/discharge footguns on PV-only units (#148, #331).
+    from .model_capabilities import resolve_capabilities
+
+    modbus_client = getattr(coordinator, "_modbus_client", None)
+    resolved_model_code = getattr(modbus_client, "model", None) or model
+    caps = resolve_capabilities(resolved_model_code)
+    coordinator.has_battery = bool(caps.has_battery)
 
     control: DispatchControl | None = None
     modbus_client = getattr(coordinator, "_modbus_client", None)

--- a/custom_components/sungrow/modbus_registers.py
+++ b/custom_components/sungrow/modbus_registers.py
@@ -88,14 +88,15 @@ SH_EMS_MODE = HoldingProbePoint(
     write_candidate=False,
 )
 
-# Absolute no-write list for the spike and production SG-RS control.
+# Absolute no-write list. Writing these registers can disconnect the inverter
+# from the grid (start/stop) or hijack the external-EMS heartbeat owned by
+# ``heartbeat.py``, so they are guarded regardless of family. The hybrid EMS /
+# charge-discharge block (13049/13050/13051) is *supported* for controlled
+# writes via ``HOLDING_CONTROL_MAPS`` — see #331 — so it is NOT denylisted.
 HOLDING_WRITE_DENYLIST_WIRE: frozenset[int] = frozenset(
     {
-        5005,  # start/stop (0xCF/0xCE)
-        13049,  # EMS mode
-        13050,  # charge/discharge command
-        13051,  # charge/discharge power
-        13079,  # external EMS heartbeat
+        5005,  # start/stop (0xCF boot / 0xCE shutdown) — never write from dispatch
+        13079,  # external EMS heartbeat — owned by heartbeat.py, not the dispatch entities
     }
 )
 
@@ -126,6 +127,106 @@ HOLDING_CONTROL_MAPS: dict[str, tuple[HoldingControlPoint, ...]] = {
     # Three-phase string maps share the low holding block on community maps.
     "sg_rt": SG_RS_HOLDING_CONTROL_POINTS,
 }
+
+
+# ---------------------------------------------------------------------------
+# SH hybrid holding controls (#331)
+# ---------------------------------------------------------------------------
+# Wire addresses transcribed from TCzerny/ha-modbus-manager's ``sungrow_shx_dynamic.yaml``
+# (MIT), which is itself based on the mkaiser SHx project + Sungrow protocol V1.1.11.
+# TCzerny's field notes confirm the RS/RT split on active-power-limit registers:
+# 13088/13089 work on SH-RT hybrids but are non-functional on SH-RS, which use
+# 31203/31204 instead. Everything else (EMS, forced charge/discharge, SoC limits,
+# export limit, backup mode) shares the 13049..13086 block across both hybrid
+# sub-families.
+#
+# ``param`` matches the canonical name in ``pysolarcloud.Control.PARAMETER_SPECS``
+# so ``Control.encode_parameter`` gives us bounds enforcement and enum→raw
+# encoding for free — no wire-value math lives here.
+
+SH_HYBRID_HOLDING_COMMON: tuple[HoldingControlPoint, ...] = (
+    HoldingControlPoint(
+        param="energy_management_mode",
+        wire_address=13049,
+        description="Hybrid EMS mode (0 self-consumption, 2 compulsory, 3 external EMS, 4 VPP)",
+        param_code="10003",
+    ),
+    HoldingControlPoint(
+        param="charge_discharge_command",
+        wire_address=13050,
+        description="Battery forced-charge/discharge command (0xAA charge / 0xBB discharge / 0xCC stop)",
+        param_code="10004",
+    ),
+    HoldingControlPoint(
+        param="charge_discharge_power",
+        wire_address=13051,
+        description="Battery forced charge/discharge power (W)",
+        param_code="10005",
+    ),
+    HoldingControlPoint(
+        param="soc_upper_limit",
+        wire_address=13057,
+        description="Battery max SoC (0.1 %; 700-1000 = 70-100 %)",
+        param_code="10001",
+    ),
+    HoldingControlPoint(
+        param="soc_lower_limit",
+        wire_address=13058,
+        description="Battery min SoC (0.1 %; 0-500 = 0-50 %)",
+        param_code="10002",
+    ),
+    HoldingControlPoint(
+        param="feed_in_limitation_value",
+        wire_address=13073,
+        description="Export power limit (W); only in effect when feed_in_limitation is enabled",
+        param_code="10013",
+    ),
+    HoldingControlPoint(
+        param="feed_in_limitation",
+        wire_address=13086,
+        description="Export power limit switch (0xAA enable / 0x55 disable)",
+        param_code="10012",
+    ),
+)
+
+# SH-RT three-phase hybrids use 13088/13089 for the active-power-limit block.
+SH_RT_HOLDING_CONTROL_POINTS: tuple[HoldingControlPoint, ...] = (
+    *SH_HYBRID_HOLDING_COMMON,
+    HoldingControlPoint(
+        param="limited_power_switch",
+        wire_address=13088,
+        description="Active power limitation switch (0xAA enable / 0x55 disable) — SH-RT hybrids",
+        param_code="10007",
+    ),
+    HoldingControlPoint(
+        param="active_power_limit_ratio",
+        wire_address=13089,
+        description="Active power limit ratio (0.1 %; 1000 = 100 %) — SH-RT hybrids",
+        param_code="10008",
+    ),
+)
+
+# SH-RS single-phase hybrids: the same param names map to a different wire block
+# (31203/31204). TCzerny confirms the SH-RS models return exception_code=2 for
+# 13088/13089, so the split lives at the family level, not the entity level.
+SH_RS_HOLDING_CONTROL_POINTS: tuple[HoldingControlPoint, ...] = (
+    *SH_HYBRID_HOLDING_COMMON,
+    HoldingControlPoint(
+        param="limited_power_switch",
+        wire_address=31203,
+        description="Active power limitation switch (0xAA enable / 0x55 disable) — SH-RS hybrids",
+        param_code="10007",
+    ),
+    HoldingControlPoint(
+        param="active_power_limit_ratio",
+        wire_address=31204,
+        description="Active power limit ratio (0.1 %; 1000 = 100 %) — SH-RS hybrids",
+        param_code="10008",
+    ),
+)
+
+HOLDING_CONTROL_MAPS["sh_rt"] = SH_RT_HOLDING_CONTROL_POINTS
+HOLDING_CONTROL_MAPS["sh_rs"] = SH_RS_HOLDING_CONTROL_POINTS
 
 # Sentinel values a register can return when the point is not supported by the
 # attached hardware/firmware.

--- a/tests/test_modbus_control.py
+++ b/tests/test_modbus_control.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock, MagicMock, call
 
 import pytest
 
@@ -80,3 +80,122 @@ async def test_empty_family_has_no_support():
     control = ModbusControl(client, family="unknown_family")
     assert control.supported_parameters == frozenset()
     assert await control.async_check_update_support("x") is False
+
+
+# ---------------------------------------------------------------------------
+# SH hybrid holding maps (#331)
+# ---------------------------------------------------------------------------
+# The SH hybrid families expose battery/EMS/export controls through the
+# 13049..13086 holding block. SH-RT and SH-RS diverge on the active-power-limit
+# addresses (13088/13089 vs 31203/31204 respectively) per TCzerny's field notes.
+
+
+_SH_HYBRID_PARAMS = {
+    "energy_management_mode",
+    "charge_discharge_command",
+    "charge_discharge_power",
+    "soc_upper_limit",
+    "soc_lower_limit",
+    "feed_in_limitation_value",
+    "feed_in_limitation",
+    "limited_power_switch",
+    "active_power_limit_ratio",
+}
+
+
+@pytest.mark.parametrize("family", ["sh_rt", "sh_rs"])
+async def test_sh_hybrid_supported_parameters_cover_ems_battery_export(family: str):
+    """Both SH hybrid sub-families expose the full battery/EMS/export control set."""
+    control = ModbusControl(_client(family=family), family=family)
+    assert control.supported_parameters >= _SH_HYBRID_PARAMS
+    # The SG-only string-inverter probe points aren't in the SH maps.
+    assert "active_power_limit_ratio" in control.supported_parameters
+
+
+async def test_sh_rt_writes_ems_and_charge_discharge_to_hybrid_block():
+    """`energy_management_mode` and forced-charge/discharge hit the 13049-13051 wires."""
+    client = _client(family="sh_rt")
+    client.async_read_holding = AsyncMock(side_effect=[[2], [170], [3000]])
+    control = ModbusControl(client, family="sh_rt")
+    await control.async_update_parameters(
+        "sn_inv",
+        {"energy_management_mode": "2", "charge_discharge_command": "170", "charge_discharge_power": "3000"},
+    )
+    assert client.async_write_holding.await_args_list == [
+        call(13049, 2),
+        call(13050, 170),
+        call(13051, 3000),
+    ]
+
+
+async def test_sh_rt_active_power_limit_hits_13088_13089():
+    """SH-RT uses the 13088/13089 active-power-limit block (per mkaiser/TCzerny)."""
+    client = _client(family="sh_rt")
+    client.async_read_holding = AsyncMock(side_effect=[[170], [1000]])
+    control = ModbusControl(client, family="sh_rt")
+    await control.async_update_parameters(
+        "sn_inv",
+        {"limited_power_switch": "170", "active_power_limit_ratio": "1000"},
+    )
+    assert client.async_write_holding.await_args_list == [
+        call(13088, 170),
+        call(13089, 1000),
+    ]
+
+
+async def test_sh_rs_active_power_limit_hits_31203_31204_split():
+    """SH-RS uses the 31203/31204 split — TCzerny confirmed 13088/13089 non-functional there."""
+    client = _client(family="sh_rs")
+    client.async_read_holding = AsyncMock(side_effect=[[170], [1000]])
+    control = ModbusControl(client, family="sh_rs")
+    await control.async_update_parameters(
+        "sn_inv",
+        {"limited_power_switch": "170", "active_power_limit_ratio": "1000"},
+    )
+    assert client.async_write_holding.await_args_list == [
+        call(31203, 170),
+        call(31204, 1000),
+    ]
+
+
+async def test_sh_hybrid_shares_common_soc_and_export_wires():
+    """SoC and export-limit registers are the same for SH-RT and SH-RS."""
+    for family in ("sh_rt", "sh_rs"):
+        client = _client(family=family)
+        client.async_read_holding = AsyncMock(side_effect=[[900], [200]])
+        control = ModbusControl(client, family=family)
+        await control.async_update_parameters(
+            "sn_inv",
+            {"soc_upper_limit": "900", "soc_lower_limit": "200"},
+        )
+        assert client.async_write_holding.await_args_list == [
+            call(13057, 900),
+            call(13058, 200),
+        ]
+
+
+async def test_denylist_still_blocks_start_stop_on_sh_hybrid():
+    """The dispatch path must never target start/stop, even on hybrids that map it read-side."""
+    from custom_components.sungrow.modbus_registers import (
+        HOLDING_CONTROL_MAPS,
+        HOLDING_WRITE_DENYLIST_WIRE,
+        HoldingControlPoint,
+    )
+
+    # Simulate a rogue map entry pointing at 5005 (start/stop) on sh_rt. This should
+    # be caught by _resolve() before any wire access.
+    poison_point = HoldingControlPoint(
+        param="power_on",  # not a canonical cloud param, but that's OK — _resolve
+        # keys on the param dict which we're monkey-patching.
+        wire_address=5005,
+        description="rogue mapping",
+        param_code=None,
+    )
+    control = ModbusControl(_client(family="sh_rt"), family="sh_rt")
+    # Force-insert the poison point so we can prove the guardrail bites.
+    object.__setattr__(control, "_by_param", {**control._by_param, "power_on": poison_point})  # noqa: SLF001
+
+    assert 5005 in HOLDING_WRITE_DENYLIST_WIRE  # sanity: still on the denylist
+    assert HOLDING_CONTROL_MAPS["sh_rt"], "sh_rt should map some params"
+    with pytest.raises(ModbusControlError, match="denylisted"):
+        await control.async_update_parameters("sn_inv", {"power_on": "0xCE"})

--- a/tests/test_modbus_control_probe.py
+++ b/tests/test_modbus_control_probe.py
@@ -23,10 +23,22 @@ from custom_components.sungrow.modbus_registers import (
 )
 
 
-def test_write_denylist_includes_start_stop_and_ems():
-    """Spike must never target start/stop or hybrid EMS wires."""
+def test_write_denylist_covers_hardware_hazards_only():
+    """The denylist protects start/stop and heartbeat wires; hybrid EMS is controllable.
+
+    5005 (start/stop) and 13079 (external EMS heartbeat) are never legal targets for a
+    dispatch entity: 0xCE shuts the inverter down and 13079 is owned by heartbeat.py.
+    13049/13050/13051 (EMS mode / charge-discharge command / charge-discharge power) are
+    the *point* of the SH hybrid holding-control map (#331), so they must NOT be
+    denylisted — writes are gated by ``HOLDING_CONTROL_MAPS`` instead.
+    """
     assert 5005 in HOLDING_WRITE_DENYLIST_WIRE
-    assert 13049 in HOLDING_WRITE_DENYLIST_WIRE
+    assert 13079 in HOLDING_WRITE_DENYLIST_WIRE
+    # Regression guard for #331 — the SH hybrid EMS block MUST NOT sit on the denylist.
+    for allowed in (13049, 13050, 13051):
+        assert allowed not in HOLDING_WRITE_DENYLIST_WIRE, (
+            f"wire {allowed} must be writable via HOLDING_CONTROL_MAPS (#331)"
+        )
 
 
 def test_classify_supported_when_noop_write_ok():
@@ -104,13 +116,17 @@ async def test_probe_noop_write_when_allowed():
 
 
 async def test_probe_refuses_denylisted_write_candidate():
-    """Even if marked write_candidate, denylist blocks the write."""
+    """Even if marked write_candidate, denylist blocks the write.
+
+    Uses wire 5005 (start/stop) — the canonical denylisted address after #331 moved
+    hybrid EMS (13049) into ``HOLDING_CONTROL_MAPS``.
+    """
     client = MagicMock()
     client.async_read_holding = AsyncMock(return_value=[0])
     client.async_write_holding = AsyncMock()
     point = HoldingProbePoint(
-        name="ems",
-        wire_address=13049,
+        name="start_stop",
+        wire_address=5005,
         description="denied",
         family="probe_negative",
         write_candidate=True,


### PR DESCRIPTION
Closes #331. Follow-up to #319 / #325 / #328 / #329 / #337.

## What

`HOLDING_CONTROL_MAPS` was limited to `sg_rs` / `sg_rt` (active-power limit switch + ratio). SH hybrid users on Modbus-only setups could read all their sensors but had to route every dispatch command through the cloud API. This unlocks local control of the battery / EMS / export block for both SH sub-families — the biggest local-control gap for offline / privacy-first installs.

## Register table

Wire addresses transcribed from [TCzerny/ha-modbus-manager](https://github.com/TCzerny/ha-modbus-manager) `sungrow_shx_dynamic.yaml` (MIT), itself based on the mkaiser SHx project + Sungrow protocol V1.1.11.

**Common to `sh_rt` and `sh_rs`:**

| Wire | Param | Notes |
|---|---|---|
| 13049 | `energy_management_mode` | 0 self-consumption, 2 compulsory, 3 external EMS, 4 VPP |
| 13050 | `charge_discharge_command` | 0xAA charge / 0xBB discharge / 0xCC stop |
| 13051 | `charge_discharge_power` | W |
| 13057 | `soc_upper_limit` | 0.1 %; 700..1000 = 70..100 % |
| 13058 | `soc_lower_limit` | 0.1 %; 0..500 = 0..50 % |
| 13073 | `feed_in_limitation_value` | W |
| 13086 | `feed_in_limitation` | 0xAA enable / 0x55 disable |

**`sh_rt` (three-phase hybrids):**

| Wire | Param |
|---|---|
| 13088 | `limited_power_switch` |
| 13089 | `active_power_limit_ratio` |

**`sh_rs` (single-phase hybrids — TCzerny field-verified RS/RT split):**

| Wire | Param |
|---|---|
| 31203 | `limited_power_switch` (13088 non-functional on RS) |
| 31204 | `active_power_limit_ratio` (13089 non-functional on RS) |

## How it slots in

Every `HoldingControlPoint.param` matches the canonical name in `pysolarcloud.Control.PARAMETER_SPECS`, so **the same UI slider or select entity works identically over cloud or local**. Bounds enforcement, enum-name → raw-code encoding, and read-back id matching for #254 / #286 verification all come from `Control.encode_parameter` — no wire-value math lives in the map.

### Denylist changes

`HOLDING_WRITE_DENYLIST_WIRE` now covers **only** the truly-dangerous wires:

- ✅ **kept**: `5005` (start/stop — 0xCE shuts the inverter down)
- ✅ **kept**: `13079` (external EMS heartbeat — owned by `heartbeat.py`, not dispatch entities)
- ➖ **removed**: `13049` / `13050` / `13051` — these are the *point* of the new SH map; writes are now gated by `HOLDING_CONTROL_MAPS` instead

### `has_battery` derivation

The Modbus-only setup path used to hard-code `coordinator.has_battery = False` with a `# until hybrid holding maps ship (#220)` comment. It's now derived from the family resolved by `first_refresh`'s device-type detection via `resolve_capabilities()`:

- SG-RS / SG-RT string inverters → `False` (unchanged — no battery, `battery_only` entities stay hidden — #148 footgun stays fixed)
- SH-RS / SH-RT hybrids → `True` (new — unlocks the SH holding controls)

## Cloud-side plumbing is unchanged

- `_read_still_self_consumption` in `select.py` reads back via `control.async_read_parameters(EMS_MODE_PARAM)` which now hits wire 13049 via FC3 on local — same shape as the cloud response.
- The #254 actuation check and #286 throttled reconciliation work transparently.
- The battery-mode select writes `energy_management_mode` + `charge_discharge_command` in one payload; `ModbusControl.async_update_parameters` already iterates the dict and does two sequential FC6 writes.

## Tests (7 new)

- **`sh_rt` and `sh_rs` both expose the full battery / EMS / export param set** (parametrized).
- **Wire routing per family**:
  - `sh_rt` writes hit `13088 / 13089` for active-power-limit
  - `sh_rs` writes hit `31203 / 31204` for the same params
  - EMS + charge/discharge + power writes hit `13049 / 13050 / 13051`
- **Shared SoC / export wires** match across sub-families (`13057 / 13058`).
- **Denylist regression**:
  - `5005` and `13079` stay blocked
  - `13049 / 13050 / 13051` explicitly asserted NOT on the denylist
  - Rogue map entry pointing at `5005` is refused before FC6 goes out

## Verification

- `pytest tests/`: 731 passed, 4 deselected (7 new)
- `ruff check` / `ruff format --check`: clean
- `mypy`: no issues in 27 source files

## ⚠️ Live verification pending

My local SG36RS can't exercise the SH wires (they return `exception_code=2` on SG string inverters, and the unsupported-block skip in `modbus.py` already handles that gracefully). Would appreciate an SH-RS or SH-RT user with a WiNet-S validating against real hardware before merge — the [live probe script pattern](https://github.com/KRoperUK/sungrow-hass/pull/329#issuecomment-5012996934) I used for #329 works identically here.

Ian in #314 has an SH10RS + SBH250 and offered to test earlier — pinging on merge.

## Attribution

Register addresses, RS/RT split, and value encodings from [TCzerny/ha-modbus-manager](https://github.com/TCzerny/ha-modbus-manager) (MIT). The RS/RT split at 31203/31204 vs 13088/13089 is TCzerny's field-tested finding, not documented in the mkaiser reference.