### PR TITLE
refactor(number): consolidate rated-power resolution on model_specs

### DIFF
--- a/custom_components/sungrow/number.py
+++ b/custom_components/sungrow/number.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import logging
 import re
-from typing import Any
+from typing import Any, Literal
 
 from homeassistant.components.number import NumberDeviceClass, NumberEntity, NumberMode, RestoreNumber
 from homeassistant.const import EntityCategory
@@ -168,38 +168,70 @@ DISPATCH_NUMBERS: dict[str, dict[str, Any]] = {
     },
 }
 
-# Watt-valued power parameters whose slider maximum is sized from the device.
-# ``feed_in_limitation_value`` follows the AC nameplate rating (an export limit
-# cannot exceed what the inverter can push to the grid). ``charge_discharge_power``
-# is a *battery-side* number and can exceed the AC rating: SH-RS single-phase
-# hybrids top out around 3–6 kW AC but drive 6.6–10.6 kW to the battery. The
-# spec catalog (#332) provides both numbers per model; entities fall back to the
-# AC rating and finally to :data:`DEFAULT_MAX_DISPATCH_POWER` when the model
-# isn't in the catalog, so behaviour is unchanged for unknown models.
-_AC_RATED_POWER_PARAMS = frozenset({"feed_in_limitation_value"})
-_BATTERY_POWER_PARAMS = frozenset({"charge_discharge_power"})
+# Watt-valued dispatch parameters whose slider maximum is sized from the device.
+# The value picks the resolution strategy — ``"ac"`` reads the AC nameplate
+# (``feed_in_limitation_value``, since an export limit cannot exceed what the
+# inverter can push to the grid), ``"battery"`` reads the battery-side rating
+# (``charge_discharge_power``, since SH-RS hybrids drive 6.6–10.6 kW to the
+# battery from a 3–6 kW AC output — the battery limit exceeds the AC rating).
+#
+# Adding a new watt-valued parameter is a one-line change here; ``_resolve_param_max_power``
+# routes on the value. Non-watt params (percent, duration, ratio) don't appear
+# in this mapping — their bounds are static per :data:`DISPATCH_NUMBERS`.
+_POWER_PARAM_RATING_KIND: dict[str, Literal["ac", "battery"]] = {
+    "feed_in_limitation_value": "ac",
+    "charge_discharge_power": "battery",
+}
 
 
-def _resolve_param_max_power(
-    param: str,
-    target: dict[str, Any],
-    ac_rated_power: int,
-) -> int:
-    """Return the slider ceiling for a watt-valued dispatch parameter.
+def _resolve_ac_rated_power(target: dict[str, Any]) -> int:
+    """Return the device's AC-side rated output power in watts.
 
-    Battery-side params consult the datasheet catalog for the model's
-    ``max_charge_power`` (larger of charge/discharge, since the same slider drives
-    both directions). AC-side params keep the historic AC-nameplate ceiling.
-    ``ac_rated_power`` is the caller's already-resolved fallback so the
-    conservative default is applied in exactly one place.
+    Single source of truth for AC-side rating resolution, priority-ordered:
+
+    1. Datasheet catalog (:func:`~custom_components.sungrow.model_specs.spec_for`) —
+       the authoritative per-model number where known. Preferred over the regex
+       fallback because e.g. SG3.6RS parses to 3600 W but the datasheet lists 3680 W.
+    2. Model-code regex (:func:`rated_power_w`) — catches unknown models that
+       still encode the kW rating in their model code.
+    3. :data:`DEFAULT_MAX_DISPATCH_POWER` — final conservative clamp.
     """
-    if param in _BATTERY_POWER_PARAMS:
-        spec = spec_for(str(target.get("device_model_code") or ""))
-        if spec is not None:
-            battery_limits = [x for x in (spec.max_charge_power, spec.max_discharge_power) if x is not None]
-            if battery_limits:
-                return max(battery_limits)
-    return ac_rated_power
+    spec = spec_for(str(target.get("device_model_code") or ""))
+    if spec is not None:
+        return spec.max_ac_output_power
+    return rated_power_w(target) or DEFAULT_MAX_DISPATCH_POWER
+
+
+def _resolve_battery_rated_power(target: dict[str, Any]) -> int:
+    """Return the device's battery-side rated power (max of charge/discharge) in watts.
+
+    Battery-side sliders drive charge OR discharge, so the ceiling is
+    ``max(charge_power, discharge_power)`` from the datasheet. Falls back to the
+    AC rating for models without battery entries in the catalog, and finally to
+    :data:`DEFAULT_MAX_DISPATCH_POWER` — same conservative floor as
+    :func:`_resolve_ac_rated_power`.
+    """
+    spec = spec_for(str(target.get("device_model_code") or ""))
+    if spec is not None:
+        battery_limits = [x for x in (spec.max_charge_power, spec.max_discharge_power) if x is not None]
+        if battery_limits:
+            return max(battery_limits)
+    return _resolve_ac_rated_power(target)
+
+
+def _resolve_param_max_power(param: str, target: dict[str, Any]) -> int | None:
+    """Return the slider ceiling for a watt-valued dispatch parameter, or ``None``.
+
+    Consults :data:`_POWER_PARAM_RATING_KIND` to decide whether the parameter is
+    AC-side or battery-side, and routes to the appropriate resolver. Returns
+    ``None`` for parameters that aren't watt-valued (their bounds are static).
+    """
+    kind = _POWER_PARAM_RATING_KIND.get(param)
+    if kind == "ac":
+        return _resolve_ac_rated_power(target)
+    if kind == "battery":
+        return _resolve_battery_rated_power(target)
+    return None
 
 
 def _build_numbers(coordinator: SungrowPlantCoordinator, control: DispatchControl | None) -> list[NumberEntity]:
@@ -220,9 +252,6 @@ def _build_numbers(coordinator: SungrowPlantCoordinator, control: DispatchContro
         return []
     if not target.get("uuid"):
         return []
-    # Fallback ceiling used when the model isn't in the datasheet catalog (#332):
-    # parse the model code's kW rating and clamp; else the conservative default.
-    ac_rated_power = rated_power_w(target) or DEFAULT_MAX_DISPATCH_POWER
     # Local ModbusControl only maps a subset of Appendix-10 params (#220).
     # Require a real collection so MagicMock control clients in tests are unaffected.
     raw_supported = getattr(control, "supported_parameters", None)
@@ -234,10 +263,11 @@ def _build_numbers(coordinator: SungrowPlantCoordinator, control: DispatchContro
             continue
         if supported is not None and param not in supported:
             continue
-        if param in _AC_RATED_POWER_PARAMS or param in _BATTERY_POWER_PARAMS:
-            max_power = _resolve_param_max_power(param, target, ac_rated_power)
-            if max_power != meta["native_max_value"]:
-                meta = {**meta, "native_max_value": max_power}
+        # Watt-valued params get their slider ceiling from the device's rated power
+        # (:func:`_resolve_param_max_power` returns ``None`` for non-watt params).
+        max_power = _resolve_param_max_power(param, target)
+        if max_power is not None and max_power != meta["native_max_value"]:
+            meta = {**meta, "native_max_value": max_power}
         entities.append(SungrowDispatchNumber(coordinator, control, target, param, meta))
     # The forced-dispatch auto-revert timeout only makes sense alongside the battery
     # charge/discharge controls, so gate it on the same has_battery check (#157/#148).

--- a/tests/test_dispatch.py
+++ b/tests/test_dispatch.py
@@ -742,6 +742,48 @@ async def test_charge_power_max_falls_back_to_default(hass: HomeAssistant):
     assert power._attr_native_max_value == DEFAULT_MAX_DISPATCH_POWER
 
 
+async def test_feed_in_limitation_prefers_datasheet_over_regex(hass: HomeAssistant):
+    """AC-side resolution reads the datasheet before the model-code regex (#353).
+
+    Regression test: SG3.6RS parses to 3600 W via ``rated_power_w`` but the datasheet
+    lists the real nameplate as 3680 W. Before consolidating on
+    :func:`_resolve_ac_rated_power`, the AC-side path went straight through the
+    regex and clipped ~80 W. The datasheet now wins.
+    """
+    entry = MockConfigEntry(domain=DOMAIN, data=MOCK_CONFIG_DATA.copy())
+    entry.add_to_hass(hass)
+    # SG3.6RS is a PV-only string inverter — no dispatch. Use an SH3.6RS (hybrid)
+    # so the export-limit entity is actually built and its ceiling is checked.
+    devices = [{"uuid": "ess-1", "device_type": DeviceType.ENERGY_STORAGE_SYSTEM, "device_model_code": "SH3.6RS"}]
+    _setup_entry_data(entry, devices)
+
+    added = []
+    await number_setup_entry(hass, entry, lambda entities: added.extend(entities))
+
+    export_limit = next(e for e in added if e.param == "feed_in_limitation_value")
+    # 3680 (datasheet SH3.6RS AC nameplate), not 3600 (regex parse of "3.6").
+    assert export_limit._attr_native_max_value == 3680
+
+
+def test_resolve_param_max_power_returns_none_for_non_watt_params():
+    """The resolver returns ``None`` for params that aren't watt-valued (#353).
+
+    Percent / duration / ratio params keep their static bounds from ``DISPATCH_NUMBERS``;
+    only ``feed_in_limitation_value`` and ``charge_discharge_power`` get per-device rescaling.
+    """
+    from custom_components.sungrow.number import _resolve_param_max_power
+
+    target = {"device_model_code": "SH3.6RS", "uuid": "ess-1"}
+    # Non-watt params: no rating resolution applies.
+    assert _resolve_param_max_power("soc_upper_limit", target) is None
+    assert _resolve_param_max_power("q_t", target) is None
+    assert _resolve_param_max_power("pf", target) is None
+    assert _resolve_param_max_power("external_ems_heartbeat", target) is None
+    # Watt params: resolution kicks in.
+    assert _resolve_param_max_power("feed_in_limitation_value", target) == 3680
+    assert _resolve_param_max_power("charge_discharge_power", target) == 6600
+
+
 # ---------------------------------------------------------------------------
 # kW unit conversion + additional controls (device-verified formats)
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #353.

## Problem

`number.py` had two overlapping "rated power" sources feeding three sites:

1. `rated_power_w()` — regex parses kW from model code.
2. `spec_for()` — datasheet catalog lookup (#332).

Consequence: the datasheet's authoritative AC nameplate was ignored for AC-side params. **SG3.6RS parses to 3600 W but the datasheet lists 3680 W** — the export-limit slider was clipping ~80 W silently.

## Change

Two small helpers with clear priority order:

- **`_resolve_ac_rated_power(target)`** — datasheet → regex → `DEFAULT_MAX_DISPATCH_POWER`.
- **`_resolve_battery_rated_power(target)`** — datasheet → AC fallback → `DEFAULT_MAX_DISPATCH_POWER`.

Both bottom out at the same conservative floor in exactly one place. Datasheet wins over regex because the catalog carries the real nameplate; regex still catches models outside the catalog.

Replace the `_AC_RATED_POWER_PARAMS` / `_BATTERY_POWER_PARAMS` frozensets with a single `_POWER_PARAM_RATING_KIND: dict[str, Literal["ac", "battery"]]` mapping. Adding a new watt-valued dispatch parameter is now a one-line change.

`_resolve_param_max_power(param, target)` returns `int | None` — `None` for non-watt params. Callers stop branching on set membership; `_build_numbers` becomes straight-line.

## Tests

Two new tests in `test_dispatch.py`:

- `test_feed_in_limitation_prefers_datasheet_over_regex` — the regression this closes: SH3.6RS's export-limit slider now reads 3680 W (datasheet) rather than 3600 W (regex).
- `test_resolve_param_max_power_returns_none_for_non_watt_params` — pins the new `None` return contract for percent / duration / ratio params.

Existing `rated_power_w`, SH-RS battery-ceiling, SG250HX fallback, and default-clamp tests still pass unchanged.

## Verification

- `.venv/bin/python -m pytest tests/` — **811 passed** (up from 809; +2 new)
- `.venv/bin/mypy` — clean (30 source files, strict)
- `.venv/bin/ruff check custom_components/ tests/` — clean
- `.venv/bin/ruff format --check custom_components/ tests/` — clean

## Impact

Users on SG3.6RS-derived hybrids get an 80 W wider slider on export-limit (previously silently clipped). No breaking changes.
