### PR TITLE
fix: rc10 follow-ups (backfill mean_type, invalid_grant, cross-entry dedup)

### DIFF
--- a/custom_components/sungrow/backfill.py
+++ b/custom_components/sungrow/backfill.py
@@ -409,9 +409,18 @@ def build_series_target(
         source = DOMAIN
         is_external = True
 
+    # ``mean_type`` replaces the deprecated ``has_mean`` bool from HA 2026.11 onwards:
+    # power series need an ARITHMETIC mean over each hour, energy series don't need a
+    # mean at all (they use ``has_sum``). Both fields are set for backward compatibility
+    # with older HA that still consults ``has_mean``.
+    from homeassistant.components.recorder.models.statistics import StatisticMeanType
+
+    mean_type = StatisticMeanType.ARITHMETIC if kind == "power" else StatisticMeanType.NONE
+
     resolved_unit = unit if unit else _DEFAULT_UNIT[kind]
     metadata: StatisticMetaData = {  # type: ignore[typeddict-item]
         "has_mean": kind == "power",
+        "mean_type": mean_type,
         "has_sum": kind == "energy",
         "name": None,
         "source": source,

--- a/custom_components/sungrow/binary_sensor.py
+++ b/custom_components/sungrow/binary_sensor.py
@@ -20,6 +20,7 @@ from pysolarcloud.plants import DeviceType
 
 from . import build_device_info
 from .coordinator import SungrowPlantCoordinator
+from .device_helpers import unique_id_owned_by_other_entry
 from .measure_points import resolve_enum_value
 from .modbus_registers import POWER_FLOW_STATUS_BITS
 
@@ -108,6 +109,16 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry, async_add_e
             for entity in _build_binary_sensors(coordinator):
                 uid = entity.unique_id
                 if uid is None or uid in known_unique_ids:
+                    continue
+                # Skip silently when another Sungrow entry already owns this unique_id
+                # (multiple entries on the same plant) so we don't produce an ERROR log
+                # per entity, per coordinator tick.
+                if unique_id_owned_by_other_entry(hass, "binary_sensor", uid, entry.entry_id):
+                    _LOGGER.info(
+                        "Skipping binary sensor %s: already owned by another Sungrow entry",
+                        uid,
+                    )
+                    known_unique_ids.add(uid)
                     continue
                 known_unique_ids.add(uid)
                 new_entities.append(entity)

--- a/custom_components/sungrow/config_flow.py
+++ b/custom_components/sungrow/config_flow.py
@@ -888,6 +888,23 @@ class SungrowConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         except ClientError as e:
             _LOGGER.warning("Client connection error in async_step_finish: %s", e)
             return self._finish_error_result("cannot_connect")
+        except PySolarCloudException as e:
+            # ``invalid_grant`` means iSolarCloud rejected the authorization code —
+            # typically because it's already been used (double-click, browser retry)
+            # or has expired. Guide the user back to the manual form with a clear
+            # message instead of surfacing a generic "unknown" error. The exposed
+            # ``.error`` attribute carries the machine-readable code from the API
+            # response envelope (``str(e)`` only returns the description text).
+            if getattr(e, "error", None) == "invalid_grant":
+                _LOGGER.warning(
+                    "iSolarCloud rejected the authorization code as invalid_grant; "
+                    "showing the manual code-entry step so the user can retry."
+                )
+                # Clear the used code so the next submission gets a fresh one.
+                self._code = None
+                return self._finish_error_result("invalid_auth_code")
+            _LOGGER.warning("iSolarCloud error in async_step_finish: %s", e)
+            return self._finish_error_result("invalid_auth")
         except Exception as e:  # pylint: disable=broad-except
             _LOGGER.exception("Unexpected exception in async_step_finish: %s", e)
             return self._finish_error_result("unknown")

--- a/custom_components/sungrow/device_helpers.py
+++ b/custom_components/sungrow/device_helpers.py
@@ -11,6 +11,7 @@ from typing import Any
 
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import device_registry as dr
+from homeassistant.helpers import entity_registry as er
 from homeassistant.helpers.device_registry import DeviceInfo
 from pysolarcloud.plants import DeviceType
 
@@ -146,3 +147,32 @@ def find_related_cloud_plant_id(hass: HomeAssistant, serial: str) -> str | None:
                     if domain_key == DOMAIN:
                         return str(ident)
     return None
+
+
+def unique_id_owned_by_other_entry(
+    hass: HomeAssistant,
+    platform: str,
+    unique_id: str,
+    entry_id: str,
+) -> bool:
+    """Return True when ``unique_id`` is already registered under a *different* config entry.
+
+    HA's entity registry keys on ``(platform, domain, unique_id)``. When a user configures
+    two or more Sungrow cloud entries that share the same iSolarCloud plant (e.g. duplicate
+    accounts, migration in progress) each entry's ``_add_new_entities`` closure will try to
+    add the same dispatch/binary entities and the second registration produces a noisy
+    ``Platform sungrow does not generate unique IDs`` ERROR log per entity, per coordinator
+    tick. This helper lets the platforms skip an entity silently (INFO-level) when it is
+    already owned by another Sungrow entry, without touching the entry that *does* own it.
+
+    Ownership by the current entry (or by a stale/orphaned registry entry with no
+    ``config_entry_id``) still returns False so the entity is created as normal.
+    """
+    registry = er.async_get(hass)
+    existing_entity_id = registry.async_get_entity_id(platform, DOMAIN, unique_id)
+    if existing_entity_id is None:
+        return False
+    existing = registry.async_get(existing_entity_id)
+    if existing is None or existing.config_entry_id is None:
+        return False
+    return existing.config_entry_id != entry_id

--- a/custom_components/sungrow/number.py
+++ b/custom_components/sungrow/number.py
@@ -19,6 +19,7 @@ from pysolarcloud.control import Control
 from . import DispatchControl, build_device_info, select_dispatch_device
 from .const import DOMAIN
 from .coordinator import SungrowPlantCoordinator
+from .device_helpers import unique_id_owned_by_other_entry
 from .modbus_control import ModbusControlError
 from .model_specs import spec_for
 
@@ -261,6 +262,16 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry, async_add_e
             for entity in _build_numbers(coordinator, control):
                 uid = entity.unique_id
                 if uid is None or uid in known_unique_ids:
+                    continue
+                # Skip silently when another Sungrow entry already owns this unique_id
+                # (multiple entries on the same plant) so we don't produce an ERROR log
+                # per entity, per coordinator tick.
+                if unique_id_owned_by_other_entry(hass, "number", uid, entry.entry_id):
+                    _LOGGER.info(
+                        "Skipping dispatch number %s: already owned by another Sungrow entry",
+                        uid,
+                    )
+                    known_unique_ids.add(uid)
                     continue
                 known_unique_ids.add(uid)
                 new_entities.append(entity)

--- a/custom_components/sungrow/select.py
+++ b/custom_components/sungrow/select.py
@@ -28,6 +28,7 @@ from . import (
 )
 from .const import DOMAIN
 from .coordinator import SungrowPlantCoordinator
+from .device_helpers import unique_id_owned_by_other_entry
 from .modbus_control import ModbusControlError
 
 _LOGGER = logging.getLogger(__name__)
@@ -176,6 +177,16 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry, async_add_e
             for entity in _build_selects(coordinator, control):
                 uid = entity.unique_id
                 if uid is None or uid in known_unique_ids:
+                    continue
+                # Skip silently when another Sungrow entry already owns this unique_id
+                # (multiple entries on the same plant) so we don't produce an ERROR log
+                # per entity, per coordinator tick.
+                if unique_id_owned_by_other_entry(hass, "select", uid, entry.entry_id):
+                    _LOGGER.info(
+                        "Skipping dispatch select %s: already owned by another Sungrow entry",
+                        uid,
+                    )
+                    known_unique_ids.add(uid)
                     continue
                 known_unique_ids.add(uid)
                 new_entities.append(entity)

--- a/custom_components/sungrow/sensor.py
+++ b/custom_components/sungrow/sensor.py
@@ -23,6 +23,7 @@ from .const import (
     INVERTER_DIAGNOSTIC_POINTS,
 )
 from .coordinator import SungrowPlantCoordinator
+from .device_helpers import unique_id_owned_by_other_entry
 from .measure_points import (
     PERCENT_FRACTION_POINT_IDS,
     normalize_unit,
@@ -215,6 +216,16 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry, async_add_e
             for entity in _build_sensors(coordinator, console_url):
                 uid = entity.unique_id
                 if uid is None or uid in known_unique_ids:
+                    continue
+                # Skip silently when another Sungrow entry already owns this unique_id
+                # (multiple entries on the same plant) so we don't produce an ERROR log
+                # per entity, per coordinator tick.
+                if unique_id_owned_by_other_entry(hass, "sensor", uid, entry.entry_id):
+                    _LOGGER.info(
+                        "Skipping sensor %s: already owned by another Sungrow entry",
+                        uid,
+                    )
+                    known_unique_ids.add(uid)
                     continue
                 known_unique_ids.add(uid)
                 new_entities.append(entity)

--- a/custom_components/sungrow/strings.json
+++ b/custom_components/sungrow/strings.json
@@ -96,6 +96,7 @@
       "cannot_connect": "Failed to connect",
       "host_unreachable": "The WiNet-S host is unreachable on port 502. Check the IP and ensure the dongle is online.",
       "invalid_auth": "Invalid authentication",
+      "invalid_auth_code": "iSolarCloud rejected the authorization code — it may have already been used or expired. Open the authorization link above to get a fresh code, then paste it here (or paste the full redirect URL).",
       "invalid_extra_measure_points": "Extra measure points must be in the form point_id=code, comma separated",
       "invalid_redirect_uri": "The Redirect URI must end with /api/sungrow_hass/callback. Update it here AND in the iSolarCloud developer portal so both match — otherwise iSolarCloud redirects to the Home Assistant homepage and the authorization code is lost.",
       "unknown": "Unexpected error"

--- a/custom_components/sungrow/translations/cy.json
+++ b/custom_components/sungrow/translations/cy.json
@@ -96,6 +96,7 @@
       "cannot_connect": "Methwyd â chysylltu",
       "host_unreachable": "The WiNet-S host is unreachable on port 502. Check the IP and ensure the dongle is online.",
       "invalid_auth": "Dilysiad annilys",
+      "invalid_auth_code": "Gwrthododd iSolarCloud y cod awdurdodi — efallai ei fod eisoes wedi'i ddefnyddio neu wedi dod i ben. Agor y ddolen awdurdodi uchod i gael cod newydd, yna gludwch ef yma (neu gludwch yr URL ailgyfeirio llawn).",
       "invalid_extra_measure_points": "Rhaid i bwyntiau mesur ychwanegol fod ar ffurf point_id=code, wedi'u gwahanu gan atalnodau",
       "invalid_redirect_uri": "Rhaid i'r URI ailgyfeirio orffen gyda /api/sungrow_hass/callback. Diweddara ef yma AC yn y porth datblygwyr iSolarCloud fel bod y ddau yn cydweddu — fel arall mae iSolarCloud yn ailgyfeirio i dudalen gartref Home Assistant a chollir y cod awdurdodi.",
       "unknown": "Gwall annisgwyl"

--- a/custom_components/sungrow/translations/de.json
+++ b/custom_components/sungrow/translations/de.json
@@ -96,6 +96,7 @@
       "cannot_connect": "Verbindung fehlgeschlagen",
       "host_unreachable": "The WiNet-S host is unreachable on port 502. Check the IP and ensure the dongle is online.",
       "invalid_auth": "Ungültige Authentifizierung",
+      "invalid_auth_code": "iSolarCloud hat den Autorisierungscode abgelehnt — er wurde möglicherweise bereits verwendet oder ist abgelaufen. Öffne den Autorisierungslink oben, um einen neuen Code zu erhalten, und füge ihn hier ein (oder füge die vollständige Weiterleitungs-URL ein).",
       "invalid_extra_measure_points": "Zusätzliche Messpunkte müssen im Format point_id=code, durch Kommata getrennt, angegeben werden",
       "invalid_redirect_uri": "Die Redirect-URI muss auf /api/sungrow_hass/callback enden. Passe sie hier UND im iSolarCloud-Entwicklerportal so an, dass beide identisch sind — sonst leitet iSolarCloud auf die Home-Assistant-Startseite um und der Autorisierungscode geht verloren.",
       "unknown": "Unerwarteter Fehler"

--- a/custom_components/sungrow/translations/en.json
+++ b/custom_components/sungrow/translations/en.json
@@ -96,6 +96,7 @@
       "cannot_connect": "Failed to connect",
       "host_unreachable": "The WiNet-S host is unreachable on port 502. Check the IP and ensure the dongle is online.",
       "invalid_auth": "Invalid authentication",
+      "invalid_auth_code": "iSolarCloud rejected the authorization code — it may have already been used or expired. Open the authorization link above to get a fresh code, then paste it here (or paste the full redirect URL).",
       "invalid_extra_measure_points": "Extra measure points must be in the form point_id=code, comma separated",
       "invalid_redirect_uri": "The Redirect URI must end with /api/sungrow_hass/callback. Update it here AND in the iSolarCloud developer portal so both match — otherwise iSolarCloud redirects to the Home Assistant homepage and the authorization code is lost.",
       "unknown": "Unexpected error"

--- a/custom_components/sungrow/translations/es.json
+++ b/custom_components/sungrow/translations/es.json
@@ -96,6 +96,7 @@
       "cannot_connect": "No se pudo conectar",
       "host_unreachable": "The WiNet-S host is unreachable on port 502. Check the IP and ensure the dongle is online.",
       "invalid_auth": "Autenticación no válida",
+      "invalid_auth_code": "iSolarCloud rechazó el código de autorización — puede que ya se haya usado o haya caducado. Abre el enlace de autorización de arriba para obtener un código nuevo y pégalo aquí (o pega la URL completa de redirección).",
       "invalid_extra_measure_points": "Los puntos de medición adicionales deben tener el formato point_id=code, separados por comas",
       "invalid_redirect_uri": "La URI de redirección debe terminar en /api/sungrow_hass/callback. Actualízala aquí Y en el portal de desarrollador de iSolarCloud para que coincidan — de lo contrario, iSolarCloud redirige a la página de inicio de Home Assistant y se pierde el código de autorización.",
       "unknown": "Error inesperado"

--- a/custom_components/sungrow/translations/fr.json
+++ b/custom_components/sungrow/translations/fr.json
@@ -96,6 +96,7 @@
       "cannot_connect": "Échec de la connexion",
       "host_unreachable": "The WiNet-S host is unreachable on port 502. Check the IP and ensure the dongle is online.",
       "invalid_auth": "Authentification non valide",
+      "invalid_auth_code": "iSolarCloud a rejeté le code d'autorisation — il a peut-être déjà été utilisé ou expiré. Ouvrez le lien d'autorisation ci-dessus pour obtenir un nouveau code, puis collez-le ici (ou collez l'URL de redirection complète).",
       "invalid_extra_measure_points": "Les points de mesure supplémentaires doivent être au format point_id=code, séparés par des virgules",
       "invalid_redirect_uri": "L'URI de redirection doit se terminer par /api/sungrow_hass/callback. Mettez-la à jour ici ET dans le portail développeur iSolarCloud pour qu'elles correspondent — sinon iSolarCloud redirige vers la page d'accueil Home Assistant et le code d'autorisation est perdu.",
       "unknown": "Erreur inattendue"

--- a/tests/test_backfill.py
+++ b/tests/test_backfill.py
@@ -68,6 +68,8 @@ def test_select_backfill_points_picks_energy_and_power():
 
 def test_build_series_target_energy_metadata_shape():
     """Energy live series -> recorder source, has_sum, unit from the live entity (7.1, 7.5)."""
+    from homeassistant.components.recorder.models.statistics import StatisticMeanType
+
     target = build_series_target(
         plant_id="123",
         point_code="total_yield",
@@ -83,6 +85,7 @@ def test_build_series_target_energy_metadata_shape():
         is_external=False,
         metadata={
             "has_mean": False,
+            "mean_type": StatisticMeanType.NONE,
             "has_sum": True,
             "name": None,
             "source": "recorder",
@@ -93,7 +96,9 @@ def test_build_series_target_energy_metadata_shape():
 
 
 def test_build_series_target_power_metadata_shape():
-    """Power series -> has_mean, W default unit when the live entity supplies none (7.2)."""
+    """Power series -> has_mean + ARITHMETIC mean_type, W default unit when live entity has none (7.2)."""
+    from homeassistant.components.recorder.models.statistics import StatisticMeanType
+
     target = build_series_target(
         plant_id="123",
         point_code="power",
@@ -102,6 +107,7 @@ def test_build_series_target_power_metadata_shape():
         unit=None,
     )
     assert target.metadata["has_mean"] is True
+    assert target.metadata["mean_type"] == StatisticMeanType.ARITHMETIC
     assert target.metadata["has_sum"] is False
     assert target.unit == "W"
     assert target.metadata["unit_of_measurement"] == "W"

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -303,6 +303,33 @@ async def test_finish_step_missing_code(hass: HomeAssistant, mock_auth):
     assert result["reason"] == "missing_code"
 
 
+async def test_finish_step_invalid_grant_shows_manual_form(hass: HomeAssistant, mock_auth):
+    """iSolarCloud ``invalid_grant`` bounces to the manual code form with a targeted error.
+
+    Regression from rc10 (v5.7.0): the code-already-used case was falling through to the
+    generic ``Exception`` handler and surfacing as ``"unknown"``, hiding the real cause
+    from users staring at a stuck flow.
+    """
+    from pysolarcloud import PySolarCloudException
+
+    flow = _flow_at_finish(hass)
+    flow._code = "one-time-code"
+    flow.auth_client = mock_auth
+    flow.auth_client.async_authorize = AsyncMock(
+        side_effect=PySolarCloudException(
+            {"error": "invalid_grant", "error_description": "Invalid authorization code: XYZ", "result_code": "2"}
+        )
+    )
+
+    result = await flow.async_step_finish()
+
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
+    assert result["step_id"] == "auth_manual"
+    assert result["errors"] == {"base": "invalid_auth_code"}
+    # The used code has been cleared so the next submission doesn't re-send the same one.
+    assert flow._code is None
+
+
 async def test_finish_leaves_modbus_only_entry_alone(hass: HomeAssistant, mock_auth):
     """Cloud OAuth finish creates a pure cloud entry and does not merge/remove local."""
     from custom_components.sungrow.const import CONF_MODBUS_HOST, CONF_MODEL, CONF_TRANSPORT, TRANSPORT_MODBUS_ONLY

--- a/tests/test_cross_entry_dedup.py
+++ b/tests/test_cross_entry_dedup.py
@@ -1,0 +1,166 @@
+"""Cross-entry ``unique_id`` collision handling for the dispatch/sensor platforms.
+
+When a user configures more than one Sungrow entry that covers the same iSolarCloud
+plant (duplicate accounts, migration in progress, ...), each entry's platform setup
+tries to add entities with the same ``unique_id``. HA's entity registry keys on
+``(platform, domain, unique_id)`` so the second attempt is rejected with an
+``ERROR`` level ``Platform sungrow does not generate unique IDs`` log per entity,
+per coordinator tick.
+
+The platforms filter these out in their ``_add_new_entities`` closures via
+:func:`custom_components.sungrow.device_helpers.unique_id_owned_by_other_entry`
+and log a single ``INFO`` line instead. These tests cover both the helper and each
+platform's use of it.
+"""
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import entity_registry as er
+from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+from custom_components.sungrow import SungrowData
+from custom_components.sungrow.binary_sensor import async_setup_entry as binary_sensor_setup_entry
+from custom_components.sungrow.const import DOMAIN
+from custom_components.sungrow.device_helpers import unique_id_owned_by_other_entry
+from custom_components.sungrow.number import async_setup_entry as number_setup_entry
+from custom_components.sungrow.select import async_setup_entry as select_setup_entry
+
+from .conftest import MOCK_CONFIG_DATA
+
+# ---------------------------------------------------------------------------
+# Helper unit tests
+# ---------------------------------------------------------------------------
+
+
+async def test_unique_id_owned_by_other_entry_no_existing_returns_false(hass: HomeAssistant):
+    """No existing entry: the helper returns False so the caller adds the entity."""
+    assert not unique_id_owned_by_other_entry(hass, "number", "12345_dev_charge_discharge_power", "entry-a")
+
+
+async def test_unique_id_owned_by_other_entry_same_entry_returns_false(hass: HomeAssistant):
+    """The current entry owning the id is not a collision — the caller adds normally."""
+    entry = MockConfigEntry(domain=DOMAIN, data=MOCK_CONFIG_DATA.copy())
+    entry.add_to_hass(hass)
+    registry = er.async_get(hass)
+    registry.async_get_or_create("number", DOMAIN, "12345_dev_charge_discharge_power", config_entry=entry)
+
+    assert not unique_id_owned_by_other_entry(hass, "number", "12345_dev_charge_discharge_power", entry.entry_id)
+
+
+async def test_unique_id_owned_by_other_entry_other_entry_returns_true(hass: HomeAssistant):
+    """A different entry already owning the id returns True — the caller skips silently."""
+    entry_a = MockConfigEntry(domain=DOMAIN, data=MOCK_CONFIG_DATA.copy(), title="A")
+    entry_a.add_to_hass(hass)
+    entry_b = MockConfigEntry(domain=DOMAIN, data=MOCK_CONFIG_DATA.copy(), title="B")
+    entry_b.add_to_hass(hass)
+    registry = er.async_get(hass)
+    registry.async_get_or_create("number", DOMAIN, "12345_dev_charge_discharge_power", config_entry=entry_a)
+
+    assert unique_id_owned_by_other_entry(hass, "number", "12345_dev_charge_discharge_power", entry_b.entry_id)
+
+
+async def test_unique_id_owned_by_other_entry_orphan_returns_false(hass: HomeAssistant):
+    """An entity with no ``config_entry_id`` (orphaned) does not count as a foreign owner.
+
+    Users can end up with orphaned entries after a delete-without-clean flow; treating
+    them as foreign would prevent the entity from ever being re-created after cleanup.
+    """
+    registry = er.async_get(hass)
+    orphan = registry.async_get_or_create("number", DOMAIN, "12345_dev_charge_discharge_power")
+    assert orphan.config_entry_id is None
+    assert not unique_id_owned_by_other_entry(hass, "number", "12345_dev_charge_discharge_power", "entry-b")
+
+
+async def test_unique_id_owned_by_other_entry_scoped_by_platform(hass: HomeAssistant):
+    """A collision on ``select`` doesn't shadow a fresh ``number`` unique_id (platform scoping)."""
+    entry_a = MockConfigEntry(domain=DOMAIN, data=MOCK_CONFIG_DATA.copy(), title="A")
+    entry_a.add_to_hass(hass)
+    registry = er.async_get(hass)
+    registry.async_get_or_create("select", DOMAIN, "12345_dev_battery_mode", config_entry=entry_a)
+
+    # Same unique_id, different platform — no cross-platform collision.
+    assert not unique_id_owned_by_other_entry(hass, "number", "12345_dev_battery_mode", "entry-b")
+
+
+# ---------------------------------------------------------------------------
+# Platform integration tests: a second entry with the same coordinator target
+# device must not attempt to add already-registered entities.
+# ---------------------------------------------------------------------------
+
+
+def _make_coordinator(plant_id: str, devices: list[dict], *, has_battery: bool = True):
+    coordinator = MagicMock()
+    coordinator.plant_id = plant_id
+    coordinator.plant_name = "Test Plant"
+    coordinator.config_entry = MagicMock()
+    coordinator.last_update_success = True
+    coordinator.has_battery = has_battery
+    coordinator.forced_dispatch_duration_minutes = 0
+    coordinator.devices = devices
+    coordinator.dispatch_update_supported = True
+    coordinator.plants_service = MagicMock()  # cloud path for binary sensors
+    coordinator.data = {}
+    return coordinator
+
+
+def _seed_runtime_data(entry, devices, *, plant_id: str = "12345") -> None:
+    control = MagicMock()
+    control.async_update_parameters = AsyncMock(return_value=[])
+    control.async_heartbeat = AsyncMock()
+    coordinator = _make_coordinator(plant_id, devices)
+    entry.runtime_data = SungrowData(
+        coordinators=[coordinator],
+        control=control,
+        devices={plant_id: devices},
+    )
+
+
+@pytest.mark.parametrize(
+    ("platform", "setup_entry"),
+    [
+        ("number", number_setup_entry),
+        ("select", select_setup_entry),
+        ("binary_sensor", binary_sensor_setup_entry),
+    ],
+)
+async def test_second_entry_skips_entities_owned_by_first_entry(
+    hass: HomeAssistant, platform: str, setup_entry
+) -> None:
+    """A second entry on the same plant does not attempt to add already-owned entities.
+
+    Sets up entry A, records its unique_ids in the entity registry (owned by A), then
+    sets up entry B against the *same* coordinator target and asserts B produces no new
+    entities — the collision path is skipped silently rather than surfaced as an ERROR
+    from HA core's ``does not generate unique IDs`` guard.
+    """
+    devices = [{"uuid": "dev-uuid-1", "device_type": "ENERGY_STORAGE_SYSTEM", "device_name": "Inverter 1"}]
+
+    entry_a = MockConfigEntry(domain=DOMAIN, data=MOCK_CONFIG_DATA.copy(), title="A")
+    entry_a.add_to_hass(hass)
+    _seed_runtime_data(entry_a, devices)
+
+    added_a: list = []
+    await setup_entry(hass, entry_a, lambda entities: added_a.extend(entities))
+    assert added_a, f"{platform} entry A should create entities for the ESS device"
+
+    # Register A's unique_ids in the entity registry against entry A. Real HA setup does
+    # this via async_add_entities → EntityPlatform.async_add_entities; going through the
+    # entity registry directly keeps this a focused unit-scope test.
+    registry = er.async_get(hass)
+    for entity in added_a:
+        if entity.unique_id is None:
+            continue
+        registry.async_get_or_create(platform, DOMAIN, entity.unique_id, config_entry=entry_a)
+
+    entry_b = MockConfigEntry(domain=DOMAIN, data=MOCK_CONFIG_DATA.copy(), title="B")
+    entry_b.add_to_hass(hass)
+    _seed_runtime_data(entry_b, devices)
+
+    added_b: list = []
+    await setup_entry(hass, entry_b, lambda entities: added_b.extend(entities))
+    assert added_b == [], (
+        f"{platform} entry B should skip every unique_id already owned by entry A "
+        f"but was asked to add {[getattr(e, 'unique_id', None) for e in added_b]}"
+    )


### PR DESCRIPTION
Three fixes surfaced by running v5.7.0-rc10 on the dell-serve HA container against a live SG3.6RS. Each is a separate conventional-commit so release-please picks them up individually — **please MERGE, don't squash**, so the three `fix:` commits reach `main` intact.

## Commits

### 1. `fix(backfill): specify mean_type for HA 2026.11 compatibility` (`09c68e7`)
Recorder metadata now needs `mean_type` alongside `has_mean` (HA 2026.11). Power series get `StatisticMeanType.ARITHMETIC`, cumulative-energy series get `StatisticMeanType.NONE`. Two existing metadata-shape tests updated to assert the new key.

### 2. `fix(config_flow): catch OAuth invalid_grant gracefully` (`8b97774`)
An `invalid_grant` (used/expired auth code) was falling through to the broad `except Exception`, logging a full traceback and showing users "unknown". Now caught explicitly via `PySolarCloudException` and dispatched on the typed `.error` attribute (not `str(e)`, which returns only the description). The stored code is cleared so the retry gets a fresh one and the manual-entry form is shown with a new `invalid_auth_code` translation key across all 5 locales.

### 3. `fix(dispatch): skip cross-entry unique_id collisions cleanly` (`114c92a`)
Multiple Sungrow entries covering the same plant produce a stream of ERROR-level `Platform sungrow does not generate unique IDs` logs, one per entity per coordinator tick. A new `unique_id_owned_by_other_entry` helper in `device_helpers` consults the entity registry and returns True only when the id is owned by a *different* config entry (orphaned ids and current-entry ids stay creatable). Wired into the `_add_new_entities` closures in `number`, `select`, `binary_sensor`, and `sensor` so the collision is skipped silently with a single INFO log.

## Verification

- `.venv/bin/python -m pytest tests/` — **798 passed**
- `.venv/bin/ruff check custom_components/ tests/` — clean
- `.venv/bin/ruff format --check custom_components/ tests/` — clean
- `.venv/bin/mypy` — clean (28 source files)
- New tests: `tests/test_cross_entry_dedup.py` (8 tests: helper + parametrized platform integration)
- New test: `test_finish_step_invalid_grant_shows_manual_form` in `test_config_flow.py`
- Updated: 2 backfill metadata tests to assert `mean_type` presence

## Log-noise findings that motivated each commit
- **#1** — `StatisticMeanType` deprecation warning emitted by HA 2026.11-dev recorder.
- **#2** — Full traceback + "unknown" toast during OAuth callback retry.
- **#3** — Repeated `does not generate unique IDs` ERROR when three sungrow entries share one plant.
