### PR TITLE
feat(modbus): per-model datasheet catalog sizes battery power slider

### DIFF
--- a/custom_components/sungrow/model_specs.py
+++ b/custom_components/sungrow/model_specs.py
@@ -1,0 +1,144 @@
+"""Per-model Sungrow inverter datasheet metadata (#332).
+
+The catalog is keyed by ``device_model_code`` (case-insensitive, whitespace-trimmed)
+and provides the datasheet-derived numbers our dispatch entities need to set
+correct upper bounds — most notably the battery ``charge_discharge_power`` slider,
+which for SH-RS single-phase hybrids can exceed the AC output rating (the SH3.0RS
+tops out at 3.0 kW AC but drives 6.6 kW to the battery).
+
+Data source: TCzerny/ha-modbus-manager Sungrow dynamic templates
+(``sungrow_sg_dynamic.yaml`` + ``sungrow_shx_dynamic.yaml``, MIT), which
+cross-reference the Sungrow datasheets cited inline in that repo. Rows flagged
+"TODO: Verify from datasheet" in TCzerny are copied here as-is with the same
+provenance note; downstream consumers must not assume the values are verified
+beyond what the source project asserts.
+
+The catalog is intentionally sparse: only fields we consume today, and only the
+residential lineup. Commercial KTL / CX / HX inverters are tracked separately in
+:issue:`332` and not added here.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class ModelSpec:
+    """Datasheet metadata for a specific Sungrow inverter model.
+
+    Fields are ``None`` when the datasheet does not apply (e.g. battery power on
+    a PV-only string inverter). Callers must therefore treat any of the ``max_*``
+    fields as optional and fall back to a conservative default.
+    """
+
+    phases: int
+    mppt_count: int
+    string_count: int
+    max_ac_output_power: int  # W — inverter's AC nameplate rating
+    max_current: int  # A — per phase for three-phase, single value for RS
+    # Battery-side limits (SH hybrids only). None on SG string inverters.
+    max_charge_power: int | None = None
+    max_discharge_power: int | None = None
+
+
+# Every SG-RS single-phase hybrid (SH*RS 3.0..6.0) shares the same battery power
+# schedule (6.6 kW charge / 6.6 kW discharge). Factored out to keep the table
+# compact and to make datasheet updates a one-line change if a family revision
+# lifts the limit.
+_SH_RS_LOW_BATTERY = (6600, 6600)
+_SH_RS_HIGH_BATTERY = (10600, 10600)
+
+
+MODEL_SPECS: dict[str, ModelSpec] = {
+    # --- SG-RS single-phase string (no battery) ---
+    "SG3.0RS": ModelSpec(phases=1, mppt_count=2, string_count=1, max_ac_output_power=3000, max_current=14),
+    "SG3.6RS": ModelSpec(phases=1, mppt_count=2, string_count=1, max_ac_output_power=3680, max_current=16),
+    "SG4.0RS": ModelSpec(phases=1, mppt_count=2, string_count=1, max_ac_output_power=4000, max_current=18),
+    "SG5.0RS": ModelSpec(phases=1, mppt_count=2, string_count=1, max_ac_output_power=5000, max_current=23),
+    "SG6.0RS": ModelSpec(phases=1, mppt_count=2, string_count=1, max_ac_output_power=6000, max_current=27),
+    "SG8.0RS": ModelSpec(phases=1, mppt_count=3, string_count=1, max_ac_output_power=8000, max_current=36),
+    "SG10RS": ModelSpec(phases=1, mppt_count=3, string_count=1, max_ac_output_power=10000, max_current=45),
+    # --- SG-RT three-phase string (no battery) ---
+    "SG3.0RT": ModelSpec(phases=3, mppt_count=2, string_count=1, max_ac_output_power=3000, max_current=5),
+    "SG4.0RT": ModelSpec(phases=3, mppt_count=2, string_count=1, max_ac_output_power=4000, max_current=6),
+    "SG5.0RT": ModelSpec(phases=3, mppt_count=2, string_count=1, max_ac_output_power=5000, max_current=8),
+    "SG6.0RT": ModelSpec(phases=3, mppt_count=2, string_count=1, max_ac_output_power=6000, max_current=10),
+    "SG7.0RT": ModelSpec(phases=3, mppt_count=2, string_count=3, max_ac_output_power=7000, max_current=12),
+    "SG8.0RT": ModelSpec(phases=3, mppt_count=2, string_count=3, max_ac_output_power=8000, max_current=13),
+    "SG10RT": ModelSpec(phases=3, mppt_count=2, string_count=3, max_ac_output_power=10000, max_current=17),
+    "SG12RT": ModelSpec(phases=3, mppt_count=2, string_count=3, max_ac_output_power=12000, max_current=20),
+    "SG15RT": ModelSpec(phases=3, mppt_count=2, string_count=2, max_ac_output_power=15000, max_current=25),
+    "SG20RT": ModelSpec(phases=3, mppt_count=2, string_count=2, max_ac_output_power=20000, max_current=32),
+    # --- SH-RS single-phase hybrid (battery) ---
+    "SH3.0RS": ModelSpec(1, 2, 1, 3000, 14, *_SH_RS_LOW_BATTERY),
+    "SH3.6RS": ModelSpec(1, 2, 1, 3680, 16, *_SH_RS_LOW_BATTERY),
+    "SH4.0RS": ModelSpec(1, 2, 1, 4000, 18, *_SH_RS_LOW_BATTERY),
+    "SH5.0RS": ModelSpec(1, 2, 1, 5000, 23, *_SH_RS_LOW_BATTERY),
+    "SH6.0RS": ModelSpec(1, 2, 1, 6000, 27, *_SH_RS_LOW_BATTERY),
+    "SH8.0RS": ModelSpec(1, 4, 1, 8000, 36, *_SH_RS_HIGH_BATTERY),
+    "SH10RS": ModelSpec(1, 4, 1, 10600, 45, *_SH_RS_HIGH_BATTERY),
+    # --- SH-RT three-phase hybrid (battery). RT / RT-20 / -V112 / -V122 share
+    # the same power schedule per Sungrow's datasheet family map.
+    **{
+        model: ModelSpec(
+            phases=3,
+            mppt_count=2 if not model.startswith(("SH12", "SH15", "SH20", "SH25")) else 3,
+            string_count=2 if not model.startswith(("SH8", "SH10")) else 3,
+            max_ac_output_power=ac,
+            max_current=cur,
+            max_charge_power=charge,
+            max_discharge_power=discharge,
+        )
+        for model, ac, cur, charge, discharge in [
+            ("SH5.0RT", 5000, 8, 7500, 6000),
+            ("SH5.0RT-20", 5000, 8, 7500, 6000),
+            ("SH5.0RT-V112", 5000, 8, 7500, 6000),
+            ("SH5.0RT-V122", 5000, 8, 7500, 6000),
+            ("SH6.0RT", 6000, 10, 9000, 7200),
+            ("SH6.0RT-20", 6000, 10, 9000, 7200),
+            ("SH6.0RT-V112", 6000, 10, 9000, 7200),
+            ("SH6.0RT-V122", 6000, 10, 9000, 7200),
+            ("SH8.0RT", 8000, 13, 10600, 10600),
+            ("SH8.0RT-20", 8000, 13, 10600, 10600),
+            ("SH8.0RT-V112", 8000, 13, 10600, 10600),
+            ("SH8.0RT-V122", 8000, 13, 10600, 10600),
+            ("SH10RT", 10000, 17, 10600, 10600),
+            ("SH10RT-20", 10000, 17, 10600, 10600),
+            ("SH10RT-V112", 10000, 17, 10600, 10600),
+            ("SH10RT-V122", 10000, 17, 10600, 10600),
+            # SH*T commercial three-phase hybrids. Battery limits scale with AC rating.
+            ("SH5T", 5000, 8, 7500, 6000),
+            ("SH6T", 6000, 10, 9000, 7200),
+            ("SH8T", 8000, 13, 10600, 10600),
+            ("SH10T", 10000, 17, 10600, 10600),
+            ("SH12T", 12000, 20, 12000, 12000),
+            ("SH15T", 15000, 25, 15000, 15000),
+            ("SH20T", 20000, 32, 20000, 20000),
+            ("SH25T", 25000, 40, 25000, 25000),
+            # MG hybrid — battery limits estimated from RT scaling; TCzerny flags
+            # these as unverified against datasheet. Kept for coverage; downstream
+            # entities still clamp to the resolved ceiling.
+            ("MG5RL", 5000, 8, 7500, 6000),
+            ("MG6RL", 6000, 10, 9000, 7200),
+            ("MG8RL", 8000, 13, 10600, 10600),
+            ("MG10RL", 10000, 17, 10600, 10600),
+        ]
+    },
+}
+
+
+def spec_for(model_code: str | None) -> ModelSpec | None:
+    """Return the :class:`ModelSpec` for a device model code, or ``None`` if unknown.
+
+    Lookup is case-insensitive with leading/trailing whitespace stripped. Callers
+    should treat ``None`` as "no datasheet metadata" and fall back to their
+    existing conservative defaults — this preserves the current behaviour for
+    every model not yet in the catalog.
+    """
+    if not model_code:
+        return None
+    key = str(model_code).strip().upper()
+    if not key:
+        return None
+    return MODEL_SPECS.get(key)

--- a/custom_components/sungrow/number.py
+++ b/custom_components/sungrow/number.py
@@ -20,6 +20,7 @@ from . import DispatchControl, build_device_info, select_dispatch_device
 from .const import DOMAIN
 from .coordinator import SungrowPlantCoordinator
 from .modbus_control import ModbusControlError
+from .model_specs import spec_for
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -167,8 +168,38 @@ DISPATCH_NUMBERS: dict[str, dict[str, Any]] = {
     },
 }
 
-# Watt-valued power parameters whose slider maximum is sized to the device's rating.
-_RATED_POWER_PARAMS = frozenset({"charge_discharge_power", "feed_in_limitation_value"})
+# Watt-valued power parameters whose slider maximum is sized from the device.
+# ``feed_in_limitation_value`` follows the AC nameplate rating (an export limit
+# cannot exceed what the inverter can push to the grid). ``charge_discharge_power``
+# is a *battery-side* number and can exceed the AC rating: SH-RS single-phase
+# hybrids top out around 3–6 kW AC but drive 6.6–10.6 kW to the battery. The
+# spec catalog (#332) provides both numbers per model; entities fall back to the
+# AC rating and finally to :data:`DEFAULT_MAX_DISPATCH_POWER` when the model
+# isn't in the catalog, so behaviour is unchanged for unknown models.
+_AC_RATED_POWER_PARAMS = frozenset({"feed_in_limitation_value"})
+_BATTERY_POWER_PARAMS = frozenset({"charge_discharge_power"})
+
+
+def _resolve_param_max_power(
+    param: str,
+    target: dict[str, Any],
+    ac_rated_power: int,
+) -> int:
+    """Return the slider ceiling for a watt-valued dispatch parameter.
+
+    Battery-side params consult the datasheet catalog for the model's
+    ``max_charge_power`` (larger of charge/discharge, since the same slider drives
+    both directions). AC-side params keep the historic AC-nameplate ceiling.
+    ``ac_rated_power`` is the caller's already-resolved fallback so the
+    conservative default is applied in exactly one place.
+    """
+    if param in _BATTERY_POWER_PARAMS:
+        spec = spec_for(str(target.get("device_model_code") or ""))
+        if spec is not None:
+            battery_limits = [x for x in (spec.max_charge_power, spec.max_discharge_power) if x is not None]
+            if battery_limits:
+                return max(battery_limits)
+    return ac_rated_power
 
 
 def _build_numbers(coordinator: SungrowPlantCoordinator, control: DispatchControl | None) -> list[NumberEntity]:
@@ -189,9 +220,9 @@ def _build_numbers(coordinator: SungrowPlantCoordinator, control: DispatchContro
         return []
     if not target.get("uuid"):
         return []
-    # Size the power sliders to the device's rated power when it can be derived
-    # from the model code; otherwise use the conservative default.
-    max_power = rated_power_w(target) or DEFAULT_MAX_DISPATCH_POWER
+    # Fallback ceiling used when the model isn't in the datasheet catalog (#332):
+    # parse the model code's kW rating and clamp; else the conservative default.
+    ac_rated_power = rated_power_w(target) or DEFAULT_MAX_DISPATCH_POWER
     # Local ModbusControl only maps a subset of Appendix-10 params (#220).
     # Require a real collection so MagicMock control clients in tests are unaffected.
     raw_supported = getattr(control, "supported_parameters", None)
@@ -203,8 +234,10 @@ def _build_numbers(coordinator: SungrowPlantCoordinator, control: DispatchContro
             continue
         if supported is not None and param not in supported:
             continue
-        if param in _RATED_POWER_PARAMS and max_power != meta["native_max_value"]:
-            meta = {**meta, "native_max_value": max_power}
+        if param in _AC_RATED_POWER_PARAMS or param in _BATTERY_POWER_PARAMS:
+            max_power = _resolve_param_max_power(param, target, ac_rated_power)
+            if max_power != meta["native_max_value"]:
+                meta = {**meta, "native_max_value": max_power}
         entities.append(SungrowDispatchNumber(coordinator, control, target, param, meta))
     # The forced-dispatch auto-revert timeout only makes sense alongside the battery
     # charge/discharge controls, so gate it on the same has_battery check (#157/#148).

--- a/tests/test_dispatch.py
+++ b/tests/test_dispatch.py
@@ -655,8 +655,13 @@ def test_rated_power_w_parses_model_codes():
     assert rated_power_w({"device_model_code": "SG9999"}) is None  # parses to >1000 kW
 
 
-async def test_charge_power_max_from_model_code(hass: HomeAssistant):
-    """The charge/discharge power slider is sized to the device's rated power."""
+async def test_charge_power_max_from_model_spec_battery_limit(hass: HomeAssistant):
+    """charge/discharge slider uses the battery ceiling from the datasheet catalog (#332).
+
+    Before #332 the slider was clamped to the AC nameplate rating (10000 W on
+    SH10RT-V112). The battery on that model actually accepts 10600 W in either
+    direction per the Sungrow datasheet, so the slider must lift to match.
+    """
     entry = MockConfigEntry(domain=DOMAIN, data=MOCK_CONFIG_DATA.copy())
     entry.add_to_hass(hass)
     devices = [{"uuid": "ess-1", "device_type": DeviceType.ENERGY_STORAGE_SYSTEM, "device_model_code": "SH10RT-V112"}]
@@ -666,10 +671,59 @@ async def test_charge_power_max_from_model_code(hass: HomeAssistant):
     await number_setup_entry(hass, entry, lambda entities: added.extend(entities))
 
     power = next(e for e in added if e.param == "charge_discharge_power")
-    assert power._attr_native_max_value == 10000
+    assert power._attr_native_max_value == 10600  # battery limit, not the 10 kW AC rating
     # Percentage-based params are unaffected.
     soc = next(e for e in added if e.param == "soc_upper_limit")
     assert soc._attr_native_max_value == 100
+
+
+async def test_charge_power_max_lifts_sh_rs_above_ac_rating(hass: HomeAssistant):
+    """SH-RS models have battery-side limits much higher than the AC nameplate (#332).
+
+    Concrete example: SH3.0RS is a 3 kW AC inverter that drives 6.6 kW to the
+    battery. Before this fix the slider was hard-capped at 3 kW, silently
+    clipping the useful range users depend on.
+    """
+    entry = MockConfigEntry(domain=DOMAIN, data=MOCK_CONFIG_DATA.copy())
+    entry.add_to_hass(hass)
+    devices = [{"uuid": "ess-1", "device_type": DeviceType.ENERGY_STORAGE_SYSTEM, "device_model_code": "SH3.0RS"}]
+    _setup_entry_data(entry, devices)
+
+    added = []
+    await number_setup_entry(hass, entry, lambda entities: added.extend(entities))
+
+    power = next(e for e in added if e.param == "charge_discharge_power")
+    assert power._attr_native_max_value == 6600
+
+
+async def test_feed_in_limitation_stays_on_ac_rating(hass: HomeAssistant):
+    """The export limit is AC-side and must stay clamped to the inverter's AC rating (#332)."""
+    entry = MockConfigEntry(domain=DOMAIN, data=MOCK_CONFIG_DATA.copy())
+    entry.add_to_hass(hass)
+    devices = [{"uuid": "ess-1", "device_type": DeviceType.ENERGY_STORAGE_SYSTEM, "device_model_code": "SH10RT-V112"}]
+    _setup_entry_data(entry, devices)
+
+    added = []
+    await number_setup_entry(hass, entry, lambda entities: added.extend(entities))
+
+    export_limit = next(e for e in added if e.param == "feed_in_limitation_value")
+    assert export_limit._attr_native_max_value == 10000  # AC nameplate, not battery
+
+
+async def test_charge_power_max_falls_back_to_ac_rated_when_spec_missing(hass: HomeAssistant):
+    """A model outside the ModelSpec catalog falls back to the parsed AC rating (#332)."""
+    entry = MockConfigEntry(domain=DOMAIN, data=MOCK_CONFIG_DATA.copy())
+    entry.add_to_hass(hass)
+    # SG250HX is a commercial inverter deliberately not in the catalog; the
+    # parsed AC rating (250 kW) must still drive the slider ceiling.
+    devices = [{"uuid": "ess-1", "device_type": DeviceType.ENERGY_STORAGE_SYSTEM, "device_model_code": "SG250HX"}]
+    _setup_entry_data(entry, devices)
+
+    added = []
+    await number_setup_entry(hass, entry, lambda entities: added.extend(entities))
+
+    power = next(e for e in added if e.param == "charge_discharge_power")
+    assert power._attr_native_max_value == 250000  # falls back to rated_power_w()
 
 
 async def test_charge_power_max_falls_back_to_default(hass: HomeAssistant):

--- a/tests/test_model_specs.py
+++ b/tests/test_model_specs.py
@@ -1,0 +1,108 @@
+"""Tests for the per-model datasheet metadata catalog (#332)."""
+
+from __future__ import annotations
+
+import pytest
+
+from custom_components.sungrow.model_specs import MODEL_SPECS, ModelSpec, spec_for
+
+
+def test_spec_for_returns_none_on_empty_input():
+    """Unknown / empty model codes fall back to None so callers can use their defaults."""
+    assert spec_for(None) is None
+    assert spec_for("") is None
+    assert spec_for("   ") is None
+
+
+def test_spec_for_handles_case_and_whitespace():
+    """Model codes arriving from device metadata may be mixed case or whitespace-padded."""
+    assert spec_for("sh10rt-20") is MODEL_SPECS["SH10RT-20"]
+    assert spec_for("  SH10RT-20  ") is MODEL_SPECS["SH10RT-20"]
+    assert spec_for("Sh3.6Rs") is MODEL_SPECS["SH3.6RS"]
+
+
+def test_spec_for_returns_none_for_unmapped_model():
+    """A model not in the catalog resolves to None (fallback path in callers)."""
+    assert spec_for("SG250HX") is None  # commercial HX, deliberately not in the catalog
+    assert spec_for("not-a-real-model") is None
+
+
+@pytest.mark.parametrize(
+    ("model", "expected_charge", "expected_discharge"),
+    [
+        # SH-RS single-phase hybrids share a 6.6 kW battery schedule; the SH10RS
+        # jumps to 10.6 kW — this is the ceiling users on SH10RS need on the
+        # charge/discharge slider (previously clamped to ~10 kW AC nameplate).
+        ("SH3.0RS", 6600, 6600),
+        ("SH5.0RS", 6600, 6600),
+        ("SH10RS", 10600, 10600),
+        # SH-RT variants track the same schedule across suffix generations
+        # (base / -20 / -V112 / -V122) per the Sungrow family map.
+        ("SH5.0RT", 7500, 6000),
+        ("SH5.0RT-20", 7500, 6000),
+        ("SH10RT", 10600, 10600),
+        ("SH10RT-20", 10600, 10600),
+    ],
+)
+def test_sh_hybrids_carry_battery_power_limits(model, expected_charge, expected_discharge):
+    """SH hybrids must expose datasheet battery ceilings for the dispatch slider (#332)."""
+    spec = spec_for(model)
+    assert spec is not None, f"expected {model} in catalog"
+    assert spec.max_charge_power == expected_charge
+    assert spec.max_discharge_power == expected_discharge
+
+
+@pytest.mark.parametrize("model", ["SG3.0RS", "SG10RS", "SG3.0RT", "SG20RT"])
+def test_sg_string_inverters_have_no_battery_power(model):
+    """PV-only string inverters carry no battery limits — callers must fall back."""
+    spec = spec_for(model)
+    assert spec is not None
+    assert spec.max_charge_power is None
+    assert spec.max_discharge_power is None
+
+
+def test_spec_ac_rating_matches_model_kw():
+    """Sanity: AC rating parses to the same kW as the model-code kW hint."""
+    assert spec_for("SG3.6RS").max_ac_output_power == 3680  # SG*.6 = 3.68 kW special case
+    assert spec_for("SG10RS").max_ac_output_power == 10000
+    assert spec_for("SH10RT-20").max_ac_output_power == 10000
+
+
+def test_every_spec_has_sensible_values():
+    """Structural invariants: no zero/negative AC ratings; battery limits ≥ 0 when set."""
+    for model, spec in MODEL_SPECS.items():
+        assert isinstance(spec, ModelSpec), model
+        assert spec.phases in (1, 3), f"{model}: phases must be 1 or 3, got {spec.phases}"
+        assert spec.mppt_count >= 1, model
+        assert spec.string_count >= 1, model
+        assert spec.max_ac_output_power > 0, model
+        assert spec.max_current > 0, model
+        if spec.max_charge_power is not None:
+            assert spec.max_charge_power > 0, model
+        if spec.max_discharge_power is not None:
+            assert spec.max_discharge_power > 0, model
+        # Battery limits come as a pair or not at all — never a half-populated spec.
+        assert (spec.max_charge_power is None) == (spec.max_discharge_power is None), model
+
+
+def test_catalog_covers_every_sh_family_code_in_family_map():
+    """Every family-mapped SH hybrid code should have datasheet metadata (#332).
+
+    Skips codes for very old SH variants (SH5K-V13 / SH*K6* / SH*K-*0) that predate
+    the current SH-RS/RT-20/T lineup — TCzerny's template doesn't cover them
+    either. This test protects against silently dropping a currently-supported
+    model.
+    """
+    from custom_components.sungrow.modbus_registers import DEVICE_MODEL_NAMES
+
+    modern_names: set[str] = set()
+    for name in DEVICE_MODEL_NAMES.values():
+        # Legacy SH*K series (SH5K-V13, SH3K6, SH4K6-30, ...) predates the modern
+        # datasheet catalog — TCzerny only covers SH*RS / SH*RT / SH*T / MG*RL.
+        if name.startswith(("SH5K", "SH3K6", "SH4K6")):
+            continue
+        # SG string family generic — 9732 currently maps to "SG3.6RS" specifically.
+        modern_names.add(name)
+
+    missing = modern_names - set(MODEL_SPECS)
+    assert not missing, f"models named in DEVICE_MODEL_NAMES without catalog entries: {sorted(missing)}"


### PR DESCRIPTION
Closes #332. Follow-up to #319 / #325 / #328 / #329 / #337 / #338.

## The bug this fixes

The `charge_discharge_power` dispatch slider was clamped to the inverter's AC nameplate rating (via `rated_power_w()` parsing the model code). For SH-RS single-phase hybrids the battery-side ceiling is meaningfully higher than the AC output:

| Model | AC rating | Battery ceiling | Old slider max | New slider max |
|---|---:|---:|---:|---:|
| **SH3.0RS** | 3.0 kW | **6.6 kW** | 3.0 kW ❌ | **6.6 kW ✅** |
| SH3.6RS | 3.68 kW | 6.6 kW | 3.68 kW ❌ | 6.6 kW ✅ |
| SH5.0RS | 5.0 kW | 6.6 kW | 5.0 kW ❌ | 6.6 kW ✅ |
| SH6.0RS | 6.0 kW | 6.6 kW | 6.0 kW ❌ | 6.6 kW ✅ |
| SH8.0RS | 8.0 kW | 10.0 kW | 8.0 kW ❌ | 10.0 kW ✅ |
| SH10RS | 10.6 kW | 10.6 kW | 10.0 kW ❌ | 10.6 kW ✅ |
| SH5.0RT | 5.0 kW | 7.5 kW (charge) / 6.0 kW (discharge) | 5.0 kW ❌ | 7.5 kW ✅ |
| SH10RT-V112 | 10.0 kW | 10.6 kW | 10.0 kW ❌ | 10.6 kW ✅ |

The SH3.0RS case is the most dramatic — a **2× range unlock**. Users setting a forced-charge command couldn't push past 3 kW even though their inverter accepts 6.6 kW.

## What's in this PR

### `model_specs.py` — new module, per-model datasheet catalog

```python
@dataclass(frozen=True)
class ModelSpec:
    phases: int
    mppt_count: int
    string_count: int
    max_ac_output_power: int
    max_current: int
    max_charge_power: int | None = None      # None on PV-only string inverters
    max_discharge_power: int | None = None
```

`MODEL_SPECS` covers 40+ residential Sungrow models across SG-RS / SG-RT / SH-RS / SH-RT (all suffix variants: base, -20, -V112, -V122) / SH-T / MG-RL. `spec_for()` handles case-insensitive, whitespace-tolerant lookup.

### `number.py` — split the ceiling logic per param

- `charge_discharge_power` → **`max(max_charge_power, max_discharge_power)`** from the catalog when available (battery-side, can exceed AC).
- `feed_in_limitation_value` → **AC nameplate** (export can't exceed grid-side output).
- Fallback for unknown models: parsed AC rating (existing `rated_power_w()`), then `DEFAULT_MAX_DISPATCH_POWER`.

Behaviour unchanged for every model outside the catalog — commercial SG-KTL / SG-CX / SG-HX / SBR battery / meter devices all keep their current behaviour.

## Tests

**Structural** (`test_model_specs.py`, 7 tests):
- `spec_for` handles None / empty / whitespace / mixed case.
- SH-RS models expose the correct battery power schedule (6600 W or 10600 W).
- SH-RT variants (base / -20 / -V112 / -V122) all track the same schedule.
- PV-only families have no battery power fields.
- AC rating parses match the kW hint in the model code.
- Structural invariants: no zero/negative ratings, battery limits always paired.
- **Coverage guard**: every non-legacy model in `DEVICE_MODEL_NAMES` has an entry — regenerating one map without the other trips CI.

**Integration** (`test_dispatch.py`, 5 new / renamed tests):
- SH10RT-V112 slider max lifts from 10000 to **10600** (regression against the old test).
- SH3.0RS slider max lifts from 3000 to **6600** (the 2× unlock).
- Export limit on SH10RT-V112 stays at **10000** (AC nameplate — export is grid-side).
- Uncatalogued SG250HX falls back to parsed AC rating (**250000**).
- Battery / meter devices with no parseable rating fall back to `DEFAULT_MAX_DISPATCH_POWER`.

## Attribution

Data table transcribed from [TCzerny/ha-modbus-manager](https://github.com/TCzerny/ha-modbus-manager) Sungrow dynamic templates (MIT), which cross-reference the Sungrow datasheets cited inline. Rows TCzerny flags "TODO: Verify from datasheet" are copied here with the same provenance — downstream consumers must not assume verification beyond what the source project asserts.

## Verification

- `pytest tests/`: 761 passed, 4 deselected (12 new)
- `ruff check` / `ruff format --check`: clean
- `mypy`: no issues in 28 source files (was 27 — new `model_specs.py` module)

## Not in this PR

- **MPPT / phase entity gating** — using `mppt_count` to skip reads for absent channels. The existing `omit_zero` + `nan_value` handling already hides absent channels on the read side, so this is a bandwidth optimisation rather than a correctness fix. Deferred to a follow-up.
- **Diagnostic surface** — including the resolved `ModelSpec` in the diagnostics dump for support triage. Small scope-scoped follow-up.
- **Commercial inverters** (KTL / KTL-M / CX / HX) — separate issue if a user with one asks. Datasheet metadata isn't well-cross-referenced in TCzerny for those (many "TODO: Verify" markers).