### PR TITLE
feat(modbus): ARM + DSP software version strings

### DIFF
--- a/custom_components/sungrow/measure_points_data.py
+++ b/custom_components/sungrow/measure_points_data.py
@@ -832,6 +832,10 @@ CODE_ALIASES: dict[str, str] = {
     "inverter_firmware_version": "Firmware Version",
     "communication_module_firmware_version": "Communication Module Firmware",
     "battery_firmware_version": "Battery Firmware Version",
+    # ARM + DSP subsystem software versions (#333). Populated on models
+    # that carry certification strings for their internal controllers.
+    "arm_software_version": "ARM Software Version",
+    "dsp_software_version": "DSP Software Version",
     # Per-device diagnostic codes whose acronyms/initialisms the generic
     # title-caser would mangle ("Mppt1", "Wlan", "Afci", "Dc", "Id").
     "mppt1_voltage": "MPPT1 Voltage",

--- a/custom_components/sungrow/modbus_registers.py
+++ b/custom_components/sungrow/modbus_registers.py
@@ -292,6 +292,12 @@ class ModbusPoint:
 # Register definitions validated against a live SG3.6RS; additional common
 # single/three-phase string points from the mkaiser SHx mapping (see module doc).
 SG_RS_INPUT_POINTS: tuple[ModbusPoint, ...] = (
+    # Certification / firmware version strings for the two internal
+    # subsystems on Sungrow inverters (ARM controller + DSP). Both are
+    # 15-register UTF-8 fields; empty on hardware that doesn't populate them,
+    # which _decode_string handles by simply omitting the point (#333).
+    ModbusPoint(4953, "arm_software_version", "string", 1, None, length=15),
+    ModbusPoint(4968, "dsp_software_version", "string", 1, None, length=15),
     # Sungrow packs the unit's serial in 10 registers of ASCII starting at wire
     # 4989 (doc 4990). Present on every family we've validated; low-address so
     # it merges into the first block.
@@ -323,6 +329,9 @@ SG_RS_INPUT_POINTS: tuple[ModbusPoint, ...] = (
 # Derived from the mkaiser SHx YAML mapping (MIT license) with on-the-wire
 # addresses and low-word-first 32-bit decoding.
 SH_RT_INPUT_POINTS: tuple[ModbusPoint, ...] = (
+    # ARM + DSP subsystem certification/firmware strings (see SG-RS map).
+    ModbusPoint(4953, "arm_software_version", "string", 1, None, length=15),
+    ModbusPoint(4968, "dsp_software_version", "string", 1, None, length=15),
     # Serial number — 10 registers of ASCII (see SG-RS map).
     ModbusPoint(4989, "inverter_serial", "string", 1, None, length=10),
     ModbusPoint(4999, "device_type_code", "u16", 1, None),
@@ -641,6 +650,9 @@ LOCAL_IDENTITY_CODES: frozenset[str] = frozenset(
         "inverter_firmware_version",
         "communication_module_firmware_version",
         "battery_firmware_version",
+        # Subsystem software strings — same diagnostic character (#333).
+        "arm_software_version",
+        "dsp_software_version",
     }
 )
 

--- a/tests/test_modbus.py
+++ b/tests/test_modbus.py
@@ -175,6 +175,67 @@ def test_block_bounds_includes_full_string_span():
     assert start + count == 5032  # s32 ends at 5030+2
 
 
+# ---------------------------------------------------------------------------
+# ARM + DSP subsystem software strings (#333)
+# ---------------------------------------------------------------------------
+# The register audit reconciled our SG-RS + SH-RT maps against mkaiser and
+# TCzerny. Both projects expose 15-register string fields at wires 4953
+# (ARM software) and 4968 (DSP software); we surface them as diagnostic
+# sensors that fall through the empty-string skip when unpopulated.
+
+
+@pytest.mark.parametrize("map_name", ["sg_rs", "sh_rt"])
+def test_arm_and_dsp_strings_present_in_family_maps(map_name):
+    """Both string points appear in the SG-RS and SH-RT input maps (#333)."""
+    from custom_components.sungrow.modbus_registers import REGISTER_MAPS
+
+    codes = {p.code: p for p in REGISTER_MAPS[map_name]}
+    for code, address, length in (
+        ("arm_software_version", 4953, 15),
+        ("dsp_software_version", 4968, 15),
+    ):
+        point = codes.get(code)
+        assert point is not None, f"{code} missing from {map_name}"
+        assert point.data_type == "string"
+        assert point.address == address
+        assert point.length == length
+
+
+def test_arm_and_dsp_strings_are_diagnostic():
+    """LOCAL_IDENTITY_CODES gates the sensor layer's DIAGNOSTIC categorisation (#333)."""
+    from custom_components.sungrow.modbus_registers import LOCAL_IDENTITY_CODES
+
+    assert "arm_software_version" in LOCAL_IDENTITY_CODES
+    assert "dsp_software_version" in LOCAL_IDENTITY_CODES
+
+
+def test_arm_and_dsp_strings_decode_from_realistic_bytes():
+    """A 15-register block round-trips into a printable version string."""
+    from custom_components.sungrow.modbus_registers import SG_RS_INPUT_POINTS
+
+    arm = next(p for p in SG_RS_INPUT_POINTS if p.code == "arm_software_version")
+    # "SAPPHIRE-H_01011.95.12" — mkaiser doc example, packed high-byte first.
+    text = "SAPPHIRE-H_01011.95.12"
+    padded = text.ljust(arm.length * 2, "\x00")  # 30 bytes total for 15 regs
+    registers = [(ord(padded[i]) << 8) | ord(padded[i + 1]) for i in range(0, arm.length * 2, 2)]
+    out = decode_registers((arm,), arm.address, registers)
+    assert out["arm_software_version"]["value"] == "SAPPHIRE-H_01011.95.12"
+    assert out["arm_software_version"]["unit"] is None
+    assert out["arm_software_version"]["source"] == "modbus"
+
+
+def test_sg_rs_low_block_still_fits_after_arm_dsp_addition():
+    """The SG-RS low block (4953..5035) stays comfortably under the 125-register cap (#333)."""
+    from custom_components.sungrow.modbus_registers import SG_RS_INPUT_POINTS
+
+    blocks = block_partitions(SG_RS_INPUT_POINTS)
+    # A single low block covers everything from ARM software to the last SG-RS
+    # numeric point. It must fit under 125 registers so pymodbus accepts it.
+    assert len(blocks) == 1
+    _, count = blocks[0]
+    assert count <= 125
+
+
 def test_block_bounds_covers_all_points_in_one_read():
     """block_bounds spans from the lowest address to past the highest (incl. 32-bit width)."""
     points = (


### PR DESCRIPTION
Refs #333.

## What

The register-catalog audit against mkaiser + TCzerny turned up two more identity strings both projects surface:

| Wire | Registers | Code | Notes |
|---|---|---|---|
| **4953** | 15 | `arm_software_version` | ARM subsystem software certification string |
| **4968** | 15 | `dsp_software_version` | DSP subsystem software certification string |

Both sit immediately before the `inverter_serial` at wire 4989 and the `device_type_code` at 4999, so they slot into the existing low block naturally. Present on both SG-RS and SH-RT families.

## Why now

Immediate diagnostic value: users filing issues can attach these strings so we can pinpoint the exact firmware they're running before poking at behaviour. Previously the only firmware identity we exposed over local Modbus was `inverter_firmware_version` (SH-RT only), leaving SG-RS users with nothing.

## Live-verified against real SG3.6RS + WiNet-S

Ran the probe script (`scripts/live_modbus_probe.py`, uncommitted) via SSH tunnel:

```
✓ arm_software_version: 'ARM_SUNSTONE-S_V11_V01_A'
✓ dsp_software_version: 'MDSP_SUNSTONE-S_V11_V01_A'
✓ Blocks: [(4953, 83)] — single 83-register block, well under the 125 cap
```

Both fields decode into meaningful printable strings — no NUL leakage, no partial reads.

## Wire-through

Zero new machinery needed thanks to #319 / #322 / #323:

- `_decode_string` already handles 15-register UTF-8 fields, empty/NUL skip, undecodable-byte tolerance.
- `LOCAL_IDENTITY_CODES` already drives `SensorEntity.entity_category = DIAGNOSTIC` for identity strings.
- `CODE_ALIASES` gives friendly display names (`ARM Software Version` / `DSP Software Version`) so users don't see the raw code.
- The 125-register cap from #319 is guaranteed by the parametric `test_every_register_map_partitions_within_modbus_cap` — a new regression test also pins the SG-RS block explicitly.

## Tests (5 new)

- Both codes are present in the SG-RS **and** SH-RT maps at the expected addresses/lengths.
- Both are members of `LOCAL_IDENTITY_CODES` (which is what gates DIAGNOSTIC categorisation on the sensor layer).
- Decode round-trip against the mkaiser doc example (`SAPPHIRE-H_01011.95.12`).
- SG-RS low block stays under 125 registers after the addition (regression pin).

## Verification

- `pytest tests/`: 775 passed, 4 deselected (5 new)
- `ruff check` / `ruff format --check`: clean
- `mypy`: no issues in 28 source files
- Live probe against real SG3.6RS: both strings decoded successfully

## Attribution

Register addresses transcribed from [mkaiser/Sungrow-SHx-Inverter-Modbus-Home-Assistant](https://github.com/mkaiser/Sungrow-SHx-Inverter-Modbus-Home-Assistant/blob/main/modbus_sungrow.yaml) `modbus_sungrow.yaml` and [TCzerny/ha-modbus-manager](https://github.com/TCzerny/ha-modbus-manager/blob/main/custom_components/modbus_manager/device_templates/sungrow_sg_dynamic.yaml) `sungrow_sg_dynamic.yaml` (both MIT).

## Remaining #333 audit items (not this PR)

- `protocol_version` at wire 4951 (u32) — needs a decoder that formats `0x01015300` → `"V1.1.53"` per TCzerny's note; skipped here to keep this PR string-only.
- DTSU666-20 meter channel 2, BDC-side (voltage / current / temperature), extra fault-status bitfields.

These are worth their own follow-up once someone with the relevant hardware volunteers to live-verify.