### PR TITLE
fix: clean up SBH SOC scaling and legacy charge_discharge select (#314)

### DIFF
--- a/custom_components/sungrow/config_flow.py
+++ b/custom_components/sungrow/config_flow.py
@@ -80,7 +80,7 @@ def _parse_winet_properties(props: dict[str, Any]) -> tuple[str | None, str | No
 class SungrowConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     """Handle a config flow for Sungrow iSolarCloud."""
 
-    VERSION = 3
+    VERSION = 4
 
     def __init__(self) -> None:
         """Initialize the config flow."""

--- a/custom_components/sungrow/migration.py
+++ b/custom_components/sungrow/migration.py
@@ -11,6 +11,7 @@ import logging
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import device_registry as dr
+from homeassistant.helpers import entity_registry as er
 
 from .const import (
     CONF_APP_ID,
@@ -36,6 +37,36 @@ _HYBRID_OPTION_KEYS = frozenset(
     }
 )
 
+# Legacy select unique_id suffix retired in v5.0.0 (replaced by ``_battery_mode``, #255).
+# HA does not auto-remove renamed entities, so the old registry row lingers as
+# "unavailable" until we sweep it (issue #314).
+_LEGACY_SELECT_SUFFIXES: tuple[str, ...] = ("_charge_discharge_command",)
+
+
+def _remove_legacy_entities(hass: HomeAssistant, config_entry: ConfigEntry) -> int:
+    """Purge entity-registry rows renamed away in earlier releases.
+
+    Idempotent: entries already missing from the registry are skipped, so calling this
+    on every migration or setup is safe. Returns the number of entities removed for
+    logging/testing.
+    """
+    registry = er.async_get(hass)
+    removed = 0
+    for entity in list(er.async_entries_for_config_entry(registry, config_entry.entry_id)):
+        if entity.platform != DOMAIN:
+            continue
+        unique_id = entity.unique_id or ""
+        if not any(unique_id.endswith(suffix) for suffix in _LEGACY_SELECT_SUFFIXES):
+            continue
+        registry.async_remove(entity.entity_id)
+        removed += 1
+        _LOGGER.info(
+            "Removed legacy Sungrow entity %s (unique_id=%s); superseded by select.*_battery_mode",
+            entity.entity_id,
+            unique_id,
+        )
+    return removed
+
 
 async def async_migrate_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> bool:
     """Migrate old config entry versions to the current schema."""
@@ -54,6 +85,19 @@ async def async_migrate_entry(hass: HomeAssistant, config_entry: ConfigEntry) ->
         hass.config_entries.async_update_entry(config_entry, data=new_data, version=3)
         _LOGGER.info(
             "Migrated config entry %s to version 3 (transport=%s)", config_entry.title, new_data[CONF_TRANSPORT]
+        )
+
+    if config_entry.version == 3:
+        # v3→v4: sweep entities renamed away in v5.0.0 (issue #314). The
+        # ``select.*_charge_discharge_command`` unique_id was replaced by
+        # ``select.*_battery_mode``; HA leaves the old row registered but permanently
+        # unavailable until we remove it here.
+        removed = _remove_legacy_entities(hass, config_entry)
+        hass.config_entries.async_update_entry(config_entry, version=4)
+        _LOGGER.info(
+            "Migrated config entry %s to version 4 (removed %d legacy entities)",
+            config_entry.title,
+            removed,
         )
 
     # Defensive back-fill: ensure cloud entries carry app_id (#245).

--- a/custom_components/sungrow/sensor.py
+++ b/custom_components/sungrow/sensor.py
@@ -397,7 +397,16 @@ class SungrowSensor(CoordinatorEntity, SensorEntity):
             # pollute long-term statistics (issue #113).
             return None
         # Capacity-factor ratios are reported as a 0–1 fraction but shown as "%".
-        return num * 100 if self._scale_to_percent else num
+        if self._scale_to_percent:
+            return num * 100
+        # Battery SOC on some plants (observed on SBH250-V11, issue #314) arrives as a
+        # 0–1 fraction from iSolarCloud instead of a 0–100 percentage. Rescale to
+        # percent so it displays correctly under the "%" unit. Skip 0 (empty battery is
+        # 0 either way) and only trigger when the value fits the fraction shape
+        # (0 < num ≤ 1.0); anything larger is already a percentage.
+        if self._attr_device_class == SensorDeviceClass.BATTERY and 0 < num <= 1.0:
+            return num * 100
+        return num
 
     @property
     def extra_state_attributes(self) -> dict[str, Any] | None:

--- a/tests/test_migration_properties.py
+++ b/tests/test_migration_properties.py
@@ -4,6 +4,7 @@ Feature: transport-mode-selector
 """
 
 import pytest
+from homeassistant.helpers import entity_registry as er
 from hypothesis import HealthCheck, given, settings
 from hypothesis import strategies as st
 from pytest_homeassistant_custom_component.common import MockConfigEntry
@@ -17,8 +18,11 @@ from custom_components.sungrow.const import (
     TRANSPORT_MODBUS_ONLY,
 )
 
+# The migration target after every v1/v2/v3 upgrade path (v3→v4 sweeps legacy entities).
+CURRENT_VERSION = 4
+
 # ---------------------------------------------------------------------------
-# Property 2: v2→v3 migration correctly sets or preserves transport
+# Property 2: v2→v4 migration correctly sets or preserves transport
 # Validates: Requirements 5.2, 5.3, 5.4
 # ---------------------------------------------------------------------------
 
@@ -34,10 +38,10 @@ from custom_components.sungrow.const import (
     ),
 )
 @pytest.mark.asyncio
-async def test_v2_to_v3_migration_sets_or_preserves_transport(
+async def test_v2_to_current_migration_sets_or_preserves_transport(
     hass, has_transport: bool, is_modbus: bool, extra_keys: dict
 ):
-    """Property 2: v2→v3 migration back-fills cloud_only or preserves modbus_only."""
+    """Property 2: v2→current migration back-fills cloud_only or preserves modbus_only."""
     data = dict(extra_keys)
     if has_transport:
         data[CONF_TRANSPORT] = TRANSPORT_MODBUS_ONLY if is_modbus else TRANSPORT_CLOUD_ONLY
@@ -47,7 +51,7 @@ async def test_v2_to_v3_migration_sets_or_preserves_transport(
 
     result = await async_migrate_entry(hass, entry)
     assert result is True
-    assert entry.version == 3
+    assert entry.version == CURRENT_VERSION
 
     if has_transport and is_modbus:
         assert entry.data[CONF_TRANSPORT] == TRANSPORT_MODBUS_ONLY
@@ -59,7 +63,7 @@ async def test_v2_to_v3_migration_sets_or_preserves_transport(
 
 
 # ---------------------------------------------------------------------------
-# Property 3: v1→v3 chained migration preserves semantics
+# Property 3: v1→current chained migration preserves semantics
 # Validates: Requirements 5.5, 5.6
 # ---------------------------------------------------------------------------
 
@@ -67,8 +71,8 @@ async def test_v2_to_v3_migration_sets_or_preserves_transport(
 @settings(max_examples=100, suppress_health_check=[HealthCheck.function_scoped_fixture])
 @given(scan_interval=st.integers(min_value=1, max_value=1440))
 @pytest.mark.asyncio
-async def test_v1_to_v3_chained_migration(hass, scan_interval: int):
-    """Property 3: v1 entry migrates to v3 with correct scan_interval and transport."""
+async def test_v1_to_current_chained_migration(hass, scan_interval: int):
+    """Property 3: v1 entry migrates end-to-end with correct scan_interval and transport."""
     entry = MockConfigEntry(
         domain=DOMAIN,
         data={"app_key": "k", "app_secret": "s"},
@@ -79,7 +83,7 @@ async def test_v1_to_v3_chained_migration(hass, scan_interval: int):
 
     result = await async_migrate_entry(hass, entry)
     assert result is True
-    assert entry.version == 3
+    assert entry.version == CURRENT_VERSION
     assert entry.options[CONF_SCAN_INTERVAL] == scan_interval * 60
     assert entry.data[CONF_TRANSPORT] == TRANSPORT_CLOUD_ONLY
 
@@ -91,27 +95,27 @@ async def test_v1_to_v3_chained_migration(hass, scan_interval: int):
 
 @pytest.mark.asyncio
 async def test_v2_entry_no_transport_gets_cloud_only(hass):
-    """v2 entry with no transport field → gets cloud_only, version 3."""
+    """v2 entry with no transport field → gets cloud_only, migrated to current version."""
     entry = MockConfigEntry(domain=DOMAIN, data={"app_key": "k"}, version=2)
     entry.add_to_hass(hass)
     await async_migrate_entry(hass, entry)
     assert entry.data[CONF_TRANSPORT] == TRANSPORT_CLOUD_ONLY
-    assert entry.version == 3
+    assert entry.version == CURRENT_VERSION
 
 
 @pytest.mark.asyncio
 async def test_v2_entry_modbus_only_preserved(hass):
-    """v2 entry with modbus_only → kept as modbus_only, version 3."""
+    """v2 entry with modbus_only → kept as modbus_only, migrated to current version."""
     entry = MockConfigEntry(domain=DOMAIN, data={CONF_TRANSPORT: TRANSPORT_MODBUS_ONLY, "serial": "SN"}, version=2)
     entry.add_to_hass(hass)
     await async_migrate_entry(hass, entry)
     assert entry.data[CONF_TRANSPORT] == TRANSPORT_MODBUS_ONLY
-    assert entry.version == 3
+    assert entry.version == CURRENT_VERSION
 
 
 @pytest.mark.asyncio
 async def test_v1_entry_scan_interval_5_migrated(hass):
-    """v1 entry with scan_interval=5 → 300s, transport backfilled, version 3."""
+    """v1 entry with scan_interval=5 → 300s, transport backfilled, migrated to current version."""
     entry = MockConfigEntry(
         domain=DOMAIN,
         data={"app_key": "k"},
@@ -122,15 +126,83 @@ async def test_v1_entry_scan_interval_5_migrated(hass):
     await async_migrate_entry(hass, entry)
     assert entry.options[CONF_SCAN_INTERVAL] == 300
     assert entry.data[CONF_TRANSPORT] == TRANSPORT_CLOUD_ONLY
-    assert entry.version == 3
+    assert entry.version == CURRENT_VERSION
 
 
 @pytest.mark.asyncio
-async def test_already_v3_no_changes(hass):
-    """Already-v3 entry → no changes applied."""
-    entry = MockConfigEntry(domain=DOMAIN, data={CONF_TRANSPORT: TRANSPORT_CLOUD_ONLY, "app_key": "k"}, version=3)
+async def test_already_current_no_changes(hass):
+    """Already-current entry → no version bump applied."""
+    entry = MockConfigEntry(
+        domain=DOMAIN, data={CONF_TRANSPORT: TRANSPORT_CLOUD_ONLY, "app_key": "k"}, version=CURRENT_VERSION
+    )
     entry.add_to_hass(hass)
     result = await async_migrate_entry(hass, entry)
     assert result is True
-    assert entry.version == 3
+    assert entry.version == CURRENT_VERSION
     assert entry.data[CONF_TRANSPORT] == TRANSPORT_CLOUD_ONLY
+
+
+# ---------------------------------------------------------------------------
+# v3→v4: sweep legacy select.*_charge_discharge_command (issue #314)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_v3_to_v4_removes_legacy_charge_discharge_select(hass):
+    """v3→v4 removes the pre-5.0.0 charge_discharge_command entity from the registry."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={CONF_TRANSPORT: TRANSPORT_CLOUD_ONLY, "app_key": "k"},
+        version=3,
+        unique_id="test_app_id",
+    )
+    entry.add_to_hass(hass)
+
+    registry = er.async_get(hass)
+    # Legacy entity that v5.0.0 (#255) renamed to select.*_battery_mode.
+    legacy = registry.async_get_or_create(
+        domain="select",
+        platform=DOMAIN,
+        unique_id="plant_1_dev_uuid_charge_discharge_command",
+        config_entry=entry,
+    )
+    # A live entity that must be preserved.
+    keep = registry.async_get_or_create(
+        domain="select",
+        platform=DOMAIN,
+        unique_id="plant_1_dev_uuid_battery_mode",
+        config_entry=entry,
+    )
+    # An unrelated platform (e.g. a Zigbee entity attached to the same entry via HA
+    # weirdness) must not be touched by our platform-scoped sweep.
+    foreign = registry.async_get_or_create(
+        domain="select",
+        platform="zha",
+        unique_id="something_charge_discharge_command",
+        config_entry=entry,
+    )
+
+    result = await async_migrate_entry(hass, entry)
+
+    assert result is True
+    assert entry.version == 4
+    assert registry.async_get(legacy.entity_id) is None
+    assert registry.async_get(keep.entity_id) is not None
+    assert registry.async_get(foreign.entity_id) is not None
+
+
+@pytest.mark.asyncio
+async def test_v3_to_v4_no_legacy_entities_is_noop(hass):
+    """v3→v4 with a clean registry just bumps the version without changes."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={CONF_TRANSPORT: TRANSPORT_CLOUD_ONLY, "app_key": "k"},
+        version=3,
+        unique_id="test_app_id",
+    )
+    entry.add_to_hass(hass)
+
+    result = await async_migrate_entry(hass, entry)
+
+    assert result is True
+    assert entry.version == 4

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -127,6 +127,40 @@ def test_battery_soc_empty_string_unit_gets_percent():
     assert sensor._attr_native_unit_of_measurement == "%"
 
 
+@pytest.mark.parametrize(
+    "raw, expected",
+    [
+        ("0.95", 95.0),  # SBH250-V11 plant returns a 0–1 fraction (#314)
+        ("0.5", 50.0),
+        ("1.0", 100.0),  # exactly 1.0 stays in the fraction bracket -> full battery
+        ("0", 0.0),  # empty battery, no scaling either way
+    ],
+)
+def test_battery_soc_fraction_scaled_to_percent(raw, expected):
+    """SOC reported as a 0–1 fraction is rescaled to a real percentage (#314).
+
+    Sungrow's iSolarCloud returns ``battery_level_soc`` (83252) as a 0–1 fraction on
+    some plants (SBH250-V11) instead of the usual 0–100. Because we already force the
+    unit to ``%`` for BATTERY sensors (#228), the raw fraction otherwise renders as
+    ``0.95 %``.
+    """
+    point = {"id": "83252", "code": "battery_level_soc", "value": raw, "unit": ""}
+    coordinator = _coord_with_devices([], data={"battery_level_soc": point})
+    sensor = SungrowSensor(coordinator, "battery_level_soc", "123", "Plant", point)
+    assert sensor._attr_device_class == SensorDeviceClass.BATTERY
+    assert sensor._attr_native_unit_of_measurement == "%"
+    assert sensor.native_value == expected
+
+
+@pytest.mark.parametrize("raw, expected", [("95", 95.0), ("100", 100.0), ("42.5", 42.5)])
+def test_battery_soc_percent_form_unchanged(raw, expected):
+    """SOC already in 0–100 percent form (>1) is passed through untouched (#314)."""
+    point = {"id": "83252", "code": "battery_level_soc", "value": raw, "unit": "%"}
+    coordinator = _coord_with_devices([], data={"battery_level_soc": point})
+    sensor = SungrowSensor(coordinator, "battery_level_soc", "123", "Plant", point)
+    assert sensor.native_value == expected
+
+
 def test_power_fraction_gets_gauge_icon():
     """A per-code override gives power_fraction a gauge icon, not the solar fallback."""
     point = {"code": "power_fraction", "value": "0.83", "unit": ""}

--- a/tests/test_transport_constants.py
+++ b/tests/test_transport_constants.py
@@ -23,6 +23,6 @@ def test_transport_modbus_only_value():
     assert TRANSPORT_MODBUS_ONLY == "modbus_only"
 
 
-def test_config_flow_version_is_3():
-    """SungrowConfigFlow.VERSION is 3 after the breaking migration."""
-    assert SungrowConfigFlow.VERSION == 3
+def test_config_flow_version_is_current():
+    """SungrowConfigFlow.VERSION reflects the latest schema (v3→v4 legacy sweep, #314)."""
+    assert SungrowConfigFlow.VERSION == 4


### PR DESCRIPTION
Two follow-ups from https://github.com/KRoperUK/sungrow-hass/issues/314 after v5.7.0-rc.6 unblocked the local SH10RS setup for @IanS58.

### 1. Cloud battery SOC arriving as a `0.95` fraction

`sensor.*_battery_state_of_charge` (plant point `83252 battery_level_soc`) came back from iSolarCloud as a **0–1 fraction** on this SBH250-V11 plant. Since #228 forces `%` on any BATTERY-classed sensor so HA accepts it, the raw `0.95` rendered as **`0.95 %`** instead of `95 %`.

Fix: in `SungrowSensor.native_value`, when the classification is BATTERY and the value fits the fraction shape (`0 < value ≤ 1.0`), rescale by ×100. Values already in 0–100 form (>1) are passed through untouched.

Tested cases:

| raw       | unit | expected |
| --------- | ---- | -------- |
| `"0.95"`  | `""` | `95.0`   |
| `"0.5"`   | `""` | `50.0`   |
| `"1.0"`   | `""` | `100.0`  |
| `"0"`     | `""` | `0.0`    |
| `"95"`    | `%`  | `95.0`   |
| `"100"`   | `%`  | `100.0`  |
| `"42.5"`  | `%`  | `42.5`   |

### 2. Stale `select.*_charge_discharge_command`

v5.0.0 (#255) renamed `select.*_charge_discharge_command` → `select.*_battery_mode`, but HA leaves the old registry row behind indefinitely — so upgraded installs saw the old entity permanently `unavailable`.

Fix: bump the config-entry schema from **v3 → v4** and, during that migration, remove any entities on this integration whose `unique_id` ends in `_charge_discharge_command`. Idempotent (`v3→v4` only fires once per entry), platform-scoped (`entity.platform == DOMAIN`), unique-id-suffix scoped so nothing else is touched.

### Tested

- `pytest tests/` — 770 passed
- `ruff check` / `ruff format --check` — clean
- `mypy` (strict) — clean

Refs: #314, #228, #255