### PR TITLE
chore: bump sungrow-isolarcloud to 0.15.0 + three small refactors

### DIFF
--- a/custom_components/sungrow/__init__.py
+++ b/custom_components/sungrow/__init__.py
@@ -315,7 +315,7 @@ async def _async_setup_modbus_only(hass: HomeAssistant, entry: SungrowConfigEntr
                 _LOGGER.debug("Modbus control support probe failed: %s", err)
                 coordinator.dispatch_update_supported = False
             if coordinator.dispatch_update_supported:
-                control = modbus_control  # type: ignore[assignment]
+                control = modbus_control  # type: ignore[assignment,unused-ignore]
             else:
                 _LOGGER.info(
                     "Local Modbus control map not readable on %s; dispatch entities disabled",
@@ -492,8 +492,10 @@ async def async_setup_entry(hass: HomeAssistant, entry: SungrowConfigEntry) -> b
         token_updater=_save_tokens,
     )
     # Restore previously stored tokens (a copy so we never mutate entry.data in place).
-    # pysolarcloud annotates Auth.tokens as None, but it holds a dict at runtime.
-    auth.tokens = dict(entry.data["tokens"])  # type: ignore[assignment]
+    # Pre-0.15.0 pysolarcloud annotated ``Auth.tokens`` as ``None``; 0.15.0 fixed it to
+    # ``dict[str, Any] | None``. The ``unused-ignore`` on the ignore code keeps this
+    # working on both the older and newer library type shapes.
+    auth.tokens = dict(entry.data["tokens"])  # type: ignore[assignment,unused-ignore]
 
     plants_service = Plants(auth)
     control_service = Control(auth)

--- a/custom_components/sungrow/_serialization.py
+++ b/custom_components/sungrow/_serialization.py
@@ -1,0 +1,104 @@
+"""JSON-safe serialisation + anonymisation helpers shared across the integration.
+
+Extracted from ``diagnostics.py`` (#355) so future features that need to
+represent API payloads as JSON — a "debug snapshot" service, a point-catalog
+UI, log-friendly formatters — can reuse the same primitives instead of
+duplicating them or reaching into ``diagnostics``' private surface.
+
+Three low-level primitives are exposed here:
+
+* :func:`jsonable` — convert enums (``DeviceType``, ``DeviceFaultStaus``) to
+  ``"NAME (value)"`` strings so :mod:`json` can serialise them, recursing
+  through dicts, lists, and tuples.
+
+* :func:`anonymise_device_keys` — replace device-uuid keys in a
+  ``{uuid: payload}`` dict with stable ``device_N`` placeholders. HA's
+  ``async_redact_data`` scrubs values under known key names but can't reach
+  keys themselves, so uuids leaked to diagnostics bundles before this.
+
+* :func:`catalog_rows` — flatten a ``{code: point}`` realtime response into
+  sorted ``{point_id, code, name, value, unit}`` rows suitable for a
+  human-readable point catalog.
+
+The higher-level ``build_points_catalog`` (which knows about
+``model_capabilities``) stays in ``diagnostics.py`` because it's specific to
+the diagnostics bundle shape.
+"""
+
+from __future__ import annotations
+
+import enum
+from typing import Any
+
+from .measure_points import resolve_name
+
+
+def jsonable(obj: Any) -> Any:
+    """Return a JSON-serialisable copy of *obj*, converting enums to strings.
+
+    pysolarcloud converts known device types and fault statuses to
+    :class:`~enum.Enum` members (``json`` can't serialise those directly). An
+    *unknown* device type — e.g. an EV charger the library hasn't catalogued
+    — is left as its raw int, which is exactly the identifier we want to
+    surface in a diagnostics dump. This helper converts enums to
+    ``"NAME (value)"`` strings and recurses through dicts, lists, and tuples;
+    everything else passes through untouched.
+    """
+    if isinstance(obj, enum.Enum):
+        return f"{obj.name} ({obj.value})"
+    if isinstance(obj, dict):
+        return {k: jsonable(v) for k, v in obj.items()}
+    if isinstance(obj, (list, tuple)):
+        return [jsonable(v) for v in obj]
+    return obj
+
+
+def anonymise_device_keys(realtime: Any, uuid_map: dict[str, str]) -> Any:
+    """Replace device-uuid keys in a per-device realtime dict with stable placeholders.
+
+    ``Plants.async_get_device_realtime`` returns ``{device_uuid: {...points...}}``
+    — the device uuids are dict *keys*, not values named ``uuid``, so HA's
+    ``async_redact_data`` (which only scrubs values under known key names)
+    can't reach them and they would otherwise leak into a diagnostics
+    download (#122). Map each uuid to a stable ``device_N`` placeholder,
+    sharing ``uuid_map`` across device types within a plant so the same
+    device keeps the same label. Non-dict payloads (e.g. an
+    ``{"error": ...}`` capture) pass through untouched — their keys are not
+    uuids.
+    """
+    if not isinstance(realtime, dict):
+        return realtime
+    anonymised: dict[str, Any] = {}
+    for uuid, payload in realtime.items():
+        placeholder = uuid_map.setdefault(str(uuid), f"device_{len(uuid_map) + 1}")
+        anonymised[placeholder] = payload
+    return anonymised
+
+
+def catalog_rows(points: Any) -> list[dict[str, Any]]:
+    """Flatten a ``{code: point}`` realtime dict into tidy, sorted catalog rows.
+
+    Each row is ``{point_id, code, name, value, unit}`` — the exact fields a
+    user needs to pick a point for the "Extra measure points" option (#252).
+    The friendly English ``name`` comes from the measure-point catalog
+    (:func:`~custom_components.sungrow.measure_points.resolve_name`), not the
+    API's Chinese-for-English-locale name nor the user's device name, so the
+    rows carry no PII.
+    """
+    if not isinstance(points, dict):
+        return []
+    rows: list[dict[str, Any]] = []
+    for code, point in points.items():
+        if not isinstance(point, dict):
+            continue
+        point_id = str(point.get("id") or code)
+        rows.append(
+            {
+                "point_id": point_id,
+                "code": str(code),
+                "name": resolve_name(point_id, str(code), point.get("name")),
+                "value": point.get("value"),
+                "unit": point.get("unit"),
+            }
+        )
+    return sorted(rows, key=lambda row: row["point_id"])

--- a/custom_components/sungrow/binary_sensor.py
+++ b/custom_components/sungrow/binary_sensor.py
@@ -11,14 +11,13 @@ import logging
 from typing import Any
 
 from homeassistant.components.binary_sensor import BinarySensorDeviceClass, BinarySensorEntity
-from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import EntityCategory
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 from pysolarcloud.plants import DeviceType
 
-from . import build_device_info
+from . import SungrowConfigEntry, build_device_info
 from .coordinator import SungrowPlantCoordinator
 from .device_helpers import unique_id_owned_by_other_entry
 from .measure_points import resolve_enum_value
@@ -96,7 +95,9 @@ def _build_binary_sensors(coordinator: SungrowPlantCoordinator) -> list[BinarySe
     return sensors
 
 
-async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry, async_add_entities: AddEntitiesCallback) -> None:
+async def async_setup_entry(
+    hass: HomeAssistant, entry: SungrowConfigEntry, async_add_entities: AddEntitiesCallback
+) -> None:
     """Set up Sungrow binary sensors from the coordinators created during entry setup."""
     coordinators = entry.runtime_data.coordinators
 

--- a/custom_components/sungrow/binary_sensor.py
+++ b/custom_components/sungrow/binary_sensor.py
@@ -12,14 +12,14 @@ from typing import Any
 
 from homeassistant.components.binary_sensor import BinarySensorDeviceClass, BinarySensorEntity
 from homeassistant.const import EntityCategory
-from homeassistant.core import HomeAssistant, callback
+from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 from pysolarcloud.plants import DeviceType
 
 from . import SungrowConfigEntry, build_device_info
 from .coordinator import SungrowPlantCoordinator
-from .device_helpers import unique_id_owned_by_other_entry
+from .entity_platform_helpers import create_entity_adder
 from .measure_points import resolve_enum_value
 from .modbus_registers import POWER_FLOW_STATUS_BITS
 
@@ -101,34 +101,17 @@ async def async_setup_entry(
     """Set up Sungrow binary sensors from the coordinators created during entry setup."""
     coordinators = entry.runtime_data.coordinators
 
-    known_unique_ids: set[str] = set()
-
-    @callback
-    def _add_new_entities() -> None:
-        new_entities: list[BinarySensorEntity] = []
-        for coordinator in coordinators:
-            for entity in _build_binary_sensors(coordinator):
-                uid = entity.unique_id
-                if uid is None or uid in known_unique_ids:
-                    continue
-                # Skip silently when another Sungrow entry already owns this unique_id
-                # (multiple entries on the same plant) so we don't produce an ERROR log
-                # per entity, per coordinator tick.
-                if unique_id_owned_by_other_entry(hass, "binary_sensor", uid, entry.entry_id):
-                    _LOGGER.info(
-                        "Skipping binary sensor %s: already owned by another Sungrow entry",
-                        uid,
-                    )
-                    known_unique_ids.add(uid)
-                    continue
-                known_unique_ids.add(uid)
-                new_entities.append(entity)
-        if new_entities:
-            async_add_entities(new_entities)
-
-    _add_new_entities()
+    adder = create_entity_adder(
+        hass,
+        entry,
+        "binary_sensor",
+        coordinators,
+        _build_binary_sensors,
+        async_add_entities,
+    )
+    adder()
     for coordinator in coordinators:
-        entry.async_on_unload(coordinator.async_add_listener(_add_new_entities))
+        entry.async_on_unload(coordinator.async_add_listener(adder))
 
 
 class SungrowDeviceFaultBinarySensor(CoordinatorEntity[SungrowPlantCoordinator], BinarySensorEntity):

--- a/custom_components/sungrow/config_flow.py
+++ b/custom_components/sungrow/config_flow.py
@@ -47,10 +47,13 @@ from .oauth_view import OAUTH_CALLBACK_PATH
 try:
     from pysolarcloud import Auth, AuthError, PySolarCloudException, UserAuth
 except ImportError:
-    # Optional import for local dev; production always has it via requirements.
-    Auth = None  # type: ignore[assignment,misc]
-    UserAuth = None  # type: ignore[assignment,misc]
-    AuthError = PySolarCloudException = Exception  # type: ignore[assignment,misc]
+    # Optional import for local dev; production always has it via requirements. The
+    # ``unused-ignore`` keeps this compatible with both pre-0.15.0 library type shapes
+    # (where the fallback assignments needed the ignore) and 0.15.0+ (where the strict
+    # types make it unnecessary).
+    Auth = None  # type: ignore[assignment,misc,unused-ignore]
+    UserAuth = None  # type: ignore[assignment,misc,unused-ignore]
+    AuthError = PySolarCloudException = Exception  # type: ignore[assignment,misc,unused-ignore]
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/custom_components/sungrow/diagnostics.py
+++ b/custom_components/sungrow/diagnostics.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import asyncio
-import enum
 import logging
 from typing import Any
 
@@ -11,7 +10,7 @@ from homeassistant.components.diagnostics import async_redact_data
 from homeassistant.core import HomeAssistant
 
 from . import SungrowConfigEntry, SungrowData
-from .measure_points import resolve_name
+from ._serialization import anonymise_device_keys, catalog_rows, jsonable
 from .model_capabilities import resolve_capabilities
 
 _LOGGER = logging.getLogger(__name__)
@@ -46,71 +45,6 @@ TO_REDACT = {
 }
 
 
-def _anonymise_device_keys(realtime: Any, uuid_map: dict[str, str]) -> Any:
-    """Replace device-uuid keys in a per-device realtime dict with stable placeholders.
-
-    ``async_get_device_realtime`` returns ``{device_uuid: {...points...}}`` — the device
-    uuids are dict *keys*, not values named ``uuid``, so ``async_redact_data`` (which only
-    scrubs values under known key names) can't reach them and they would otherwise leak
-    into a diagnostics download (#122). Map each uuid to a stable ``device_N`` placeholder,
-    sharing ``uuid_map`` across device types within a plant so the same device keeps the
-    same label. Non-dict payloads (e.g. an ``{"error": ...}`` capture) pass through
-    untouched — their keys are not uuids.
-    """
-    if not isinstance(realtime, dict):
-        return realtime
-    anonymised: dict[str, Any] = {}
-    for uuid, payload in realtime.items():
-        placeholder = uuid_map.setdefault(str(uuid), f"device_{len(uuid_map) + 1}")
-        anonymised[placeholder] = payload
-    return anonymised
-
-
-def _jsonable(obj: Any) -> Any:
-    """Make API payloads JSON-serialisable for the diagnostics download.
-
-    pysolarcloud converts *known* device types / fault statuses to ``enum`` members
-    (which ``json`` can't serialise); an *unknown* device type — e.g. an EV charger
-    the library hasn't catalogued — is left as its raw int, which is exactly the
-    identifier we want to surface. Convert enums to ``"NAME (value)"`` and recurse
-    into containers; everything else passes through untouched.
-    """
-    if isinstance(obj, enum.Enum):
-        return f"{obj.name} ({obj.value})"
-    if isinstance(obj, dict):
-        return {k: _jsonable(v) for k, v in obj.items()}
-    if isinstance(obj, (list, tuple)):
-        return [_jsonable(v) for v in obj]
-    return obj
-
-
-def _catalog_rows(points: Any) -> list[dict[str, Any]]:
-    """Flatten a ``{code: point}`` realtime dict into tidy, sorted catalog rows.
-
-    Each row is ``{point_id, code, name, value, unit}`` — the exact fields a user needs
-    to pick a point for the "Extra measure points" option (#252). The friendly English
-    ``name`` comes from the measure-point catalog (``resolve_name``), not the API's
-    Chinese-for-English-locale name nor the user's device name, so the rows carry no PII.
-    """
-    if not isinstance(points, dict):
-        return []
-    rows: list[dict[str, Any]] = []
-    for code, point in points.items():
-        if not isinstance(point, dict):
-            continue
-        point_id = str(point.get("id") or code)
-        rows.append(
-            {
-                "point_id": point_id,
-                "code": str(code),
-                "name": resolve_name(point_id, str(code), point.get("name")),
-                "value": point.get("value"),
-                "unit": point.get("unit"),
-            }
-        )
-    return sorted(rows, key=lambda row: row["point_id"])
-
-
 def build_points_catalog(
     plant_realtime: Any,
     device_realtime: dict[str, Any],
@@ -126,7 +60,7 @@ def build_points_catalog(
     metadata and model codes — no uuids, serials or user-set names — so it is safe to
     include in a shared diagnostics bundle.
     """
-    catalog: dict[str, Any] = {"plant": _catalog_rows(plant_realtime), "devices": {}}
+    catalog: dict[str, Any] = {"plant": catalog_rows(plant_realtime), "devices": {}}
     for type_id, per_device in device_realtime.items():
         # Merge points across all devices of this type, deduped by point id (devices of
         # one type report the same point set). ``per_device`` is ``{device_N: {code:
@@ -134,7 +68,7 @@ def build_points_catalog(
         merged: dict[str, dict[str, Any]] = {}
         if isinstance(per_device, dict):
             for payload in per_device.values():
-                for row in _catalog_rows(payload):
+                for row in catalog_rows(payload):
                     merged.setdefault(row["point_id"], row)
         model = models_by_type.get(type_id)
         caps = resolve_capabilities(model)
@@ -190,12 +124,12 @@ async def _probe_plant_devices(
         try:
             async with asyncio.timeout(PROBE_TIMEOUT):
                 realtime = await service.async_get_device_realtime(plant_id, device_type)
-            device_realtime[str(type_id)] = _anonymise_device_keys(_jsonable(realtime), uuid_map)
+            device_realtime[str(type_id)] = anonymise_device_keys(jsonable(realtime), uuid_map)
         except Exception as err:  # pylint: disable=broad-except
             _LOGGER.debug("Diagnostics: device realtime failed for type %s: %s", type_id, err)
             device_realtime[str(type_id)] = {"error": str(err)}
 
-    return _jsonable(all_devices), device_realtime, models_by_type
+    return jsonable(all_devices), device_realtime, models_by_type
 
 
 async def async_get_config_entry_diagnostics(hass: HomeAssistant, entry: SungrowConfigEntry) -> dict[str, Any]:
@@ -230,7 +164,7 @@ async def async_get_config_entry_diagnostics(hass: HomeAssistant, entry: Sungrow
             "last_update_success": coordinator.last_update_success,
             "data": coordinator.data,
             # Devices the integration created dispatch entities for (inverter/ESS).
-            "devices": _jsonable(devices_by_plant.get(plant_id, [])),
+            "devices": jsonable(devices_by_plant.get(plant_id, [])),
             # Every device on the plant, including hardware without mapped sensors.
             "all_devices": all_devices,
             # Per-device-type realtime data (best effort; {} where unsupported).

--- a/custom_components/sungrow/entity_platform_helpers.py
+++ b/custom_components/sungrow/entity_platform_helpers.py
@@ -1,0 +1,111 @@
+"""Shared helpers for the four Sungrow entity platforms.
+
+``number.py``, ``select.py``, ``binary_sensor.py``, and ``sensor.py`` all follow
+the same three-step pattern in their ``async_setup_entry``:
+
+1. Track a per-entry ``set`` of already-seen ``unique_id`` values so a repeated
+   coordinator update doesn't re-yield the same entity.
+2. Consult the entity registry via
+   :func:`~custom_components.sungrow.device_helpers.unique_id_owned_by_other_entry`
+   so multiple Sungrow entries on the same plant don't produce the noisy
+   ``Platform sungrow does not generate unique IDs`` ERROR from HA core
+   (see #346, addressed in #347).
+3. Register a coordinator listener that re-runs the adder when the coordinator's
+   device set changes (dynamic-devices).
+
+This module extracts the boilerplate into :func:`create_entity_adder` so each
+platform's ``async_setup_entry`` shrinks from ~15 lines to ~5, and any future
+platform we add can't accidentally omit the collision skip added in #347.
+
+Closes #351.
+"""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Callable, Iterable
+from typing import TYPE_CHECKING
+
+from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers.entity import Entity
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+
+from .device_helpers import unique_id_owned_by_other_entry
+
+if TYPE_CHECKING:
+    from . import SungrowConfigEntry
+    from .coordinator import SungrowPlantCoordinator
+
+_LOGGER = logging.getLogger(__name__)
+
+
+def create_entity_adder[EntityT: Entity](
+    hass: HomeAssistant,
+    entry: SungrowConfigEntry,
+    platform: str,
+    coordinators: Iterable[SungrowPlantCoordinator],
+    build: Callable[[SungrowPlantCoordinator], Iterable[EntityT]],
+    async_add_entities: AddEntitiesCallback,
+) -> Callable[[], None]:
+    """Return an ``_add_new_entities`` closure with dedup + cross-entry collision skip.
+
+    Encapsulates the per-entry ``known_unique_ids`` cache, the cross-entry
+    collision check from :func:`~custom_components.sungrow.device_helpers.unique_id_owned_by_other_entry`
+    (#347), and the INFO-level log line so no platform can regress the fix by
+    forgetting one of the steps.
+
+    Args:
+        hass: The Home Assistant instance the entry belongs to.
+        entry: The typed Sungrow config entry being set up.
+        platform: The HA platform name (``"number"`` / ``"select"`` /
+            ``"binary_sensor"`` / ``"sensor"``) used both in the collision-check
+            registry lookup and in the skip-log line.
+        coordinators: The plant coordinators to build entities from. The returned
+            closure iterates this on every call, so new coordinators added to the
+            entry's runtime data after setup are picked up automatically.
+        build: Callable that takes a coordinator and yields the entities it should
+            contribute. Called per-coordinator on every adder invocation, so any
+            per-poll device-set changes surface as new entities. Return an empty
+            iterable when a coordinator has nothing to contribute.
+        async_add_entities: The platform's ``async_add_entities`` callback, forwarded
+            verbatim.
+
+    Returns:
+        A ``@callback``-marked function that consumers should call once immediately
+        (to add the initial set) and then register as a listener on each
+        coordinator via ``entry.async_on_unload(coordinator.async_add_listener(...))``.
+
+    Behaviour on repeated calls:
+        - Entities with ``unique_id in known_unique_ids`` are silently skipped
+          (per-entry dedup — a coordinator update that re-yields the same entities
+          shouldn't produce duplicates).
+        - Entities whose ``unique_id`` is already registered against a different
+          Sungrow config entry are skipped with a single INFO-level log line, then
+          added to ``known_unique_ids`` so the log doesn't repeat per coordinator
+          tick (see #346 for the noise class this prevents).
+        - Entities with ``unique_id is None`` are skipped (HA rejects them anyway).
+    """
+    known_unique_ids: set[str] = set()
+
+    @callback
+    def _add_new_entities() -> None:
+        new_entities: list[EntityT] = []
+        for coordinator in coordinators:
+            for entity in build(coordinator):
+                uid = entity.unique_id
+                if uid is None or uid in known_unique_ids:
+                    continue
+                if unique_id_owned_by_other_entry(hass, platform, uid, entry.entry_id):
+                    _LOGGER.info(
+                        "Skipping %s %s: already owned by another Sungrow entry",
+                        platform,
+                        uid,
+                    )
+                    known_unique_ids.add(uid)
+                    continue
+                known_unique_ids.add(uid)
+                new_entities.append(entity)
+        if new_entities:
+            async_add_entities(new_entities)
+
+    return _add_new_entities

--- a/custom_components/sungrow/manifest.json
+++ b/custom_components/sungrow/manifest.json
@@ -21,7 +21,7 @@
   ],
   "quality_scale": "platinum",
   "requirements": [
-    "sungrow-isolarcloud==0.14.0",
+    "sungrow-isolarcloud==0.15.0",
     "pymodbus>=3.6.0"
   ],
   "version": "5.6.1",

--- a/custom_components/sungrow/number.py
+++ b/custom_components/sungrow/number.py
@@ -7,7 +7,6 @@ import re
 from typing import Any
 
 from homeassistant.components.number import NumberDeviceClass, NumberEntity, NumberMode, RestoreNumber
-from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import EntityCategory
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.exceptions import HomeAssistantError
@@ -16,7 +15,7 @@ from homeassistant.helpers.update_coordinator import CoordinatorEntity
 from pysolarcloud import PySolarCloudException
 from pysolarcloud.control import Control
 
-from . import DispatchControl, build_device_info, select_dispatch_device
+from . import DispatchControl, SungrowConfigEntry, build_device_info, select_dispatch_device
 from .const import DOMAIN
 from .coordinator import SungrowPlantCoordinator
 from .device_helpers import unique_id_owned_by_other_entry
@@ -247,7 +246,9 @@ def _build_numbers(coordinator: SungrowPlantCoordinator, control: DispatchContro
     return entities
 
 
-async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry, async_add_entities: AddEntitiesCallback) -> None:
+async def async_setup_entry(
+    hass: HomeAssistant, entry: SungrowConfigEntry, async_add_entities: AddEntitiesCallback
+) -> None:
     """Set up Sungrow dispatch number entities."""
     data = entry.runtime_data
     control = data.control

--- a/custom_components/sungrow/number.py
+++ b/custom_components/sungrow/number.py
@@ -8,7 +8,7 @@ from typing import Any
 
 from homeassistant.components.number import NumberDeviceClass, NumberEntity, NumberMode, RestoreNumber
 from homeassistant.const import EntityCategory
-from homeassistant.core import HomeAssistant, callback
+from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
@@ -18,7 +18,7 @@ from pysolarcloud.control import Control
 from . import DispatchControl, SungrowConfigEntry, build_device_info, select_dispatch_device
 from .const import DOMAIN
 from .coordinator import SungrowPlantCoordinator
-from .device_helpers import unique_id_owned_by_other_entry
+from .entity_platform_helpers import create_entity_adder
 from .modbus_control import ModbusControlError
 from .model_specs import spec_for
 
@@ -254,34 +254,17 @@ async def async_setup_entry(
     control = data.control
     coordinators = data.coordinators
 
-    known_unique_ids: set[str] = set()
-
-    @callback
-    def _add_new_entities() -> None:
-        new_entities: list[NumberEntity] = []
-        for coordinator in coordinators:
-            for entity in _build_numbers(coordinator, control):
-                uid = entity.unique_id
-                if uid is None or uid in known_unique_ids:
-                    continue
-                # Skip silently when another Sungrow entry already owns this unique_id
-                # (multiple entries on the same plant) so we don't produce an ERROR log
-                # per entity, per coordinator tick.
-                if unique_id_owned_by_other_entry(hass, "number", uid, entry.entry_id):
-                    _LOGGER.info(
-                        "Skipping dispatch number %s: already owned by another Sungrow entry",
-                        uid,
-                    )
-                    known_unique_ids.add(uid)
-                    continue
-                known_unique_ids.add(uid)
-                new_entities.append(entity)
-        if new_entities:
-            async_add_entities(new_entities)
-
-    _add_new_entities()
+    adder = create_entity_adder(
+        hass,
+        entry,
+        "number",
+        coordinators,
+        lambda coordinator: _build_numbers(coordinator, control),
+        async_add_entities,
+    )
+    adder()
     for coordinator in coordinators:
-        entry.async_on_unload(coordinator.async_add_listener(_add_new_entities))
+        entry.async_on_unload(coordinator.async_add_listener(adder))
 
 
 class SungrowDispatchNumber(CoordinatorEntity[SungrowPlantCoordinator], RestoreNumber):

--- a/custom_components/sungrow/select.py
+++ b/custom_components/sungrow/select.py
@@ -7,7 +7,6 @@ import time
 from typing import Any
 
 from homeassistant.components.select import SelectEntity
-from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import EntityCategory
 from homeassistant.core import CALLBACK_TYPE, HomeAssistant, callback
 from homeassistant.exceptions import HomeAssistantError
@@ -21,6 +20,7 @@ from pysolarcloud.control import Control
 
 from . import (
     DispatchControl,
+    SungrowConfigEntry,
     async_start_heartbeat,
     async_stop_heartbeat,
     build_device_info,
@@ -162,7 +162,9 @@ def _build_selects(coordinator: SungrowPlantCoordinator, control: DispatchContro
     ]
 
 
-async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry, async_add_entities: AddEntitiesCallback) -> None:
+async def async_setup_entry(
+    hass: HomeAssistant, entry: SungrowConfigEntry, async_add_entities: AddEntitiesCallback
+) -> None:
     """Set up Sungrow dispatch select entities."""
     data = entry.runtime_data
     control = data.control

--- a/custom_components/sungrow/select.py
+++ b/custom_components/sungrow/select.py
@@ -28,7 +28,7 @@ from . import (
 )
 from .const import DOMAIN
 from .coordinator import SungrowPlantCoordinator
-from .device_helpers import unique_id_owned_by_other_entry
+from .entity_platform_helpers import create_entity_adder
 from .modbus_control import ModbusControlError
 
 _LOGGER = logging.getLogger(__name__)
@@ -170,34 +170,17 @@ async def async_setup_entry(
     control = data.control
     coordinators = data.coordinators
 
-    known_unique_ids: set[str] = set()
-
-    @callback
-    def _add_new_entities() -> None:
-        new_entities: list[SelectEntity] = []
-        for coordinator in coordinators:
-            for entity in _build_selects(coordinator, control):
-                uid = entity.unique_id
-                if uid is None or uid in known_unique_ids:
-                    continue
-                # Skip silently when another Sungrow entry already owns this unique_id
-                # (multiple entries on the same plant) so we don't produce an ERROR log
-                # per entity, per coordinator tick.
-                if unique_id_owned_by_other_entry(hass, "select", uid, entry.entry_id):
-                    _LOGGER.info(
-                        "Skipping dispatch select %s: already owned by another Sungrow entry",
-                        uid,
-                    )
-                    known_unique_ids.add(uid)
-                    continue
-                known_unique_ids.add(uid)
-                new_entities.append(entity)
-        if new_entities:
-            async_add_entities(new_entities)
-
-    _add_new_entities()
+    adder = create_entity_adder(
+        hass,
+        entry,
+        "select",
+        coordinators,
+        lambda coordinator: _build_selects(coordinator, control),
+        async_add_entities,
+    )
+    adder()
     for coordinator in coordinators:
-        entry.async_on_unload(coordinator.async_add_listener(_add_new_entities))
+        entry.async_on_unload(coordinator.async_add_listener(adder))
 
 
 class SungrowDispatchSelect(CoordinatorEntity[SungrowPlantCoordinator], RestoreEntity, SelectEntity):

--- a/custom_components/sungrow/sensor.py
+++ b/custom_components/sungrow/sensor.py
@@ -5,14 +5,13 @@ from dataclasses import dataclass
 from typing import Any
 
 from homeassistant.components.sensor import SensorDeviceClass, SensorEntity, SensorStateClass
-from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import PERCENTAGE, EntityCategory
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 from pysolarcloud.plants import DeviceType
 
-from . import build_device_info, build_plant_device_info, resolve_point_device
+from . import SungrowConfigEntry, build_device_info, build_plant_device_info, resolve_point_device
 from .const import (
     BATTERY_DIAGNOSTIC_CODES,
     COMM_MODULE_POINTS,
@@ -200,7 +199,9 @@ def _build_sensors(coordinator: SungrowPlantCoordinator, console_url: str) -> li
     return sensors
 
 
-async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry, async_add_entities: AddEntitiesCallback) -> None:
+async def async_setup_entry(
+    hass: HomeAssistant, entry: SungrowConfigEntry, async_add_entities: AddEntitiesCallback
+) -> None:
     """Set up Sungrow sensors from the coordinators created during entry setup."""
     coordinators = entry.runtime_data.coordinators
     # Point the device "Visit" link at the region's iSolarCloud web console.

--- a/custom_components/sungrow/sensor.py
+++ b/custom_components/sungrow/sensor.py
@@ -6,7 +6,7 @@ from typing import Any
 
 from homeassistant.components.sensor import SensorDeviceClass, SensorEntity, SensorStateClass
 from homeassistant.const import PERCENTAGE, EntityCategory
-from homeassistant.core import HomeAssistant, callback
+from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 from pysolarcloud.plants import DeviceType
@@ -22,7 +22,7 @@ from .const import (
     INVERTER_DIAGNOSTIC_POINTS,
 )
 from .coordinator import SungrowPlantCoordinator
-from .device_helpers import unique_id_owned_by_other_entry
+from .entity_platform_helpers import create_entity_adder
 from .measure_points import (
     PERCENT_FRACTION_POINT_IDS,
     normalize_unit,
@@ -207,36 +207,18 @@ async def async_setup_entry(
     # Point the device "Visit" link at the region's iSolarCloud web console.
     console_url = GATEWAY_CONSOLE_URLS.get(entry.data.get(CONF_GATEWAY, ""), DEFAULT_CONSOLE_URL)
 
-    known_unique_ids: set[str] = set()
-
-    @callback
-    def _add_new_entities() -> None:
-        """Add entities for any plant points / devices not seen yet."""
-        new_entities: list[SensorEntity] = []
-        for coordinator in coordinators:
-            for entity in _build_sensors(coordinator, console_url):
-                uid = entity.unique_id
-                if uid is None or uid in known_unique_ids:
-                    continue
-                # Skip silently when another Sungrow entry already owns this unique_id
-                # (multiple entries on the same plant) so we don't produce an ERROR log
-                # per entity, per coordinator tick.
-                if unique_id_owned_by_other_entry(hass, "sensor", uid, entry.entry_id):
-                    _LOGGER.info(
-                        "Skipping sensor %s: already owned by another Sungrow entry",
-                        uid,
-                    )
-                    known_unique_ids.add(uid)
-                    continue
-                known_unique_ids.add(uid)
-                new_entities.append(entity)
-        if new_entities:
-            async_add_entities(new_entities)
-
+    adder = create_entity_adder(
+        hass,
+        entry,
+        "sensor",
+        coordinators,
+        lambda coordinator: _build_sensors(coordinator, console_url),
+        async_add_entities,
+    )
     # Add the initial set, then keep watching each coordinator for new devices.
-    _add_new_entities()
+    adder()
     for coordinator in coordinators:
-        entry.async_on_unload(coordinator.async_add_listener(_add_new_entities))
+        entry.async_on_unload(coordinator.async_add_listener(adder))
 
 
 class SungrowSensor(CoordinatorEntity, SensorEntity):

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -11,5 +11,5 @@ ruff==0.15.22
 mypy==2.3.0
 
 # Component dependencies
-sungrow-isolarcloud==0.14.0
+sungrow-isolarcloud==0.15.0
 pymodbus==3.14.0

--- a/tests/test_serialization.py
+++ b/tests/test_serialization.py
@@ -1,0 +1,147 @@
+"""Tests for the shared JSON-serialisation helpers (#355).
+
+These primitives were extracted from ``diagnostics.py``; the diagnostics tests
+still exercise them via the ``async_get_config_entry_diagnostics`` end-to-end
+path, but as pure functions they deserve targeted unit coverage of the edge
+cases (non-dict inputs, enum recursion, uuid-anonymisation stability, PII-free
+name resolution) so a refactor of ``diagnostics.py`` can't silently regress
+them.
+"""
+
+from __future__ import annotations
+
+from enum import Enum
+
+from custom_components.sungrow._serialization import (
+    anonymise_device_keys,
+    catalog_rows,
+    jsonable,
+)
+
+
+class _Colour(Enum):
+    RED = 1
+    BLUE = "blue"
+
+
+# ---------------------------------------------------------------------------
+# jsonable
+# ---------------------------------------------------------------------------
+
+
+def test_jsonable_converts_enum_to_name_and_value_string():
+    """Known enums serialise as ``"NAME (value)"`` so ``json`` can round-trip them."""
+    assert jsonable(_Colour.RED) == "RED (1)"
+    assert jsonable(_Colour.BLUE) == "BLUE (blue)"
+
+
+def test_jsonable_recurses_through_dicts_and_lists():
+    """Enums nested inside containers are converted at every level."""
+    payload = {"colours": [_Colour.RED, {"nested": _Colour.BLUE}], "count": 2}
+    assert jsonable(payload) == {
+        "colours": ["RED (1)", {"nested": "BLUE (blue)"}],
+        "count": 2,
+    }
+
+
+def test_jsonable_passes_through_primitives():
+    """Ints, strings, booleans, and None pass through untouched."""
+    assert jsonable(42) == 42
+    assert jsonable("hello") == "hello"
+    assert jsonable(True) is True
+    assert jsonable(None) is None
+
+
+def test_jsonable_converts_tuple_to_list():
+    """Tuples become lists so JSON can represent them (JSON has no tuple type)."""
+    assert jsonable((_Colour.RED, 1, "x")) == ["RED (1)", 1, "x"]
+
+
+def test_jsonable_leaves_unknown_int_device_type_as_int():
+    """An *unknown* device-type int isn't wrapped as an enum — it stays as the raw int
+    so consumers can see exactly which type ID the API returned (motivating case for #18)."""
+    # pysolarcloud leaves unmapped device types as raw ints; jsonable doesn't touch them.
+    assert jsonable(99) == 99
+
+
+# ---------------------------------------------------------------------------
+# anonymise_device_keys
+# ---------------------------------------------------------------------------
+
+
+def test_anonymise_device_keys_replaces_uuids_with_stable_placeholders():
+    """UUID keys are replaced with ``device_N`` placeholders in insertion order."""
+    uuid_map: dict[str, str] = {}
+    result = anonymise_device_keys({"aaa-111": {"x": 1}, "bbb-222": {"y": 2}}, uuid_map)
+    assert result == {"device_1": {"x": 1}, "device_2": {"y": 2}}
+    # ``uuid_map`` accumulates the mapping so a second call reuses the same placeholders.
+    assert uuid_map == {"aaa-111": "device_1", "bbb-222": "device_2"}
+
+
+def test_anonymise_device_keys_shares_uuid_map_across_calls():
+    """The same uuid seen in a later call gets the same placeholder, so the diagnostics
+    bundle stays coherent across multiple device-type sections (#122)."""
+    uuid_map: dict[str, str] = {}
+    anonymise_device_keys({"shared-uuid": {"inv": True}}, uuid_map)
+    result = anonymise_device_keys({"shared-uuid": {"meter": True}, "new-uuid": {}}, uuid_map)
+    # The pre-existing "shared-uuid" keeps its ``device_1`` label; "new-uuid" gets ``device_2``.
+    assert result == {"device_1": {"meter": True}, "device_2": {}}
+
+
+def test_anonymise_device_keys_passes_non_dict_through():
+    """A non-dict payload (e.g. ``{"error": ...}``) with dict keys that aren't uuids
+    passes through untouched — the helper only anonymises the ``{uuid: payload}`` shape."""
+    assert anonymise_device_keys("not-a-dict", {}) == "not-a-dict"
+    assert anonymise_device_keys(None, {}) is None
+    assert anonymise_device_keys([1, 2, 3], {}) == [1, 2, 3]
+
+
+# ---------------------------------------------------------------------------
+# catalog_rows
+# ---------------------------------------------------------------------------
+
+
+def test_catalog_rows_flattens_and_sorts_by_point_id():
+    """Rows come out sorted by ``point_id`` regardless of dict-insertion order (#252)."""
+    points = {
+        "power": {"id": "83033", "value": "1000", "unit": "W"},
+        "energy": {"id": "83024", "value": "5.5", "unit": "kWh"},
+    }
+    rows = catalog_rows(points)
+    # 83024 < 83033 lexicographically as strings; that's the requested sort order.
+    assert [row["point_id"] for row in rows] == ["83024", "83033"]
+    assert rows[0]["code"] == "energy"
+    assert rows[0]["value"] == "5.5"
+    assert rows[0]["unit"] == "kWh"
+
+
+def test_catalog_rows_falls_back_to_code_when_id_missing():
+    """A point without a numeric ``id`` field uses the code as its ``point_id`` fallback."""
+    points = {"unknown_code": {"value": "x"}}
+    rows = catalog_rows(points)
+    assert rows[0]["point_id"] == "unknown_code"
+    assert rows[0]["code"] == "unknown_code"
+
+
+def test_catalog_rows_skips_non_dict_points():
+    """A malformed entry (value is not a dict) is skipped rather than raised on."""
+    rows = catalog_rows({"good": {"id": "1", "value": 1}, "bad": "just-a-string", "other": None})
+    assert [row["code"] for row in rows] == ["good"]
+
+
+def test_catalog_rows_returns_empty_list_for_non_dict_input():
+    """A non-dict input (e.g. an ``{"error": ...}`` capture) yields ``[]`` cleanly."""
+    assert catalog_rows("bad") == []
+    assert catalog_rows(None) == []
+    assert catalog_rows([]) == []
+
+
+def test_catalog_rows_uses_resolved_english_name_not_api_name():
+    """The friendly ``name`` field comes from the catalog, not the API's payload name
+    (which is often the wrong locale) — so shared diagnostics bundles carry no PII."""
+    # For a known point (83033 = total_active_power), the catalog resolves the English
+    # name from ``measure_points.resolve_name`` regardless of what the API returned.
+    rows = catalog_rows({"total_active_power": {"id": "83033", "value": "1000", "name": "totally wrong"}})
+    # The exact resolved English name is measure_points-dependent; just assert the
+    # override happened rather than pinning to a specific string.
+    assert rows[0]["name"] != "totally wrong"


### PR DESCRIPTION
Bumps the library and lands three small refactors that were queued waiting for the version bump. Each is a self-contained commit — please **MERGE (not squash)** so release-please picks up each closure independently.

## Commits

### 1. `chore(deps): bump sungrow-isolarcloud from 0.14.0 to 0.15.0` (`d148f66`)
- Pinned in `manifest.json` and `requirements_test.txt` in lockstep.
- Added `unused-ignore` to three pre-existing `# type: ignore` comments in `__init__.py` and `config_flow.py` — 0.14.0 needed them; 0.15.0's strict types don't. The `unused-ignore` codes keep them working under both library versions.
- 798 existing tests pass unchanged against the new library.

Highlights from the 0.15.0 release the follow-up commits do not yet exploit but future work will:
- `PARAMETERS` / `ParameterSpec` (typed Appendix-10 metadata) — unblocks consolidating `DISPATCH_NUMBERS` / `DISPATCH_SELECTS` (#71 follow-up).
- `DeviceNotWritableError` — unblocks tightening `except Exception` swallows on the control path (#350).
- `RateLimitError.retry_after` — coordinator can honor the server's back-off hint.
- `Plants.async_iter_historical_data` — will replace backfill's manual cursor loop.

### 2. `refactor(platforms): type entry as SungrowConfigEntry in setup signatures` (`ac93c96`) — closes #352
- Import and use the existing `SungrowConfigEntry = ConfigEntry[SungrowData]` alias in each platform's `async_setup_entry`.
- Zero runtime change; `entry.runtime_data` is now properly typed, unlocking mypy verification on `coordinators` / `control` / `devices` access.

### 3. `refactor(platforms): extract shared _add_new_entities helper` (`d0613f3`) — closes #351
- New `entity_platform_helpers.create_entity_adder` encapsulates the per-entry `known_unique_ids` cache, the cross-entry collision check from `unique_id_owned_by_other_entry` (#347), the INFO skip log, and the closure wiring.
- Each platform's `async_setup_entry` body shrinks from ~20 lines to ~10.
- Generic over the entity subclass (`[EntityT: Entity]`) so each platform's inferred entity type flows through unchanged.
- No future platform can accidentally regress #347 by forgetting one of the steps.

### 4. `refactor(diagnostics): promote serialization helpers to shared _serialization module` (`2e2fd86`) — closes #355
- Extract `jsonable`, `anonymise_device_keys`, `catalog_rows` from `diagnostics.py` into a new `_serialization.py` module.
- `build_points_catalog` stays in `diagnostics.py` (higher-level, knows about `model_capabilities`).
- New `test_serialization.py` (13 tests) covers each primitive directly — enum conversion, container recursion, stable uuid placeholders shared across calls (correctness for #122), sort order, code-as-fallback, non-dict pass-through, and the PII-safe API-name override.

## Not in this PR

- **#348** (remove dead cloud+modbus transport) — needs a migration to reroute existing entries to `cloud_only`, plus updates across ~5 test files. Deserves its own PR.
- **#350** (narrow broad-except swallows) — best done per file with careful review of what the library now surfaces as typed. Follow-up.
- **`GATEWAY_CONSOLE_URLS` → `Server.web_console_url`** — the library returns `web3.isolarcloud.*` (OAuth-adjacent) while the integration currently uses `isolarcloud.*` (top-level dashboard). Silent URL change; needs a separate discussion.

## Verification

- `.venv/bin/python -m pytest tests/` — **811 passed** (up from 798; +13 in `test_serialization.py`)
- `.venv/bin/mypy` — clean (30 source files)
- `.venv/bin/ruff check custom_components/ tests/` — clean
- `.venv/bin/ruff format --check custom_components/ tests/` — clean
