### PR TITLE
feat(modbus): Sungrow protocol version diagnostic sensor

### DIFF
--- a/custom_components/sungrow/measure_points_data.py
+++ b/custom_components/sungrow/measure_points_data.py
@@ -836,6 +836,8 @@ CODE_ALIASES: dict[str, str] = {
     # that carry certification strings for their internal controllers.
     "arm_software_version": "ARM Software Version",
     "dsp_software_version": "DSP Software Version",
+    # Sungrow Modbus protocol version (BCD-packed u32 at wire 4951; #333).
+    "protocol_version": "Modbus Protocol Version",
     # Per-device diagnostic codes whose acronyms/initialisms the generic
     # title-caser would mangle ("Mppt1", "Wlan", "Afci", "Dc", "Id").
     "mppt1_voltage": "MPPT1 Voltage",

--- a/custom_components/sungrow/modbus_registers.py
+++ b/custom_components/sungrow/modbus_registers.py
@@ -241,11 +241,13 @@ class ModbusPoint:
 
     ``address`` is the on-the-wire register address (documented number - 1).
     ``code`` matches the cloud transport's measure-point code so both sources feed
-    the same entity. ``data_type`` is one of ``u16``/``s16``/``u32``/``s32``/``string``;
-    32-bit types consume two registers (low word first), string types consume
-    ``length`` registers with two ASCII bytes per register (high byte first).
-    The displayed value is the raw register value multiplied by ``scale`` (numeric)
-    or the decoded UTF-8 text (string).
+    the same entity. ``data_type`` is one of ``u16``/``s16``/``u32``/``s32``/
+    ``string``/``version_bcd``; 32-bit types consume two registers (low word
+    first), string types consume ``length`` registers with two ASCII bytes per
+    register (high byte first), and ``version_bcd`` is a two-register u32 whose
+    top three bytes decode as byte-BCD into ``"V<major>.<minor>.<patch>"``.
+    The displayed value is the raw register value multiplied by ``scale`` (numeric),
+    the decoded UTF-8 text (string), or the formatted version string (version_bcd).
 
     ``length`` is the width in 16-bit registers for a ``string`` point; ignored for
     numeric types. Set it to match the documented Sungrow field width (serial
@@ -276,14 +278,15 @@ class ModbusPoint:
     def register_count(self) -> int:
         """Number of 16-bit registers this point occupies.
 
-        Numeric types are one register (u16/s16) or two (u32/s32); string types
-        take ``length`` registers packing two ASCII bytes each.
+        Numeric 16-bit types (u16/s16) take one register, 32-bit types
+        (u32/s32/version_bcd) take two, string types take ``length`` registers
+        packing two ASCII bytes each.
         """
         if self.data_type == "string":
             if self.length <= 0:
                 raise ValueError(f"string point {self.code!r} needs length > 0")
             return self.length
-        return 2 if self.data_type in ("u32", "s32") else 1
+        return 2 if self.data_type in ("u32", "s32", "version_bcd") else 1
 
 
 # String-inverter (SG-RS) input registers — Modbus function 0x04. Codes are reused
@@ -292,6 +295,9 @@ class ModbusPoint:
 # Register definitions validated against a live SG3.6RS; additional common
 # single/three-phase string points from the mkaiser SHx mapping (see module doc).
 SG_RS_INPUT_POINTS: tuple[ModbusPoint, ...] = (
+    # Sungrow Modbus protocol version — byte-BCD packed into a u32 at wire
+    # 4951; ``version_bcd`` decodes it to "V<major>.<minor>.<patch>" (#333).
+    ModbusPoint(4951, "protocol_version", "version_bcd", 1, None),
     # Certification / firmware version strings for the two internal
     # subsystems on Sungrow inverters (ARM controller + DSP). Both are
     # 15-register UTF-8 fields; empty on hardware that doesn't populate them,
@@ -329,6 +335,8 @@ SG_RS_INPUT_POINTS: tuple[ModbusPoint, ...] = (
 # Derived from the mkaiser SHx YAML mapping (MIT license) with on-the-wire
 # addresses and low-word-first 32-bit decoding.
 SH_RT_INPUT_POINTS: tuple[ModbusPoint, ...] = (
+    # Sungrow Modbus protocol version (see SG-RS map).
+    ModbusPoint(4951, "protocol_version", "version_bcd", 1, None),
     # ARM + DSP subsystem certification/firmware strings (see SG-RS map).
     ModbusPoint(4953, "arm_software_version", "string", 1, None, length=15),
     ModbusPoint(4968, "dsp_software_version", "string", 1, None, length=15),
@@ -653,6 +661,8 @@ LOCAL_IDENTITY_CODES: frozenset[str] = frozenset(
         # Subsystem software strings — same diagnostic character (#333).
         "arm_software_version",
         "dsp_software_version",
+        # Modbus protocol version decoded from wire 4951 (#333).
+        "protocol_version",
     }
 )
 
@@ -719,6 +729,21 @@ def decode_registers(
                 "source": "modbus",
             }
             continue
+        if point.data_type == "version_bcd":
+            raw_u32 = registers[offset] + (registers[offset + 1] << 16)
+            version = _decode_version_bcd(raw_u32)
+            # A zero register or invalid BCD digits mean the register isn't
+            # populated on this firmware — skip the point rather than emitting
+            # something misleading like "V0.0.0".
+            if not version:
+                continue
+            out[point.code] = {
+                "code": point.code,
+                "value": version,
+                "unit": None,
+                "source": "modbus",
+            }
+            continue
         raw = _combine(registers, offset, point.data_type)
         if point.nan_value is not None and raw == point.nan_value:
             continue
@@ -763,6 +788,34 @@ def _decode_string(registers: list[int], offset: int, length: int) -> str:
     text = raw.decode("ascii", errors="ignore").rstrip("\x00").strip()
     # Strip any remaining control chars (some firmware zero-pads mid-string).
     return "".join(ch for ch in text if ch.isprintable() or ch.isspace()).strip()
+
+
+def _decode_version_bcd(raw: int) -> str:
+    """Decode a Sungrow byte-BCD version u32 into ``"V<major>.<minor>.<patch>"``.
+
+    Sungrow packs firmware / protocol version numbers as byte-BCD in the top three
+    bytes of a u32 with the bottom byte reserved. Each byte carries two decimal
+    digits: the high nibble is tens, the low nibble is units. Example from
+    TCzerny/ha-modbus-manager: ``0x01015300`` → ``"V1.1.53"``.
+
+    Returns an empty string if the register is zero (unpopulated) or contains a
+    nibble that isn't a valid BCD digit (0–9), so the caller can omit the point
+    rather than emit a misleading ``"V0.0.0"`` or a version with non-numeric
+    digits from a firmware that repurposed the register.
+    """
+    if raw == 0:
+        return ""
+    major = (raw >> 24) & 0xFF
+    minor = (raw >> 16) & 0xFF
+    patch = (raw >> 8) & 0xFF
+    parts: list[int] = []
+    for byte in (major, minor, patch):
+        high = (byte >> 4) & 0x0F
+        low = byte & 0x0F
+        if high > 9 or low > 9:
+            return ""  # not a valid BCD encoding — treat as unpopulated
+        parts.append(high * 10 + low)
+    return f"V{parts[0]}.{parts[1]}.{parts[2]}"
 
 
 def block_bounds(points: tuple[ModbusPoint, ...]) -> tuple[int, int]:

--- a/tests/test_modbus.py
+++ b/tests/test_modbus.py
@@ -225,15 +225,90 @@ def test_arm_and_dsp_strings_decode_from_realistic_bytes():
 
 
 def test_sg_rs_low_block_still_fits_after_arm_dsp_addition():
-    """The SG-RS low block (4953..5035) stays comfortably under the 125-register cap (#333)."""
+    """The SG-RS low block (4951..5035) stays comfortably under the 125-register cap (#333)."""
     from custom_components.sungrow.modbus_registers import SG_RS_INPUT_POINTS
 
     blocks = block_partitions(SG_RS_INPUT_POINTS)
-    # A single low block covers everything from ARM software to the last SG-RS
-    # numeric point. It must fit under 125 registers so pymodbus accepts it.
+    # A single low block covers everything from the protocol_version u32 at 4951
+    # to the last SG-RS numeric point. It must fit under 125 registers so
+    # pymodbus accepts it.
     assert len(blocks) == 1
     _, count = blocks[0]
     assert count <= 125
+
+
+# ---------------------------------------------------------------------------
+# Byte-BCD protocol version (#333)
+# ---------------------------------------------------------------------------
+# Wire 4951 is a u32 whose top three bytes are byte-BCD encoded — each byte
+# carries two decimal digits (high nibble = tens, low nibble = units).
+# Example from TCzerny: 0x01015300 → "V1.1.53".
+
+
+def test_version_bcd_register_count_is_two():
+    """A version_bcd point occupies two registers, like a u32."""
+    point = ModbusPoint(4951, "protocol_version", "version_bcd", 1, None)
+    assert point.register_count == 2
+
+
+def test_decode_version_bcd_matches_documented_example():
+    """0x01015300 decodes to 'V1.1.53' — the mkaiser/TCzerny worked example."""
+    point = ModbusPoint(0, "protocol_version", "version_bcd", 1, None)
+    # u32 low-word-first: 0x01015300 = low 0x5300, high 0x0101.
+    registers = [0x5300, 0x0101]
+    out = decode_registers((point,), 0, registers)
+    assert out["protocol_version"]["value"] == "V1.1.53"
+    assert out["protocol_version"]["unit"] is None
+    assert out["protocol_version"]["source"] == "modbus"
+
+
+def test_decode_version_bcd_omits_unpopulated_register():
+    """An all-zero register means the firmware doesn't expose the version."""
+    point = ModbusPoint(0, "protocol_version", "version_bcd", 1, None)
+    out = decode_registers((point,), 0, [0, 0])
+    assert "protocol_version" not in out
+
+
+def test_decode_version_bcd_rejects_invalid_bcd_digits():
+    """A byte whose nibble is > 9 isn't valid BCD — treat as unpopulated."""
+    point = ModbusPoint(0, "protocol_version", "version_bcd", 1, None)
+    # 0xAB as the "major" byte: high nibble A, low nibble B — not valid BCD.
+    # Low word 0x0000, high word 0xAB01 -> u32 = 0xAB010000.
+    registers = [0x0000, 0xAB01]
+    out = decode_registers((point,), 0, registers)
+    assert "protocol_version" not in out
+
+
+def test_decode_version_bcd_handles_zero_minor_and_patch():
+    """A version like V2.0.0 decodes even though minor and patch are zero bytes.
+
+    The all-zero *raw* is treated as unpopulated, but a non-zero raw with zero
+    minor / patch bytes must produce the correct version string.
+    """
+    point = ModbusPoint(0, "protocol_version", "version_bcd", 1, None)
+    # 0x02000000 -> V2.0.0 (major=0x02, minor=0x00, patch=0x00).
+    registers = [0x0000, 0x0200]
+    out = decode_registers((point,), 0, registers)
+    assert out["protocol_version"]["value"] == "V2.0.0"
+
+
+def test_protocol_version_present_in_both_family_maps():
+    """protocol_version appears in the SG-RS and SH-RT maps at wire 4951."""
+    from custom_components.sungrow.modbus_registers import REGISTER_MAPS
+
+    for family in ("sg_rs", "sh_rt"):
+        codes = {p.code: p for p in REGISTER_MAPS[family]}
+        point = codes.get("protocol_version")
+        assert point is not None, f"protocol_version missing from {family}"
+        assert point.data_type == "version_bcd"
+        assert point.address == 4951
+
+
+def test_protocol_version_is_diagnostic():
+    """protocol_version is in LOCAL_IDENTITY_CODES so it lands under Diagnostic."""
+    from custom_components.sungrow.modbus_registers import LOCAL_IDENTITY_CODES
+
+    assert "protocol_version" in LOCAL_IDENTITY_CODES
 
 
 def test_block_bounds_covers_all_points_in_one_read():


### PR DESCRIPTION
Refs #333. Third register-catalog audit slice after #344.

## What

Wire 4951 holds the Modbus protocol revision Sungrow uses to speak to us. It's a u32 whose **top three bytes are byte-BCD encoded** — each byte's high nibble is tens, low nibble is units, bottom byte reserved. TCzerny's worked example: `0x01015300` → `V1.1.53`.

Add `version_bcd` as a first-class `ModbusPoint.data_type` alongside `u16`/`s16`/`u32`/`s32`/`string`. Two registers (u32-width, low-word-first), decodes to `V<major>.<minor>.<patch>` via `_decode_version_bcd`. Empty registers and invalid BCD nibbles are treated as unpopulated so unsupported firmware doesn't leak misleading `V0.0.0` sensors.

Registered in both SG-RS and SH-RT maps at wire 4951 — one register before the ARM software string block landed in #344.

## Live-verified on real SG3.6RS + WiNet-S

```
✓ Family: 'sg_rs'
✓ Blocks: [(4951, 85)]                            ← single block, 85 registers < 125 cap
✓ protocol_version: 'V1.1.19'                     ← this PR
✓ arm_software_version: 'ARM_SUNSTONE-S_V11_V01_A' ← from #344
✓ dsp_software_version: 'MDSP_SUNSTONE-S_V11_V01_A' ← from #344
✓ inverter_serial: 'REDACTED'                  ← from #329
```

`V1.1.19` is a real, plausible Sungrow protocol revision — validates the low-word-first u32 combine + top-3-bytes byte-BCD decode against real hardware, not just TCzerny's synthetic doc example.

## Wire-through

- `ModbusPoint.register_count` extended: `version_bcd` counts as 2 registers, same as u32/s32.
- `LOCAL_IDENTITY_CODES` gains `protocol_version` so the sensor-layer DIAGNOSTIC gate from #323 applies.
- `CODE_ALIASES` adds "Modbus Protocol Version" so the display name beats the generic title-caser.
- Docstring on `ModbusPoint.data_type` now lists `version_bcd` explicitly.

## Tests (7 new)

- `register_count == 2` for a `version_bcd` point.
- Documented `0x01015300` decodes to `V1.1.53`.
- Zero register → point omitted (unpopulated).
- Invalid BCD nibble (e.g. `0xAB` where nibbles > 9) → point omitted, not `V<garbage>`.
- Non-zero raw with zero minor/patch (`0x02000000` → `V2.0.0`) still decodes.
- Point is present in both `sg_rs` and `sh_rt` maps at wire 4951.
- `protocol_version` ∈ `LOCAL_IDENTITY_CODES`.

## Verification

- `pytest tests/`: 789 passed, 4 deselected (7 new)
- `ruff check` / `ruff format --check`: clean
- `mypy`: no issues in 28 source files
- Live probe on SG3.6RS: `V1.1.19`

## Attribution

Address, packing convention, and the byte-BCD decode formula transcribed from [TCzerny/ha-modbus-manager `sungrow_sg_dynamic.yaml`](https://github.com/TCzerny/ha-modbus-manager/blob/main/custom_components/modbus_manager/device_templates/sungrow_sg_dynamic.yaml) (MIT), which cites the Sungrow protocol spec directly.

## Remaining #333 items

- **DTSU666-20 meter channel 2** — no hardware
- **BDC-side measurements** (V/I/T) — needs SH hardware  
- **Extra fault-status bitfields** — no clear consumer yet

At this point the identity/diagnostic side of the audit is done. What's left needs specific hardware access to verify.