### PR TITLE
fix(config_flow): normalize and validate the OAuth redirect URI

### DIFF
--- a/custom_components/sungrow/config_flow.py
+++ b/custom_components/sungrow/config_flow.py
@@ -41,6 +41,7 @@ from .const import (
     TRANSPORT_CLOUD_USER,
     TRANSPORT_MODBUS_ONLY,
 )
+from .oauth_view import OAUTH_CALLBACK_PATH
 
 # Try to import pysolarcloud, handle if missing gracefully for development
 try:
@@ -58,6 +59,56 @@ _LOGGER = logging.getLogger(__name__)
 # can be slow — a redirect that lands within this window completes the flow
 # automatically even if the user has already reached the manual-entry form.
 CALLBACK_WAIT_TIMEOUT = 300
+
+
+def _normalize_redirect_uri(raw: str | None) -> str | None:
+    """Return a redirect URI whose path is the OAuth callback, or ``None`` if unfixable.
+
+    iSolarCloud must redirect the user back to Home Assistant's OAuth callback view,
+    which is registered at :data:`OAUTH_CALLBACK_PATH` (``/api/sungrow_hass/callback``).
+    Users occasionally paste just their Home Assistant base URL into the ``redirect_uri``
+    field (e.g. ``http://192.168.0.218:8123``), which sends iSolarCloud to the HA
+    homepage instead of the callback endpoint and silently drops the ``code`` query
+    parameter (#340).
+
+    Rules applied here:
+
+    - Whitespace is stripped.
+    - Trailing slashes on the base URL are collapsed.
+    - If the URI already ends with :data:`OAUTH_CALLBACK_PATH`, it is returned as-is.
+    - If it looks like a bare base URL (has a scheme and host, no path or just ``/``),
+      the callback path is appended.
+    - Anything else — a URI with an *incorrect* non-empty path, a value missing the
+      scheme, or an empty string — is refused by returning ``None`` so the caller can
+      surface a clear validation error rather than silently sending iSolarCloud a
+      URI that would misroute the callback.
+    """
+    if raw is None:
+        return None
+    text = raw.strip()
+    if not text:
+        return None
+    # Require a scheme so we never silently accept ``example.com`` (no scheme -> Sungrow
+    # would reject the redirect anyway, but the failure would be far from the input).
+    if "://" not in text:
+        return None
+    if text.endswith(OAUTH_CALLBACK_PATH):
+        return text
+    # Split scheme + rest, then split host + path.
+    scheme, rest = text.split("://", 1)
+    if "/" in rest:
+        host, path = rest.split("/", 1)
+        path = "/" + path
+    else:
+        host = rest
+        path = ""
+    # Accept bare base URLs (``http://host:port`` or ``http://host:port/``) and auto-
+    # append the callback path. Reject anything with a non-empty, non-slash path that
+    # doesn't end in the callback — that's a mis-configuration a user should fix
+    # deliberately, not one we should paper over.
+    if path in ("", "/"):
+        return f"{scheme}://{host}{OAUTH_CALLBACK_PATH}"
+    return None
 
 
 def _parse_winet_properties(props: dict[str, Any]) -> tuple[str | None, str | None]:
@@ -148,16 +199,22 @@ class SungrowConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         self._is_reconfigure = True
         self._transport = transport
 
+        errors: dict[str, str] = {}
         if user_input is not None:
-            # Preserve the App ID (identity) and drop stale tokens — we re-authorize.
-            self.init_info = {**entry.data, **user_input}
-            self.init_info.pop("tokens", None)
-            # Start a fresh Auth client for the (possibly changed) credentials.
-            self.auth_client = None
-            # For cloud_modbus: collect an updated modbus host before re-authorizing.
-            if transport == TRANSPORT_CLOUD_MODBUS:
-                return await self.async_step_reconfigure_modbus_host()
-            return await self.async_step_auth()
+            fixed_uri = _normalize_redirect_uri(user_input.get(CONF_REDIRECT_URI))
+            if fixed_uri is None:
+                errors[CONF_REDIRECT_URI] = "invalid_redirect_uri"
+            else:
+                user_input = {**user_input, CONF_REDIRECT_URI: fixed_uri}
+                # Preserve the App ID (identity) and drop stale tokens — we re-authorize.
+                self.init_info = {**entry.data, **user_input}
+                self.init_info.pop("tokens", None)
+                # Start a fresh Auth client for the (possibly changed) credentials.
+                self.auth_client = None
+                # For cloud_modbus: collect an updated modbus host before re-authorizing.
+                if transport == TRANSPORT_CLOUD_MODBUS:
+                    return await self.async_step_reconfigure_modbus_host()
+                return await self.async_step_auth()
 
         current = entry.data
         # Build the schema dynamically: include App ID when the entry is missing it
@@ -175,6 +232,7 @@ class SungrowConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         return self.async_show_form(
             step_id="reconfigure",
             data_schema=vol.Schema(schema_fields),
+            errors=errors,
         )
 
     async def async_step_reconfigure_modbus_host(self, user_input: dict[str, Any] | None = None) -> ConfigFlowResult:
@@ -332,23 +390,32 @@ class SungrowConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         errors: dict[str, str] = {}
 
         if user_input is not None:
-            self.init_info = user_input
-            await self.async_set_unique_id(str(user_input[CONF_APP_ID]))
-            self._abort_if_unique_id_configured()
+            # Normalise / validate the redirect URI: iSolarCloud drops the auth code if
+            # it redirects anywhere other than the OAuth callback view (#340). Auto-fix
+            # obvious bare-host inputs; otherwise reject with a clear error so the user
+            # updates BOTH this field and the developer-portal registration.
+            fixed_uri = _normalize_redirect_uri(user_input.get(CONF_REDIRECT_URI))
+            if fixed_uri is None:
+                errors[CONF_REDIRECT_URI] = "invalid_redirect_uri"
+            else:
+                user_input = {**user_input, CONF_REDIRECT_URI: fixed_uri}
+                self.init_info = user_input
+                await self.async_set_unique_id(str(user_input[CONF_APP_ID]))
+                self._abort_if_unique_id_configured()
 
-            # If hybrid mode, collect the Modbus host next.
-            if self._transport == TRANSPORT_CLOUD_MODBUS:
-                return await self.async_step_modbus_host()
+                # If hybrid mode, collect the Modbus host next.
+                if self._transport == TRANSPORT_CLOUD_MODBUS:
+                    return await self.async_step_modbus_host()
 
-            # Create the hub immediately, before authorizing. Setting up this
-            # token-less entry runs async_setup — which registers the OAuth
-            # callback view — and then raises ConfigEntryAuthFailed, so Home
-            # Assistant starts a reauth flow to finish authorization.
-            data = {**user_input, CONF_TRANSPORT: self._transport or TRANSPORT_CLOUD_ONLY}
-            return self.async_create_entry(
-                title=f"Sungrow {user_input[CONF_APP_ID]}",
-                data=data,
-            )
+                # Create the hub immediately, before authorizing. Setting up this
+                # token-less entry runs async_setup — which registers the OAuth
+                # callback view — and then raises ConfigEntryAuthFailed, so Home
+                # Assistant starts a reauth flow to finish authorization.
+                data = {**user_input, CONF_TRANSPORT: self._transport or TRANSPORT_CLOUD_ONLY}
+                return self.async_create_entry(
+                    title=f"Sungrow {user_input[CONF_APP_ID]}",
+                    data=data,
+                )
 
         # Attempt to automatically detect the callback URL
         try:
@@ -356,7 +423,7 @@ class SungrowConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         except Exception:
             base_url = "http://homeassistant.local:8123"  # Fallback
 
-        default_redirect = f"{base_url}/api/sungrow_hass/callback"
+        default_redirect = f"{base_url}{OAUTH_CALLBACK_PATH}"
 
         self.context["title_placeholders"] = {"app_id": "YourAppID"}
 

--- a/custom_components/sungrow/oauth_view.py
+++ b/custom_components/sungrow/oauth_view.py
@@ -18,11 +18,18 @@ from .const import DOMAIN
 _LOGGER = logging.getLogger(__name__)
 
 
+# Path segment iSolarCloud must redirect back to on Home Assistant. The full
+# redirect URI (what the user enters in the config flow AND registers in the
+# developer portal) is ``<HA base URL>{OAUTH_CALLBACK_PATH}``. Shared with
+# config_flow.py so the two never drift (#340).
+OAUTH_CALLBACK_PATH = "/api/sungrow_hass/callback"
+
+
 class SungrowAuthCallbackView(HomeAssistantView):
     """Sungrow Authorization Callback View."""
 
     requires_auth = False
-    url = "/api/sungrow_hass/callback"
+    url = OAUTH_CALLBACK_PATH
     name = "api:sungrow_hass:callback"
 
     @staticmethod

--- a/custom_components/sungrow/strings.json
+++ b/custom_components/sungrow/strings.json
@@ -97,6 +97,7 @@
       "host_unreachable": "The WiNet-S host is unreachable on port 502. Check the IP and ensure the dongle is online.",
       "invalid_auth": "Invalid authentication",
       "invalid_extra_measure_points": "Extra measure points must be in the form point_id=code, comma separated",
+      "invalid_redirect_uri": "The Redirect URI must end with /api/sungrow_hass/callback. Update it here AND in the iSolarCloud developer portal so both match — otherwise iSolarCloud redirects to the Home Assistant homepage and the authorization code is lost.",
       "unknown": "Unexpected error"
     },
     "abort": {

--- a/custom_components/sungrow/translations/cy.json
+++ b/custom_components/sungrow/translations/cy.json
@@ -97,6 +97,7 @@
       "host_unreachable": "The WiNet-S host is unreachable on port 502. Check the IP and ensure the dongle is online.",
       "invalid_auth": "Dilysiad annilys",
       "invalid_extra_measure_points": "Rhaid i bwyntiau mesur ychwanegol fod ar ffurf point_id=code, wedi'u gwahanu gan atalnodau",
+      "invalid_redirect_uri": "Rhaid i'r URI ailgyfeirio orffen gyda /api/sungrow_hass/callback. Diweddara ef yma AC yn y porth datblygwyr iSolarCloud fel bod y ddau yn cydweddu — fel arall mae iSolarCloud yn ailgyfeirio i dudalen gartref Home Assistant a chollir y cod awdurdodi.",
       "unknown": "Gwall annisgwyl"
     },
     "abort": {

--- a/custom_components/sungrow/translations/de.json
+++ b/custom_components/sungrow/translations/de.json
@@ -97,6 +97,7 @@
       "host_unreachable": "The WiNet-S host is unreachable on port 502. Check the IP and ensure the dongle is online.",
       "invalid_auth": "Ungültige Authentifizierung",
       "invalid_extra_measure_points": "Zusätzliche Messpunkte müssen im Format point_id=code, durch Kommata getrennt, angegeben werden",
+      "invalid_redirect_uri": "Die Redirect-URI muss auf /api/sungrow_hass/callback enden. Passe sie hier UND im iSolarCloud-Entwicklerportal so an, dass beide identisch sind — sonst leitet iSolarCloud auf die Home-Assistant-Startseite um und der Autorisierungscode geht verloren.",
       "unknown": "Unerwarteter Fehler"
     },
     "abort": {

--- a/custom_components/sungrow/translations/en.json
+++ b/custom_components/sungrow/translations/en.json
@@ -97,6 +97,7 @@
       "host_unreachable": "The WiNet-S host is unreachable on port 502. Check the IP and ensure the dongle is online.",
       "invalid_auth": "Invalid authentication",
       "invalid_extra_measure_points": "Extra measure points must be in the form point_id=code, comma separated",
+      "invalid_redirect_uri": "The Redirect URI must end with /api/sungrow_hass/callback. Update it here AND in the iSolarCloud developer portal so both match — otherwise iSolarCloud redirects to the Home Assistant homepage and the authorization code is lost.",
       "unknown": "Unexpected error"
     },
     "abort": {

--- a/custom_components/sungrow/translations/es.json
+++ b/custom_components/sungrow/translations/es.json
@@ -97,6 +97,7 @@
       "host_unreachable": "The WiNet-S host is unreachable on port 502. Check the IP and ensure the dongle is online.",
       "invalid_auth": "Autenticación no válida",
       "invalid_extra_measure_points": "Los puntos de medición adicionales deben tener el formato point_id=code, separados por comas",
+      "invalid_redirect_uri": "La URI de redirección debe terminar en /api/sungrow_hass/callback. Actualízala aquí Y en el portal de desarrollador de iSolarCloud para que coincidan — de lo contrario, iSolarCloud redirige a la página de inicio de Home Assistant y se pierde el código de autorización.",
       "unknown": "Error inesperado"
     },
     "abort": {

--- a/custom_components/sungrow/translations/fr.json
+++ b/custom_components/sungrow/translations/fr.json
@@ -97,6 +97,7 @@
       "host_unreachable": "The WiNet-S host is unreachable on port 502. Check the IP and ensure the dongle is online.",
       "invalid_auth": "Authentification non valide",
       "invalid_extra_measure_points": "Les points de mesure supplémentaires doivent être au format point_id=code, séparés par des virgules",
+      "invalid_redirect_uri": "L'URI de redirection doit se terminer par /api/sungrow_hass/callback. Mettez-la à jour ici ET dans le portail développeur iSolarCloud pour qu'elles correspondent — sinon iSolarCloud redirige vers la page d'accueil Home Assistant et le code d'autorisation est perdu.",
       "unknown": "Erreur inattendue"
     },
     "abort": {

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -1066,3 +1066,113 @@ async def test_cloud_user_invalid_auth_shows_error(hass: HomeAssistant):
     assert result3["type"] == data_entry_flow.FlowResultType.FORM
     assert result3["step_id"] == "cloud_user"
     assert result3["errors"]["base"] == "invalid_auth"
+
+
+# ---------------------------------------------------------------------------
+# Redirect URI validation (#340)
+# ---------------------------------------------------------------------------
+# iSolarCloud silently drops the ``code`` query parameter if it redirects to
+# anywhere other than the OAuth callback view. The config flow must therefore
+# either normalise or reject bare-host / wrong-path inputs before the user
+# clicks through the authorization page and finds it doesn't work.
+
+
+def test_normalize_redirect_uri_auto_appends_callback_to_bare_host():
+    """A bare Home Assistant base URL is auto-fixed to the callback path (#340)."""
+    from custom_components.sungrow.config_flow import _normalize_redirect_uri
+
+    # This is the exact shape a user pastes when they forget the callback path.
+    assert _normalize_redirect_uri("http://192.168.0.218:8123") == "http://192.168.0.218:8123/api/sungrow_hass/callback"
+    # Trailing slash is tolerated.
+    assert (
+        _normalize_redirect_uri("http://192.168.0.218:8123/") == "http://192.168.0.218:8123/api/sungrow_hass/callback"
+    )
+    # HTTPS + Nabu Casa style host.
+    assert (
+        _normalize_redirect_uri("https://abc-def.ui.nabu.casa")
+        == "https://abc-def.ui.nabu.casa/api/sungrow_hass/callback"
+    )
+
+
+def test_normalize_redirect_uri_leaves_correct_input_unchanged():
+    """A URI that already ends with the callback path is returned verbatim."""
+    from custom_components.sungrow.config_flow import _normalize_redirect_uri
+
+    assert (
+        _normalize_redirect_uri("http://192.168.0.218:8123/api/sungrow_hass/callback")
+        == "http://192.168.0.218:8123/api/sungrow_hass/callback"
+    )
+    # Whitespace around a correct URI is stripped.
+    assert (
+        _normalize_redirect_uri("  http://192.168.0.218:8123/api/sungrow_hass/callback  ")
+        == "http://192.168.0.218:8123/api/sungrow_hass/callback"
+    )
+
+
+def test_normalize_redirect_uri_rejects_wrong_path():
+    """A URI with a non-empty, non-callback path is refused (returns None)."""
+    from custom_components.sungrow.config_flow import _normalize_redirect_uri
+
+    # A user with a proxy path we can't auto-fix without silently changing behaviour.
+    assert _normalize_redirect_uri("http://192.168.0.218:8123/some/other/path") is None
+    # A callback path with typo — reject rather than paper over.
+    assert _normalize_redirect_uri("http://192.168.0.218:8123/api/sungrow/callback") is None
+
+
+def test_normalize_redirect_uri_rejects_missing_scheme():
+    """A URI without a scheme (host only) is refused."""
+    from custom_components.sungrow.config_flow import _normalize_redirect_uri
+
+    assert _normalize_redirect_uri("192.168.0.218:8123") is None
+    assert _normalize_redirect_uri("homeassistant.local") is None
+
+
+def test_normalize_redirect_uri_rejects_empty_and_none():
+    """None / empty / whitespace-only inputs return None."""
+    from custom_components.sungrow.config_flow import _normalize_redirect_uri
+
+    assert _normalize_redirect_uri(None) is None
+    assert _normalize_redirect_uri("") is None
+    assert _normalize_redirect_uri("   ") is None
+
+
+async def test_cloud_credentials_auto_appends_callback_path(hass: HomeAssistant):
+    """Submitting the cloud creds form with a bare host auto-fixes the redirect URI (#340)."""
+    result = await hass.config_entries.flow.async_init(DOMAIN, context={"source": "user"})
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], user_input={CONF_TRANSPORT: TRANSPORT_CLOUD_ONLY}
+    )
+    assert result["step_id"] == "cloud_credentials"
+
+    bare = {
+        CONF_APP_KEY: "k",
+        CONF_APP_SECRET: "s",
+        CONF_APP_ID: "id_bare_redirect",
+        CONF_GATEWAY: "Europe",
+        CONF_REDIRECT_URI: "http://192.168.0.218:8123",  # missing callback path
+    }
+    result2 = await hass.config_entries.flow.async_configure(result["flow_id"], user_input=bare)
+    # A tokenless entry gets created — the callback path was appended, not rejected.
+    assert result2["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
+    assert result2["data"][CONF_REDIRECT_URI] == "http://192.168.0.218:8123/api/sungrow_hass/callback"
+
+
+async def test_cloud_credentials_rejects_wrong_path(hass: HomeAssistant):
+    """A redirect URI with an incorrect non-callback path shows the invalid_redirect_uri error."""
+    result = await hass.config_entries.flow.async_init(DOMAIN, context={"source": "user"})
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], user_input={CONF_TRANSPORT: TRANSPORT_CLOUD_ONLY}
+    )
+
+    bad = {
+        CONF_APP_KEY: "k",
+        CONF_APP_SECRET: "s",
+        CONF_APP_ID: "id_bad_redirect",
+        CONF_GATEWAY: "Europe",
+        CONF_REDIRECT_URI: "http://192.168.0.218:8123/oauth/callback",  # wrong path
+    }
+    result2 = await hass.config_entries.flow.async_configure(result["flow_id"], user_input=bad)
+    # Form re-shown with the invalid_redirect_uri error keyed on the redirect_uri field.
+    assert result2["type"] == data_entry_flow.FlowResultType.FORM
+    assert result2["step_id"] == "cloud_credentials"
+    assert result2["errors"] == {CONF_REDIRECT_URI: "invalid_redirect_uri"}


### PR DESCRIPTION
Closes #340.

## The bug

Graham (in #340) submitted a Redirect URI of `http://192.168.0.218:8123` — no path — during config flow setup. iSolarCloud honoured that URI verbatim, so after he approved the app it redirected him to the Home Assistant homepage and silently dropped the `code` query parameter. The flow stayed forever at *Waiting for authorization*.

Looking at Graham's authorize URL confirms the pattern:

```
https://auweb3.isolarcloud.com/#/authorized-app
    ?cloudId=7
    &applicationId=1599
    &redirectUrl=http://192.168.0.218:8123    ← should be …:8123/api/sungrow_hass/callback
```

The callback view is registered at `/api/sungrow_hass/callback` in HA and there's no way to relocate it, so any Redirect URI that doesn't end there breaks the flow. This is a config-time error we can catch.

## Fix

New helper `_normalize_redirect_uri()`:

| Input | Output | Reasoning |
|---|---|---|
| `http://host:8123` | `http://host:8123/api/sungrow_hass/callback` | **Auto-fixed** — this is the exact form of Graham's mistake |
| `http://host:8123/` | `http://host:8123/api/sungrow_hass/callback` | Auto-fixed |
| `https://x.ui.nabu.casa` | `https://x.ui.nabu.casa/api/sungrow_hass/callback` | Auto-fixed |
| `http://host:8123/api/sungrow_hass/callback` | unchanged | Already correct |
| `http://host:8123/some/other/path` | `None` → `invalid_redirect_uri` error | Custom non-empty path — reject rather than paper over a proxy misconfiguration |
| `host:8123` (no scheme) | `None` → error | iSolarCloud would fail anyway; catch it up front with a clear message |
| `""` / `None` | `None` → error | |

Wired into:

- **`async_step_cloud_credentials`** — initial setup path Graham hit.
- **`async_step_reconfigure`** — the "Reconfigure" flow so an existing entry can also be fixed.

The normalised URI is stored on the entry, so the token-exchange and any future re-auth use the same value the auth request did.

## Housekeeping

- New shared constant `OAUTH_CALLBACK_PATH` in `oauth_view.py`. The `HomeAssistantView.url` class attribute now points at it, so the validator and the actual view route can never drift on that path segment.
- `strings.json` + all five `translations/*.json` (`en/de/es/fr/cy`) gain the `invalid_redirect_uri` error string. The wording reminds users to update the developer portal registration too, because iSolarCloud enforces a byte-for-byte match on the token exchange.

## Tests (7 new)

- `_normalize_redirect_uri` — auto-append for bare hosts (with and without trailing slash, HTTP + HTTPS), unchanged for correct URIs, reject wrong path / missing scheme / empty / None.
- `async_step_cloud_credentials` auto-appends on submission and the CREATE_ENTRY payload carries the fixed URI.
- `async_step_cloud_credentials` re-shows the form with `invalid_redirect_uri` keyed on the `redirect_uri` field when a wrong-path URI is submitted.

## Docs

`docs/TROUBLESHOOTING.md` and `docs/installation.md` already emphasise that the URI must end with `/api/sungrow_hass/callback`, so no doc update needed. Users who ignore the docs are exactly the ones this validator catches.

## Verification

- `pytest tests/`: 777 passed, 4 deselected (7 new)
- `ruff check` / `ruff format --check`: clean
- `mypy`: no issues in 28 source files

Ready for review.