### PR TITLE
feat(diagnostics): include active Repair issues in the diagnostics bundle

### DIFF
--- a/custom_components/sungrow/diagnostics.py
+++ b/custom_components/sungrow/diagnostics.py
@@ -8,9 +8,11 @@ from typing import Any
 
 from homeassistant.components.diagnostics import async_redact_data
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers import issue_registry as ir
 
 from . import SungrowConfigEntry, SungrowData
 from ._serialization import anonymise_device_keys, catalog_rows, jsonable
+from .const import DOMAIN
 from .model_capabilities import resolve_capabilities
 
 _LOGGER = logging.getLogger(__name__)
@@ -43,6 +45,48 @@ TO_REDACT = {
     "device_name",
     "ps_name",
 }
+
+
+def collect_active_repairs(hass: HomeAssistant) -> list[dict[str, Any]]:
+    """Snapshot every Sungrow-owned Repair for the diagnostics bundle (#357).
+
+    Users routinely download diagnostics to attach to a support ticket, but the
+    Repairs inbox lives in a separate UI panel and is easy to forget — support
+    ends up asking "check your Repairs and screenshot them" as a second round-trip.
+    Including a snapshot here means one download tells the whole story.
+
+    Returned rows carry only non-PII identifiers: the ``issue_id`` (which encodes
+    the plant id, never a secret), the translation key, severity, active/ignored
+    flags, and the created timestamp. Deliberately dropped:
+
+    * ``data`` — Repairs sometimes carry endpoint URLs or error strings that could
+      leak network configuration; safer to omit than to try scrubbing.
+    * ``translation_placeholders`` — may carry plant/device names.
+    * ``domain`` — always ``sungrow``; noise.
+    * ``breaks_in_ha_version`` / ``is_persistent`` — internal to the Repair
+      framework, not useful for triage.
+
+    Rows are sorted by ``issue_id`` for a deterministic bundle (diff-friendly).
+    """
+    registry = ir.async_get(hass)
+    rows: list[dict[str, Any]] = []
+    for (domain, issue_id), issue in registry.issues.items():
+        if domain != DOMAIN:
+            continue
+        rows.append(
+            {
+                "issue_id": issue_id,
+                "translation_key": issue.translation_key,
+                "severity": issue.severity.value if issue.severity is not None else None,
+                "is_fixable": issue.is_fixable,
+                "learn_more_url": issue.learn_more_url,
+                "active": issue.active,
+                "dismissed_version": issue.dismissed_version,
+                "created": issue.created.isoformat() if issue.created is not None else None,
+            }
+        )
+    rows.sort(key=lambda row: row["issue_id"])
+    return rows
 
 
 def build_points_catalog(
@@ -184,6 +228,10 @@ async def async_get_config_entry_diagnostics(hass: HomeAssistant, entry: Sungrow
             "tokens_present": "tokens" in entry.data,
             "options": dict(entry.options),
             "plants": plant_data,
+            # Active Sungrow Repairs (#357). Global to the integration (issues aren't
+            # per-entry) so the same list appears in every entry's bundle — harmless
+            # duplication for a much friendlier one-shot support workflow.
+            "repairs": collect_active_repairs(hass),
         },
         TO_REDACT,
     )

--- a/tests/test_diagnostics.py
+++ b/tests/test_diagnostics.py
@@ -388,3 +388,100 @@ async def test_points_catalog_handles_probe_error(hass: HomeAssistant):
     assert charger["points"] == []
     assert charger["family"] == "unknown"
     json.dumps(diag)
+
+
+# ---------------------------------------------------------------------------
+# Active Repairs in the diagnostics bundle (#357)
+# ---------------------------------------------------------------------------
+
+
+async def test_diagnostics_includes_active_sungrow_repairs(hass: HomeAssistant):
+    """Active Sungrow-owned issue-registry entries appear under ``repairs`` (#357)."""
+    from homeassistant.helpers import issue_registry as ir
+
+    from custom_components.sungrow.const import DOMAIN
+
+    ir.async_create_issue(
+        hass,
+        DOMAIN,
+        "rate_limited_12345",
+        is_fixable=False,
+        severity=ir.IssueSeverity.WARNING,
+        translation_key="rate_limited",
+    )
+    ir.async_create_issue(
+        hass,
+        DOMAIN,
+        "dispatch_not_actuated_12345",
+        is_fixable=False,
+        severity=ir.IssueSeverity.WARNING,
+        translation_key="dispatch_not_actuated",
+    )
+    # A non-Sungrow issue that must NOT appear in the bundle.
+    ir.async_create_issue(
+        hass,
+        "some_other_domain",
+        "unrelated_issue",
+        is_fixable=False,
+        severity=ir.IssueSeverity.ERROR,
+        translation_key="unrelated",
+    )
+
+    entry = MagicMock()
+    entry.entry_id = "test_entry"
+    entry.data = {"gateway": "Europe", "tokens": {"access_token": "x", "refresh_token": "y"}}
+    entry.options = {}
+    entry.runtime_data = SungrowData(coordinators=[], control=MagicMock(), devices={})
+
+    diag = await async_get_config_entry_diagnostics(hass, entry)
+
+    assert "repairs" in diag
+    repair_ids = {row["issue_id"] for row in diag["repairs"]}
+    # Only Sungrow-owned issues appear.
+    assert repair_ids == {"dispatch_not_actuated_12345", "rate_limited_12345"}
+    # And they carry the expected non-PII fields.
+    rate_row = next(row for row in diag["repairs"] if row["issue_id"] == "rate_limited_12345")
+    assert rate_row["translation_key"] == "rate_limited"
+    assert rate_row["severity"] == "warning"
+    assert rate_row["is_fixable"] is False
+    assert rate_row["active"] is True
+
+
+async def test_diagnostics_repairs_is_empty_when_no_issues(hass: HomeAssistant):
+    """A clean registry produces an empty ``repairs`` list — never a missing key."""
+    entry = MagicMock()
+    entry.entry_id = "test_entry"
+    entry.data = {"gateway": "Europe", "tokens": {"access_token": "x", "refresh_token": "y"}}
+    entry.options = {}
+    entry.runtime_data = SungrowData(coordinators=[], control=MagicMock(), devices={})
+
+    diag = await async_get_config_entry_diagnostics(hass, entry)
+
+    assert diag["repairs"] == []
+
+
+async def test_diagnostics_repairs_are_sorted_deterministically(hass: HomeAssistant):
+    """``repairs`` rows come out sorted by ``issue_id`` so bundle diffs stay noise-free."""
+    from homeassistant.helpers import issue_registry as ir
+
+    from custom_components.sungrow.const import DOMAIN
+
+    for issue_id in ("z_last", "a_first", "m_middle"):
+        ir.async_create_issue(
+            hass,
+            DOMAIN,
+            issue_id,
+            is_fixable=False,
+            severity=ir.IssueSeverity.WARNING,
+            translation_key="whatever",
+        )
+
+    entry = MagicMock()
+    entry.entry_id = "test_entry"
+    entry.data = {"gateway": "Europe", "tokens": {"access_token": "x", "refresh_token": "y"}}
+    entry.options = {}
+    entry.runtime_data = SungrowData(coordinators=[], control=MagicMock(), devices={})
+
+    diag = await async_get_config_entry_diagnostics(hass, entry)
+
+    assert [row["issue_id"] for row in diag["repairs"]] == ["a_first", "m_middle", "z_last"]


### PR DESCRIPTION
Closes #357.

## What

Attach the active Sungrow Repairs to the diagnostics bundle so support tickets don't need a separate "please check your Repairs inbox" round-trip.

```jsonc
// diagnostics bundle
{
  "entry_id": "...",
  "gateway": "Europe",
  "plants": { ... },
  "repairs": [
    {
      "issue_id": "dispatch_not_actuated_12345",
      "translation_key": "dispatch_not_actuated",
      "severity": "warning",
      "is_fixable": false,
      "learn_more_url": "https://github.com/KRoperUK/sungrow-hass/blob/main/docs/TROUBLESHOOTING.md",
      "active": true,
      "dismissed_version": null,
      "created": "2026-07-19T12:34:56+00:00"
    }
  ]
}
```

## Design

New `collect_active_repairs(hass)` helper in `diagnostics.py`. It walks the issue registry, filters to the `sungrow` domain, and returns a deterministically-sorted list of rows with only non-PII fields.

**Included:** `issue_id`, `translation_key`, `severity`, `is_fixable`, `learn_more_url`, `active`, `dismissed_version`, `created`.

**Deliberately dropped:**
- `data` — Repairs sometimes carry endpoint URLs or error strings that could leak network configuration.
- `translation_placeholders` — may carry plant/device names.
- `domain` — always `"sungrow"`, noise.
- `breaks_in_ha_version` / `is_persistent` — Repair-framework internals, not useful for triage.

Repairs are integration-global (not per-entry), so the same list appears in every entry's bundle. Harmless duplication for a much friendlier one-shot support workflow.

Rows are sorted by `issue_id` for a stable diff-friendly bundle.

## Tests

Three new tests in `test_diagnostics.py`:

- `test_diagnostics_includes_active_sungrow_repairs` — Sungrow-owned issues appear, non-Sungrow issues are filtered out, and rows carry the expected non-PII fields.
- `test_diagnostics_repairs_is_empty_when_no_issues` — clean registry yields `"repairs": []` (never a missing key — consumers can rely on the shape).
- `test_diagnostics_repairs_are_sorted_deterministically` — rows come out sorted by `issue_id` so support bundles diff cleanly.

## Verification

- `.venv/bin/python -m pytest tests/` — **814 passed** (up from 811 in main; +3 new)
- `.venv/bin/mypy` — clean (30 source files, strict)
- `.venv/bin/ruff check custom_components/ tests/` — clean
- `.venv/bin/ruff format --check custom_components/ tests/` — clean
