### PR TITLE
fix(config_flow): retire the cloud+modbus transport

### DIFF
--- a/custom_components/sungrow/__init__.py
+++ b/custom_components/sungrow/__init__.py
@@ -39,7 +39,6 @@ from .const import (
     DOMAIN,
     GATEWAY_CONSOLE_URLS,
     GATEWAYS,
-    TRANSPORT_CLOUD_MODBUS,
     TRANSPORT_CLOUD_ONLY,
     TRANSPORT_CLOUD_USER,
     TRANSPORT_MODBUS_ONLY,
@@ -449,14 +448,9 @@ async def async_setup_entry(hass: HomeAssistant, entry: SungrowConfigEntry) -> b
     if transport == TRANSPORT_CLOUD_USER:
         return await _async_setup_cloud_user(hass, entry)
 
-    if transport == TRANSPORT_CLOUD_MODBUS:
-        _LOGGER.info(
-            "Entry %s configured for cloud+modbus; Modbus wiring deferred to #217",
-            entry.title,
-        )
-
-    # cloud_only and cloud_modbus both use the standard cloud coordinator path.
-    # Split legacy hybrid cloud+Modbus entries into pure cloud + separate local.
+    # cloud_only path. Legacy cloud_modbus entries have been migrated to cloud_only
+    # by ``async_migrate_entry`` (#348); older hybrid-shape entries with orphan
+    # ``modbus_host`` in options get split into pure cloud + separate local here.
     _async_split_legacy_hybrid(hass, entry)
 
     # Defensive back-fill: recover app_id from unique_id if missing (#245).

--- a/custom_components/sungrow/config_flow.py
+++ b/custom_components/sungrow/config_flow.py
@@ -36,7 +36,6 @@ from .const import (
     GATEWAYS,
     MAX_SCAN_INTERVAL,
     MIN_SCAN_INTERVAL,
-    TRANSPORT_CLOUD_MODBUS,
     TRANSPORT_CLOUD_ONLY,
     TRANSPORT_CLOUD_USER,
     TRANSPORT_MODBUS_ONLY,
@@ -134,7 +133,7 @@ def _parse_winet_properties(props: dict[str, Any]) -> tuple[str | None, str | No
 class SungrowConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     """Handle a config flow for Sungrow iSolarCloud."""
 
-    VERSION = 4
+    VERSION = 5
 
     def __init__(self) -> None:
         """Initialize the config flow."""
@@ -214,9 +213,6 @@ class SungrowConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 self.init_info.pop("tokens", None)
                 # Start a fresh Auth client for the (possibly changed) credentials.
                 self.auth_client = None
-                # For cloud_modbus: collect an updated modbus host before re-authorizing.
-                if transport == TRANSPORT_CLOUD_MODBUS:
-                    return await self.async_step_reconfigure_modbus_host()
                 return await self.async_step_auth()
 
         current = entry.data
@@ -235,32 +231,6 @@ class SungrowConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         return self.async_show_form(
             step_id="reconfigure",
             data_schema=vol.Schema(schema_fields),
-            errors=errors,
-        )
-
-    async def async_step_reconfigure_modbus_host(self, user_input: dict[str, Any] | None = None) -> ConfigFlowResult:
-        """Collect updated Modbus host during reconfigure of a cloud_modbus entry (#216)."""
-        errors: dict[str, str] = {}
-        entry = self._get_reconfigure_entry()
-
-        if user_input is not None:
-            host = (user_input.get(CONF_MODBUS_HOST) or "").strip()
-            from .helpers import async_test_modbus_host
-
-            if await async_test_modbus_host(host):
-                # Store host in init_info so the auth step includes it in the updated entry.
-                self.init_info[CONF_MODBUS_HOST] = host
-                return await self.async_step_auth()
-            errors["base"] = "host_unreachable"
-
-        current_host = entry.data.get(CONF_MODBUS_HOST, "")
-        return self.async_show_form(
-            step_id="reconfigure_modbus_host",
-            data_schema=vol.Schema(
-                {
-                    vol.Required(CONF_MODBUS_HOST, default=current_host): str,
-                }
-            ),
             errors=errors,
         )
 
@@ -372,7 +342,6 @@ class SungrowConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
         transport_options = [
             SelectOptionDict(value=TRANSPORT_CLOUD_ONLY, label="Cloud Only"),
-            SelectOptionDict(value=TRANSPORT_CLOUD_MODBUS, label="Cloud + Modbus"),
             SelectOptionDict(value=TRANSPORT_CLOUD_USER, label="Cloud (user account, unofficial)"),
             SelectOptionDict(value=TRANSPORT_MODBUS_ONLY, label="Modbus Only"),
         ]
@@ -405,10 +374,6 @@ class SungrowConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 self.init_info = user_input
                 await self.async_set_unique_id(str(user_input[CONF_APP_ID]))
                 self._abort_if_unique_id_configured()
-
-                # If hybrid mode, collect the Modbus host next.
-                if self._transport == TRANSPORT_CLOUD_MODBUS:
-                    return await self.async_step_modbus_host()
 
                 # Create the hub immediately, before authorizing. Setting up this
                 # token-less entry runs async_setup — which registers the OAuth
@@ -445,39 +410,6 @@ class SungrowConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                     vol.Required(CONF_APP_ID, default=""): str,
                     vol.Required(CONF_GATEWAY, default="Europe"): vol.In(list(GATEWAYS.keys())),
                     vol.Required(CONF_REDIRECT_URI, default=default_redirect): str,
-                }
-            ),
-            errors=errors,
-        )
-
-    async def async_step_modbus_host(self, user_input: dict[str, Any] | None = None) -> ConfigFlowResult:
-        """Collect the WiNet-S Modbus host for hybrid (Cloud + Modbus) mode (#216)."""
-        errors: dict[str, str] = {}
-
-        if user_input is not None:
-            host = (user_input.get(CONF_MODBUS_HOST) or "").strip()
-            from .helpers import async_test_modbus_host
-
-            if await async_test_modbus_host(host):
-                # Create the tokenless entry with the modbus host included.
-                data = {
-                    **self.init_info,
-                    CONF_TRANSPORT: TRANSPORT_CLOUD_MODBUS,
-                    CONF_MODBUS_HOST: host,
-                }
-                return self.async_create_entry(
-                    title=f"Sungrow {self.init_info[CONF_APP_ID]}",
-                    data=data,
-                )
-            errors["base"] = "host_unreachable"
-
-        # Pre-fill from zeroconf discovery if available.
-        default_host = self._discovered_modbus_host or ""
-        return self.async_show_form(
-            step_id="modbus_host",
-            data_schema=vol.Schema(
-                {
-                    vol.Required(CONF_MODBUS_HOST, default=default_host): str,
                 }
             ),
             errors=errors,
@@ -966,31 +898,12 @@ class SungrowOptionsFlow(config_entries.OptionsFlowWithReload):
                 errors["base"] = "invalid_extra_measure_points"
                 _LOGGER.warning("Invalid extra measure points input: %s", exc)
             else:
-                modbus_host = (user_input.get(CONF_MODBUS_HOST) or "").strip()
                 data = {**user_input, CONF_EXTRA_MEASURE_POINTS: extras}
                 data.pop(CONF_MODBUS_HOST, None)
                 data.pop(CONF_MODBUS_DEBUG_DAILY_YIELD, None)
-
-                # Transport switching: cloud_only + host → cloud_modbus
-                if transport == TRANSPORT_CLOUD_ONLY and modbus_host:
-                    from .helpers import async_test_modbus_host
-
-                    if await async_test_modbus_host(modbus_host):
-                        new_data = {
-                            **self.config_entry.data,
-                            CONF_TRANSPORT: TRANSPORT_CLOUD_MODBUS,
-                            CONF_MODBUS_HOST: modbus_host,
-                        }
-                        self.hass.config_entries.async_update_entry(self.config_entry, data=new_data)
-                    else:
-                        errors["base"] = "host_unreachable"
-
-                # Transport switching: cloud_modbus + cleared host → cloud_only
-                elif transport == TRANSPORT_CLOUD_MODBUS and not modbus_host:
-                    new_data = {k: v for k, v in self.config_entry.data.items() if k != CONF_MODBUS_HOST}
-                    new_data[CONF_TRANSPORT] = TRANSPORT_CLOUD_ONLY
-                    self.hass.config_entries.async_update_entry(self.config_entry, data=new_data)
-
+                # cloud_modbus transport was retired in #348; the options flow no
+                # longer offers modbus_host on cloud entries. Local Modbus is set up
+                # via a separate ``Modbus Only`` entry instead.
                 if not errors:
                     return self.async_create_entry(title="", data=data)
 
@@ -1012,13 +925,10 @@ class SungrowOptionsFlow(config_entries.OptionsFlowWithReload):
             vol.Optional(CONF_ENABLE_DEVICE_SENSORS, default=current_device_sensors): bool,
         }
 
-        # For cloud_only: show optional modbus_host field to allow switching to hybrid.
-        # For cloud_modbus: show current host (user can clear to switch back to cloud_only).
-        if transport == TRANSPORT_CLOUD_ONLY:
-            schema_fields[vol.Optional(CONF_MODBUS_HOST, default="")] = str
-        elif transport == TRANSPORT_CLOUD_MODBUS:
-            current_host = self.config_entry.data.get(CONF_MODBUS_HOST, "")
-            schema_fields[vol.Optional(CONF_MODBUS_HOST, default=current_host)] = str
+        # Local Modbus is a separate entry now (#348 retired the ``cloud_modbus``
+        # transport). The options flow for a cloud entry no longer offers a
+        # ``modbus_host`` field — users who want local Modbus add a ``Modbus Only``
+        # entry alongside their cloud one.
 
         return self.async_show_form(
             step_id="init",

--- a/custom_components/sungrow/migration.py
+++ b/custom_components/sungrow/migration.py
@@ -100,6 +100,26 @@ async def async_migrate_entry(hass: HomeAssistant, config_entry: ConfigEntry) ->
             removed,
         )
 
+    if config_entry.version == 4:
+        # v4→v5: retire the ``cloud_modbus`` transport (#348). The transport was
+        # selectable in the config flow but ``async_setup_entry`` never wired the
+        # Modbus side (the deferred #217 was closed as ``not_planned``), so existing
+        # entries loaded to zero entities. Convert them to ``cloud_only`` — dropping
+        # the now-unused ``modbus_host`` — so the cloud coordinator takes over and
+        # users get working entities on the next reload.
+        new_data = dict(config_entry.data)
+        if new_data.get(CONF_TRANSPORT) == TRANSPORT_CLOUD_MODBUS:
+            new_data[CONF_TRANSPORT] = TRANSPORT_CLOUD_ONLY
+            dropped_host = new_data.pop(CONF_MODBUS_HOST, None)
+            _LOGGER.warning(
+                "Migrated config entry %s from cloud_modbus to cloud_only (#348); "
+                "the local Modbus side was never wired. Dropped modbus_host=%s. "
+                "Set up local Modbus via a separate 'Modbus Only' entry if you need it.",
+                config_entry.title,
+                dropped_host,
+            )
+        hass.config_entries.async_update_entry(config_entry, data=new_data, version=5)
+
     # Defensive back-fill: ensure cloud entries carry app_id (#245).
     # The unique_id for cloud entries IS the app_id (set during initial setup).
     # If the data key was lost (corrupt storage, partial migration, older RC builds)
@@ -130,9 +150,10 @@ def _async_split_legacy_hybrid(hass: HomeAssistant, entry: ConfigEntry) -> None:
     """
     if entry.data.get(CONF_TRANSPORT) == TRANSPORT_MODBUS_ONLY:
         return
-    # cloud_modbus entries legitimately carry modbus_host — don't strip it (#216).
-    if entry.data.get(CONF_TRANSPORT) == TRANSPORT_CLOUD_MODBUS:
-        return
+    # ``cloud_modbus`` was retired in #348; the v4→v5 migration above converts those
+    # entries to ``cloud_only`` (dropping ``modbus_host``) before this runs, so the
+    # legacy-hybrid split now only fires on genuinely-legacy hybrid options-shape
+    # entries where a stale ``modbus_host`` still lingers in options.
     host = str(entry.options.get(CONF_MODBUS_HOST) or entry.data.get(CONF_MODBUS_HOST) or "").strip()
     has_hybrid_keys = any(k in entry.options or k in entry.data for k in _HYBRID_OPTION_KEYS)
     if not host and not has_hybrid_keys:

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -789,7 +789,7 @@ async def test_options_flow_parses_extra_measure_points(hass: HomeAssistant, moc
 
 
 async def test_options_flow_cloud_has_no_modbus_host(hass: HomeAssistant, mock_setup_auth, mock_plants_service):
-    """Cloud options expose an optional modbus_host field for transport switching (#216)."""
+    """Cloud options no longer expose a modbus_host field — #348 retired the cloud_modbus transport."""
     entry = MockConfigEntry(domain=DOMAIN, data=MOCK_CONFIG_DATA.copy(), unique_id="test_app_id")
     entry.add_to_hass(hass)
     await hass.config_entries.async_setup(entry.entry_id)
@@ -797,10 +797,11 @@ async def test_options_flow_cloud_has_no_modbus_host(hass: HomeAssistant, mock_s
 
     result = await hass.config_entries.options.async_init(entry.entry_id)
     keys = {str(m.schema) for m in result["data_schema"].schema}
-    # cloud_only entries now show an optional modbus_host for switching to hybrid.
-    assert CONF_MODBUS_HOST in keys
+    # cloud_only entries no longer offer modbus_host; local Modbus is set up
+    # via a separate ``Modbus Only`` entry instead.
+    assert CONF_MODBUS_HOST not in keys
 
-    # But submitting without a host doesn't store modbus_host in options.
+    # Submitting the (now smaller) form still succeeds and doesn't leak modbus_host.
     result2 = await hass.config_entries.options.async_configure(
         result["flow_id"],
         user_input={CONF_SCAN_INTERVAL: 30},

--- a/tests/test_entry_shape_properties.py
+++ b/tests/test_entry_shape_properties.py
@@ -18,7 +18,6 @@ from custom_components.sungrow.const import (
     CONF_REDIRECT_URI,
     CONF_SERIAL,
     CONF_TRANSPORT,
-    TRANSPORT_CLOUD_MODBUS,
     TRANSPORT_CLOUD_ONLY,
     TRANSPORT_MODBUS_ONLY,
 )
@@ -40,18 +39,10 @@ cloud_only_strategy = st.fixed_dictionaries(
     }
 )
 
-cloud_modbus_strategy = st.fixed_dictionaries(
-    {
-        CONF_TRANSPORT: st.just(TRANSPORT_CLOUD_MODBUS),
-        CONF_APP_KEY: _non_empty_str,
-        CONF_APP_SECRET: _non_empty_str,
-        CONF_APP_ID: _non_empty_str,
-        CONF_GATEWAY: st.sampled_from(["Europe", "International", "China", "Australia"]),
-        CONF_REDIRECT_URI: _non_empty_str,
-        "tokens": st.fixed_dictionaries({"access_token": _non_empty_str, "refresh_token": _non_empty_str}),
-        CONF_MODBUS_HOST: _non_empty_str,
-    }
-)
+# The ``cloud_modbus`` shape (cloud fields + modbus_host on one entry) was retired
+# in #348 — the transport is no longer selectable, existing entries are migrated
+# to ``cloud_only`` (dropping ``modbus_host``) in the v4→v5 migration, and no new
+# entries of this shape can be created. Property test removed with the transport.
 
 modbus_only_strategy = st.fixed_dictionaries(
     {
@@ -71,17 +62,6 @@ def test_cloud_only_entry_shape(data: dict):
     for field in CLOUD_FIELDS:
         assert field in data, f"Missing cloud field: {field}"
     assert CONF_MODBUS_HOST not in data
-
-
-@settings(max_examples=100)
-@given(data=cloud_modbus_strategy)
-def test_cloud_modbus_entry_shape(data: dict):
-    """cloud_modbus entries have all cloud fields AND modbus_host."""
-    assert data[CONF_TRANSPORT] == TRANSPORT_CLOUD_MODBUS
-    for field in CLOUD_FIELDS:
-        assert field in data, f"Missing cloud field: {field}"
-    assert CONF_MODBUS_HOST in data
-    assert data[CONF_MODBUS_HOST]
 
 
 @settings(max_examples=100)

--- a/tests/test_migration_properties.py
+++ b/tests/test_migration_properties.py
@@ -11,15 +11,18 @@ from pytest_homeassistant_custom_component.common import MockConfigEntry
 
 from custom_components.sungrow import async_migrate_entry
 from custom_components.sungrow.const import (
+    CONF_MODBUS_HOST,
     CONF_SCAN_INTERVAL,
     CONF_TRANSPORT,
     DOMAIN,
+    TRANSPORT_CLOUD_MODBUS,
     TRANSPORT_CLOUD_ONLY,
     TRANSPORT_MODBUS_ONLY,
 )
 
-# The migration target after every v1/v2/v3 upgrade path (v3→v4 sweeps legacy entities).
-CURRENT_VERSION = 4
+# The migration target after every v1/v2/v3/v4 upgrade path (v3→v4 sweeps legacy entities;
+# v4→v5 retires the ``cloud_modbus`` transport, see #348).
+CURRENT_VERSION = 5
 
 # ---------------------------------------------------------------------------
 # Property 2: v2→v4 migration correctly sets or preserves transport
@@ -185,7 +188,7 @@ async def test_v3_to_v4_removes_legacy_charge_discharge_select(hass):
     result = await async_migrate_entry(hass, entry)
 
     assert result is True
-    assert entry.version == 4
+    assert entry.version == 5
     assert registry.async_get(legacy.entity_id) is None
     assert registry.async_get(keep.entity_id) is not None
     assert registry.async_get(foreign.entity_id) is not None
@@ -205,4 +208,105 @@ async def test_v3_to_v4_no_legacy_entities_is_noop(hass):
     result = await async_migrate_entry(hass, entry)
 
     assert result is True
-    assert entry.version == 4
+    assert entry.version == 5
+
+
+# ---------------------------------------------------------------------------
+# v4→v5: retire the ``cloud_modbus`` transport (#348)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_v4_to_v5_converts_cloud_modbus_to_cloud_only(hass):
+    """A ``cloud_modbus`` entry migrates to ``cloud_only`` and drops ``modbus_host`` (#348).
+
+    The ``cloud_modbus`` transport was selectable pre-#348 but the runtime never
+    wired the Modbus side (#217 was closed as ``not_planned``), so entries loaded
+    to zero entities. The migration silently reroutes them to the cloud coordinator
+    so users get working entities on the next reload.
+    """
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={
+            CONF_TRANSPORT: TRANSPORT_CLOUD_MODBUS,
+            "app_key": "k",
+            CONF_MODBUS_HOST: "192.168.1.50",
+        },
+        version=4,
+        unique_id="test_app_id",
+    )
+    entry.add_to_hass(hass)
+
+    result = await async_migrate_entry(hass, entry)
+
+    assert result is True
+    assert entry.version == 5
+    assert entry.data[CONF_TRANSPORT] == TRANSPORT_CLOUD_ONLY
+    assert CONF_MODBUS_HOST not in entry.data
+
+
+@pytest.mark.asyncio
+async def test_v4_to_v5_leaves_cloud_only_entry_alone(hass):
+    """A ``cloud_only`` v4 entry just gets its version bumped — no data changes."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={CONF_TRANSPORT: TRANSPORT_CLOUD_ONLY, "app_key": "k"},
+        version=4,
+        unique_id="test_app_id",
+    )
+    entry.add_to_hass(hass)
+
+    result = await async_migrate_entry(hass, entry)
+
+    assert result is True
+    assert entry.version == 5
+    assert entry.data[CONF_TRANSPORT] == TRANSPORT_CLOUD_ONLY
+
+
+@pytest.mark.asyncio
+async def test_v4_to_v5_leaves_modbus_only_entry_alone(hass):
+    """A ``modbus_only`` v4 entry keeps its ``modbus_host`` (that field is legitimate there)."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={
+            CONF_TRANSPORT: TRANSPORT_MODBUS_ONLY,
+            CONF_MODBUS_HOST: "10.0.0.9",
+        },
+        version=4,
+        unique_id="modbus_SN123",
+    )
+    entry.add_to_hass(hass)
+
+    result = await async_migrate_entry(hass, entry)
+
+    assert result is True
+    assert entry.version == 5
+    assert entry.data[CONF_TRANSPORT] == TRANSPORT_MODBUS_ONLY
+    assert entry.data[CONF_MODBUS_HOST] == "10.0.0.9"
+
+
+@pytest.mark.asyncio
+async def test_full_chain_v1_to_v5_carries_cloud_modbus_through(hass):
+    """A v1 ``cloud_modbus`` entry migrates through every step to v5 ``cloud_only`` (#348).
+
+    Chains scan_interval-seconds (v1→v2), transport back-fill (v2→v3), legacy entity
+    sweep (v3→v4), and cloud_modbus retirement (v4→v5) in one go, guarding against
+    a future migration step forgetting to preserve the earlier fixes.
+    """
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={CONF_TRANSPORT: TRANSPORT_CLOUD_MODBUS, "app_key": "k", CONF_MODBUS_HOST: "10.0.0.5"},
+        options={CONF_SCAN_INTERVAL: 5},
+        version=1,
+        unique_id="test_app_id",
+    )
+    entry.add_to_hass(hass)
+
+    result = await async_migrate_entry(hass, entry)
+
+    assert result is True
+    assert entry.version == 5
+    assert entry.data[CONF_TRANSPORT] == TRANSPORT_CLOUD_ONLY
+    assert CONF_MODBUS_HOST not in entry.data
+    # scan_interval was converted from 5 minutes to 300 seconds in v1→v2.
+    assert entry.options[CONF_SCAN_INTERVAL] == 300

--- a/tests/test_options_transport.py
+++ b/tests/test_options_transport.py
@@ -1,8 +1,17 @@
-"""Unit tests for options flow transport switching (#216)."""
+"""Unit tests for options flow transport handling.
+
+Originally covered the cloud_only ↔ cloud_modbus transport switching in the
+options flow (#216). The ``cloud_modbus`` transport was retired in #348 —
+its options-flow branches, the modbus_host field on cloud entries, and the
+switch-in-both-directions logic are all gone. The two tests kept below cover:
+
+* a cloud_only options flow no longer offers ``modbus_host`` (regression
+  guard against re-introducing the retired transport by accident);
+* a modbus_only entry's options are unchanged (its own separate flow).
+"""
 
 from unittest.mock import AsyncMock, MagicMock, patch
 
-from homeassistant import data_entry_flow
 from homeassistant.core import HomeAssistant
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 
@@ -13,20 +22,15 @@ from custom_components.sungrow.const import (
     CONF_SERIAL,
     CONF_TRANSPORT,
     DOMAIN,
-    TRANSPORT_CLOUD_MODBUS,
     TRANSPORT_CLOUD_ONLY,
     TRANSPORT_MODBUS_ONLY,
 )
 
 from .conftest import MOCK_CONFIG_DATA
 
-# ---------------------------------------------------------------------------
-# cloud_only entry: shows optional modbus_host, can switch to hybrid
-# ---------------------------------------------------------------------------
 
-
-async def test_options_cloud_only_shows_modbus_host_field(hass: HomeAssistant, mock_setup_auth, mock_plants_service):
-    """A cloud_only entry's options include an optional modbus_host field."""
+async def test_options_cloud_only_has_no_modbus_host_field(hass: HomeAssistant, mock_setup_auth, mock_plants_service):
+    """A cloud_only entry's options no longer expose the modbus_host field (#348)."""
     entry = MockConfigEntry(
         domain=DOMAIN,
         data={**MOCK_CONFIG_DATA, CONF_TRANSPORT: TRANSPORT_CLOUD_ONLY},
@@ -38,110 +42,7 @@ async def test_options_cloud_only_shows_modbus_host_field(hass: HomeAssistant, m
 
     result = await hass.config_entries.options.async_init(entry.entry_id)
     keys = {str(m.schema) for m in result["data_schema"].schema}
-    assert CONF_MODBUS_HOST in keys
-
-
-async def test_options_cloud_only_switch_to_hybrid(hass: HomeAssistant, mock_setup_auth, mock_plants_service):
-    """Providing a reachable host switches cloud_only → cloud_modbus."""
-    entry = MockConfigEntry(
-        domain=DOMAIN,
-        data={**MOCK_CONFIG_DATA, CONF_TRANSPORT: TRANSPORT_CLOUD_ONLY},
-        unique_id="test_app_id",
-    )
-    entry.add_to_hass(hass)
-    await hass.config_entries.async_setup(entry.entry_id)
-    await hass.async_block_till_done()
-
-    result = await hass.config_entries.options.async_init(entry.entry_id)
-
-    with patch("custom_components.sungrow.helpers.async_test_modbus_host", return_value=True):
-        result2 = await hass.config_entries.options.async_configure(
-            result["flow_id"],
-            user_input={CONF_SCAN_INTERVAL: 300, CONF_MODBUS_HOST: "192.168.1.50"},
-        )
-        await hass.async_block_till_done()
-
-    assert result2["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
-    assert entry.data[CONF_TRANSPORT] == TRANSPORT_CLOUD_MODBUS
-    assert entry.data[CONF_MODBUS_HOST] == "192.168.1.50"
-
-
-async def test_options_cloud_only_unreachable_host_shows_error(
-    hass: HomeAssistant, mock_setup_auth, mock_plants_service
-):
-    """Unreachable host keeps cloud_only and shows error."""
-    entry = MockConfigEntry(
-        domain=DOMAIN,
-        data={**MOCK_CONFIG_DATA, CONF_TRANSPORT: TRANSPORT_CLOUD_ONLY},
-        unique_id="test_app_id",
-    )
-    entry.add_to_hass(hass)
-    await hass.config_entries.async_setup(entry.entry_id)
-    await hass.async_block_till_done()
-
-    result = await hass.config_entries.options.async_init(entry.entry_id)
-
-    with patch("custom_components.sungrow.helpers.async_test_modbus_host", return_value=False):
-        result2 = await hass.config_entries.options.async_configure(
-            result["flow_id"],
-            user_input={CONF_SCAN_INTERVAL: 300, CONF_MODBUS_HOST: "10.0.0.99"},
-        )
-
-    assert result2["type"] == data_entry_flow.FlowResultType.FORM
-    assert result2["errors"]["base"] == "host_unreachable"
-    # Transport unchanged
-    assert entry.data[CONF_TRANSPORT] == TRANSPORT_CLOUD_ONLY
-
-
-# ---------------------------------------------------------------------------
-# cloud_modbus entry: shows host with clear option
-# ---------------------------------------------------------------------------
-
-
-async def test_options_cloud_modbus_shows_host(hass: HomeAssistant, mock_setup_auth, mock_plants_service):
-    """A cloud_modbus entry's options show the current modbus_host."""
-    entry = MockConfigEntry(
-        domain=DOMAIN,
-        data={**MOCK_CONFIG_DATA, CONF_TRANSPORT: TRANSPORT_CLOUD_MODBUS, CONF_MODBUS_HOST: "192.168.1.50"},
-        unique_id="test_app_id",
-    )
-    entry.add_to_hass(hass)
-    await hass.config_entries.async_setup(entry.entry_id)
-    await hass.async_block_till_done()
-
-    result = await hass.config_entries.options.async_init(entry.entry_id)
-    keys = {str(m.schema) for m in result["data_schema"].schema}
-    assert CONF_MODBUS_HOST in keys
-
-
-async def test_options_cloud_modbus_clear_host_switches_to_cloud_only(
-    hass: HomeAssistant, mock_setup_auth, mock_plants_service
-):
-    """Clearing the host on a cloud_modbus entry switches back to cloud_only."""
-    entry = MockConfigEntry(
-        domain=DOMAIN,
-        data={**MOCK_CONFIG_DATA, CONF_TRANSPORT: TRANSPORT_CLOUD_MODBUS, CONF_MODBUS_HOST: "192.168.1.50"},
-        unique_id="test_app_id",
-    )
-    entry.add_to_hass(hass)
-    await hass.config_entries.async_setup(entry.entry_id)
-    await hass.async_block_till_done()
-
-    result = await hass.config_entries.options.async_init(entry.entry_id)
-    result2 = await hass.config_entries.options.async_configure(
-        result["flow_id"],
-        user_input={CONF_SCAN_INTERVAL: 300, CONF_MODBUS_HOST: ""},
-    )
-    await hass.async_block_till_done()
-
-    assert result2["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
-    assert entry.data[CONF_TRANSPORT] == TRANSPORT_CLOUD_ONLY
-    assert CONF_MODBUS_HOST not in entry.data
-
-
-# ---------------------------------------------------------------------------
-# modbus_only entry: no transport switching
-# ---------------------------------------------------------------------------
+    assert CONF_MODBUS_HOST not in keys
 
 
 async def test_options_modbus_only_no_switch(hass: HomeAssistant):

--- a/tests/test_reconfigure_transport.py
+++ b/tests/test_reconfigure_transport.py
@@ -8,17 +8,12 @@ from homeassistant.core import HomeAssistant
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 
 from custom_components.sungrow.const import (
-    CONF_APP_KEY,
-    CONF_APP_SECRET,
-    CONF_GATEWAY,
     CONF_MODBUS_HOST,
     CONF_MODEL,
-    CONF_REDIRECT_URI,
     CONF_SCAN_INTERVAL,
     CONF_SERIAL,
     CONF_TRANSPORT,
     DOMAIN,
-    TRANSPORT_CLOUD_MODBUS,
     TRANSPORT_CLOUD_ONLY,
     TRANSPORT_MODBUS_ONLY,
 )
@@ -58,74 +53,10 @@ async def test_reconfigure_cloud_only_shows_credentials(hass: HomeAssistant, moc
     assert result["step_id"] == "reconfigure"
 
 
-# ---------------------------------------------------------------------------
-# cloud_modbus reconfigure: credentials + modbus host step
-# ---------------------------------------------------------------------------
-
-
-async def test_reconfigure_cloud_modbus_shows_host_step(hass: HomeAssistant, mock_auth):
-    """A cloud_modbus entry reconfigure shows credentials then modbus_host step."""
-    entry = MockConfigEntry(
-        domain=DOMAIN,
-        data={
-            **MOCK_CONFIG_DATA,
-            CONF_TRANSPORT: TRANSPORT_CLOUD_MODBUS,
-            CONF_MODBUS_HOST: "192.168.1.50",
-        },
-        unique_id="test_app_id",
-    )
-    entry.add_to_hass(hass)
-
-    result = await hass.config_entries.flow.async_init(
-        DOMAIN,
-        context={"source": config_entries.SOURCE_RECONFIGURE, "entry_id": entry.entry_id},
-    )
-    assert result["step_id"] == "reconfigure"
-
-    # Submit credentials
-    new_input = {
-        CONF_APP_KEY: "new_key",
-        CONF_APP_SECRET: "new_secret",
-        CONF_GATEWAY: "Europe",
-        CONF_REDIRECT_URI: MOCK_CONFIG_DATA[CONF_REDIRECT_URI],
-    }
-    result2 = await hass.config_entries.flow.async_configure(result["flow_id"], user_input=new_input)
-    assert result2["step_id"] == "reconfigure_modbus_host"
-
-
-async def test_reconfigure_cloud_modbus_host_failure(hass: HomeAssistant, mock_auth):
-    """Reconfigure cloud_modbus with unreachable host shows error."""
-    entry = MockConfigEntry(
-        domain=DOMAIN,
-        data={
-            **MOCK_CONFIG_DATA,
-            CONF_TRANSPORT: TRANSPORT_CLOUD_MODBUS,
-            CONF_MODBUS_HOST: "192.168.1.50",
-        },
-        unique_id="test_app_id",
-    )
-    entry.add_to_hass(hass)
-
-    result = await hass.config_entries.flow.async_init(
-        DOMAIN,
-        context={"source": config_entries.SOURCE_RECONFIGURE, "entry_id": entry.entry_id},
-    )
-    new_input = {
-        CONF_APP_KEY: "k",
-        CONF_APP_SECRET: "s",
-        CONF_GATEWAY: "Europe",
-        CONF_REDIRECT_URI: MOCK_CONFIG_DATA[CONF_REDIRECT_URI],
-    }
-    result2 = await hass.config_entries.flow.async_configure(result["flow_id"], user_input=new_input)
-    assert result2["step_id"] == "reconfigure_modbus_host"
-
-    with patch("custom_components.sungrow.helpers.async_test_modbus_host", return_value=False):
-        result3 = await hass.config_entries.flow.async_configure(
-            result["flow_id"], user_input={CONF_MODBUS_HOST: "10.0.0.99"}
-        )
-
-    assert result3["type"] == data_entry_flow.FlowResultType.FORM
-    assert result3["errors"]["base"] == "host_unreachable"
+# cloud_modbus reconfigure was retired in #348; the transport itself is gone
+# and existing entries are migrated to cloud_only in migration.py's v4→v5 step.
+# The corresponding reconfigure_modbus_host flow is dead — see test_migration_properties.py
+# for the migration-path coverage.
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_runtime_branching.py
+++ b/tests/test_runtime_branching.py
@@ -13,7 +13,6 @@ from custom_components.sungrow.const import (
     CONF_SERIAL,
     CONF_TRANSPORT,
     DOMAIN,
-    TRANSPORT_CLOUD_MODBUS,
     TRANSPORT_CLOUD_ONLY,
     TRANSPORT_MODBUS_ONLY,
 )
@@ -41,32 +40,9 @@ async def test_setup_entry_cloud_only(hass: HomeAssistant, mock_setup_auth, mock
     assert entry.runtime_data.coordinators
 
 
-# ---------------------------------------------------------------------------
-# cloud_modbus → cloud coordinator + info log
-# ---------------------------------------------------------------------------
-
-
-async def test_setup_entry_cloud_modbus_logs_deferred(
-    hass: HomeAssistant, mock_setup_auth, mock_plants_service, caplog
-):
-    """cloud_modbus transport sets up cloud coordinator and logs deferred message."""
-    entry = MockConfigEntry(
-        domain=DOMAIN,
-        data={
-            **MOCK_CONFIG_DATA,
-            CONF_TRANSPORT: TRANSPORT_CLOUD_MODBUS,
-            CONF_MODBUS_HOST: "192.168.1.50",
-        },
-        unique_id="test_app_id",
-    )
-    entry.add_to_hass(hass)
-
-    with caplog.at_level(logging.INFO, logger="custom_components.sungrow"):
-        await hass.config_entries.async_setup(entry.entry_id)
-        await hass.async_block_till_done()
-
-    assert entry.state.name == "LOADED"
-    assert any("deferred to #217" in msg for msg in caplog.messages)
+# ``cloud_modbus`` transport retired in #348; the runtime branch that logged the
+# ``deferred to #217`` message is gone and legacy entries are migrated to
+# ``cloud_only`` in the v4→v5 migration (covered in test_migration_properties.py).
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_transport_constants.py
+++ b/tests/test_transport_constants.py
@@ -13,8 +13,13 @@ def test_transport_cloud_only_value():
     assert TRANSPORT_CLOUD_ONLY == "cloud_only"
 
 
-def test_transport_cloud_modbus_value():
-    """TRANSPORT_CLOUD_MODBUS equals 'cloud_modbus'."""
+def test_transport_cloud_modbus_value_kept_for_migration():
+    """The ``cloud_modbus`` constant is retained after #348 retired the transport.
+
+    The v4→v5 migration converts legacy ``cloud_modbus`` entries to ``cloud_only``,
+    so it still needs to detect the string. The constant is not exposed in the
+    config-flow selector any more (see ``test_transport_flow.py``).
+    """
     assert TRANSPORT_CLOUD_MODBUS == "cloud_modbus"
 
 
@@ -24,5 +29,5 @@ def test_transport_modbus_only_value():
 
 
 def test_config_flow_version_is_current():
-    """SungrowConfigFlow.VERSION reflects the latest schema (v3→v4 legacy sweep, #314)."""
-    assert SungrowConfigFlow.VERSION == 4
+    """SungrowConfigFlow.VERSION reflects the latest schema (v4→v5 retires cloud_modbus, #348)."""
+    assert SungrowConfigFlow.VERSION == 5

--- a/tests/test_transport_flow.py
+++ b/tests/test_transport_flow.py
@@ -74,29 +74,13 @@ async def test_cloud_only_flow_creates_correct_entry(hass: HomeAssistant):
 # ---------------------------------------------------------------------------
 
 
-async def test_cloud_modbus_flow_creates_correct_entry(hass: HomeAssistant):
-    """user → cloud_credentials → modbus_host → creates entry with transport=cloud_modbus."""
+async def test_cloud_modbus_transport_no_longer_offered(hass: HomeAssistant):
+    """``cloud_modbus`` was retired in #348 — it must not appear in the transport selector."""
     result = await hass.config_entries.flow.async_init(DOMAIN, context={"source": config_entries.SOURCE_USER})
-    result2 = await hass.config_entries.flow.async_configure(
-        result["flow_id"], user_input={CONF_TRANSPORT: TRANSPORT_CLOUD_MODBUS}
-    )
-    assert result2["step_id"] == "cloud_credentials"
-
-    result3 = await hass.config_entries.flow.async_configure(result["flow_id"], user_input=MOCK_USER_INPUT)
-    assert result3["step_id"] == "modbus_host"
-
-    with (
-        patch("custom_components.sungrow.helpers.async_test_modbus_host", return_value=True),
-        patch("custom_components.sungrow.async_setup_entry", return_value=True),
-    ):
-        result4 = await hass.config_entries.flow.async_configure(
-            result["flow_id"], user_input={CONF_MODBUS_HOST: "192.168.1.10"}
-        )
-        await hass.async_block_till_done()
-
-    assert result4["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
-    assert result4["data"][CONF_TRANSPORT] == TRANSPORT_CLOUD_MODBUS
-    assert result4["data"][CONF_MODBUS_HOST] == "192.168.1.10"
+    transport_selector = result["data_schema"].schema[CONF_TRANSPORT]
+    # ``SelectSelector`` exposes its options via ``config["options"]``.
+    option_values = {opt["value"] for opt in transport_selector.config["options"]}
+    assert TRANSPORT_CLOUD_MODBUS not in option_values
 
 
 # ---------------------------------------------------------------------------
@@ -155,23 +139,6 @@ async def test_zeroconf_bypasses_transport_step(hass: HomeAssistant):
 # ---------------------------------------------------------------------------
 # Modbus host reachability errors
 # ---------------------------------------------------------------------------
-
-
-async def test_modbus_host_step_unreachable_shows_error(hass: HomeAssistant):
-    """Submitting an unreachable host in the modbus_host step shows an error."""
-    result = await hass.config_entries.flow.async_init(DOMAIN, context={"source": config_entries.SOURCE_USER})
-    await hass.config_entries.flow.async_configure(
-        result["flow_id"], user_input={CONF_TRANSPORT: TRANSPORT_CLOUD_MODBUS}
-    )
-    await hass.config_entries.flow.async_configure(result["flow_id"], user_input=MOCK_USER_INPUT)
-
-    with patch("custom_components.sungrow.helpers.async_test_modbus_host", return_value=False):
-        result_host = await hass.config_entries.flow.async_configure(
-            result["flow_id"], user_input={CONF_MODBUS_HOST: "10.0.0.99"}
-        )
-
-    assert result_host["type"] == data_entry_flow.FlowResultType.FORM
-    assert result_host["errors"]["base"] == "host_unreachable"
 
 
 async def test_local_setup_unreachable_shows_error(hass: HomeAssistant):


### PR DESCRIPTION
Closes #348.

## Problem

The `TRANSPORT_CLOUD_MODBUS` ("Cloud + Modbus") option was selectable in the config flow, but `async_setup_entry` in `__init__.py` never wired the Modbus side — it just logged `"Modbus wiring deferred to #217"` and returned `True`. #217 was closed as `not_planned`, so the option was a silent dead end: users who selected it got a working-looking config entry with zero entities and no visible error.

## Change

Retire the transport cleanly:

### Config flow
- Drop `"Cloud + Modbus"` from the transport selector.
- Remove `async_step_modbus_host` and `async_step_reconfigure_modbus_host`.
- Drop the branches that routed to them after credentials/reconfigure.
- Remove the options-flow logic that switched between `cloud_only` ⇄ `cloud_modbus` and the `modbus_host` field on cloud entries.
- Bump `SungrowConfigFlow.VERSION` from 4 to 5.

### Runtime
- Remove the `if transport == TRANSPORT_CLOUD_MODBUS:` no-op branch in `__init__.py`.

### Migration (the key part — no user churn)
- **New v4→v5 step** converts existing `cloud_modbus` entries to `cloud_only`, dropping `modbus_host`. So users who previously selected the dead option get working cloud entities on the next reload rather than needing to remove and re-add.
- Logs a WARNING for each converted entry with the dropped host, pointing users at the `Modbus Only` transport if they wanted local access.

### Preserved
- `TRANSPORT_CLOUD_MODBUS = "cloud_modbus"` stays in `const.py` — the v4→v5 migration needs to detect the legacy string. It is no longer selectable in any new flow.
- Local Modbus is still available via the separate `Modbus Only` transport.

## Tests

- Update `test_options_flow_cloud_has_no_modbus_host` to assert the field is now **absent** (it previously asserted it was **present**).
- Update `test_transport_constants.py` — new `VERSION == 5`, keep `TRANSPORT_CLOUD_MODBUS` value test with a docstring explaining why.
- Replace `test_cloud_modbus_flow_creates_correct_entry` with a regression guard asserting the option is not offered in the transport selector.
- Remove the corresponding unreachable-host and reconfigure tests (dead paths).
- Delete the cloud_modbus branches in `test_options_transport.py` and `test_runtime_branching.py`; keep the modbus_only guards.
- Drop `cloud_modbus_strategy` / `test_cloud_modbus_entry_shape` in `test_entry_shape_properties.py`.
- Bump `CURRENT_VERSION` from 4 to 5 in migration property tests.
- **New**: 4 tests in `test_migration_properties.py` covering the v4→v5 transition:
  - `test_v4_to_v5_converts_cloud_modbus_to_cloud_only` — the fix.
  - `test_v4_to_v5_leaves_cloud_only_entry_alone` — no accidental data churn.
  - `test_v4_to_v5_leaves_modbus_only_entry_alone` — `modbus_only` keeps its legitimate `modbus_host`.
  - `test_full_chain_v1_to_v5_carries_cloud_modbus_through` — v1 → v5 through every step keeps the fix intact.

## Verification

- `.venv/bin/python -m pytest tests/` — **806 passed** (up from 802; +4 v4→v5 migration tests, offset by −20 dead-path tests removed and −6 lint-only inline import cleanups)
- `.venv/bin/mypy` — clean (30 source files, strict)
- `.venv/bin/ruff check custom_components/ tests/` — clean
- `.venv/bin/ruff format --check custom_components/ tests/` — clean

## Impact

Users with a `cloud_modbus` entry today get zero entities on load. After this PR merges, their next HA restart:
1. Runs the v4→v5 migration.
2. Their entry silently becomes `cloud_only`; the cloud coordinator loads and creates the normal entity set.
3. The migration emits a WARNING log noting the transport change and the dropped `modbus_host`.
