### PR TITLE
feat(sensor): expose modbus_diagnostics as a diagnostic entity

### DIFF
--- a/custom_components/sungrow/sensor.py
+++ b/custom_components/sungrow/sensor.py
@@ -196,6 +196,15 @@ def _build_sensors(coordinator: SungrowPlantCoordinator, console_url: str) -> li
                     continue
                 sensors.append(sensor)
 
+    # Modbus-only diagnostic sensor (#361): a text sensor whose state is the last
+    # error string ("ok" on success). Disabled by default — power users enable it
+    # in the entity registry so they can alert on Modbus stalls without decoding
+    # the ``extra_state_attributes`` on the connectivity binary_sensor.
+    if coordinator.plants_service is None:
+        for device in coordinator.devices:
+            if device.get("device_type") == DeviceType.INVERTER and device.get("uuid"):
+                sensors.append(SungrowModbusStatusSensor(coordinator, device))
+
     return sensors
 
 
@@ -518,3 +527,61 @@ class SungrowPlantDetailSensor(CoordinatorEntity[SungrowPlantCoordinator], Senso
             return str(raw)
         # Counts (alarm/fault) are whole numbers, not floats.
         return int(num) if self._desc.integer else num
+
+
+class SungrowModbusStatusSensor(CoordinatorEntity[SungrowPlantCoordinator], SensorEntity):
+    """A per-inverter diagnostic status text sensor for local Modbus entries (#361).
+
+    Reports the last Modbus poll's error string, or ``"ok"`` when the last poll
+    succeeded. Attributes carry the resolved device family and any register
+    blocks that were skipped as unsupported so users can alert on repeated errors
+    or a growing skipped-block list without decoding the connectivity sensor's
+    ``extra_state_attributes``.
+
+    Disabled by default (``entity_registry_enabled_default = False``): the state
+    is verbose and only matters to users diagnosing Modbus problems. Power users
+    enable it in the entity registry when they want alerting on poll failure.
+    """
+
+    _attr_has_entity_name = True
+    _attr_entity_category = EntityCategory.DIAGNOSTIC
+    _attr_entity_registry_enabled_default = False
+    _attr_translation_key = "modbus_status"
+
+    def __init__(self, coordinator: SungrowPlantCoordinator, device: dict[str, Any]) -> None:
+        """Initialize the diagnostic status sensor for a local inverter."""
+        super().__init__(coordinator)
+        self.device_uuid = str(device["uuid"])
+        self._attr_unique_id = f"{coordinator.plant_id}_{self.device_uuid}_modbus_status"
+        local_url = getattr(coordinator, "local_configuration_url", None)
+        self._attr_device_info = build_device_info(
+            device,
+            coordinator.plant_id,
+            fallback_name=coordinator.plant_name,
+            via_plant_id=getattr(coordinator, "via_plant_id", None),
+            configuration_url=local_url if isinstance(local_url, str) else None,
+        )
+
+    @property
+    def native_value(self) -> str:
+        """Return ``"ok"`` on a successful last poll; else the last error string.
+
+        Falls back to ``"unknown"`` when the coordinator hasn't reported an error
+        but ``last_update_success`` is somehow False — should be rare in practice
+        but avoids the None state that HA would render as "unknown" anyway.
+        """
+        if self.coordinator.last_update_success:
+            return "ok"
+        diag = getattr(self.coordinator, "modbus_diagnostics", None) or {}
+        return str(diag.get("last_error") or "unknown")
+
+    @property
+    def extra_state_attributes(self) -> dict[str, Any]:
+        """Expose the resolved device family and any skipped register blocks."""
+        diag = getattr(self.coordinator, "modbus_diagnostics", None) or {}
+        attrs: dict[str, Any] = {}
+        if diag.get("device_family"):
+            attrs["device_family"] = diag["device_family"]
+        if diag.get("skipped_blocks"):
+            attrs["skipped_blocks"] = diag["skipped_blocks"]
+        return attrs

--- a/custom_components/sungrow/strings.json
+++ b/custom_components/sungrow/strings.json
@@ -234,6 +234,11 @@
       "battery_mode": {
         "name": "Battery Mode"
       }
+    },
+    "sensor": {
+      "modbus_status": {
+        "name": "Modbus Status"
+      }
     }
   },
   "exceptions": {

--- a/custom_components/sungrow/translations/cy.json
+++ b/custom_components/sungrow/translations/cy.json
@@ -234,6 +234,11 @@
       "battery_mode": {
         "name": "Modd batri"
       }
+    },
+    "sensor": {
+      "modbus_status": {
+        "name": "Statws Modbus"
+      }
     }
   },
   "exceptions": {

--- a/custom_components/sungrow/translations/de.json
+++ b/custom_components/sungrow/translations/de.json
@@ -234,6 +234,11 @@
       "battery_mode": {
         "name": "Batteriemodus"
       }
+    },
+    "sensor": {
+      "modbus_status": {
+        "name": "Modbus-Status"
+      }
     }
   },
   "exceptions": {

--- a/custom_components/sungrow/translations/en.json
+++ b/custom_components/sungrow/translations/en.json
@@ -234,6 +234,11 @@
       "battery_mode": {
         "name": "Battery Mode"
       }
+    },
+    "sensor": {
+      "modbus_status": {
+        "name": "Modbus Status"
+      }
     }
   },
   "exceptions": {

--- a/custom_components/sungrow/translations/es.json
+++ b/custom_components/sungrow/translations/es.json
@@ -234,6 +234,11 @@
       "battery_mode": {
         "name": "Modo de batería"
       }
+    },
+    "sensor": {
+      "modbus_status": {
+        "name": "Estado de Modbus"
+      }
     }
   },
   "exceptions": {

--- a/custom_components/sungrow/translations/fr.json
+++ b/custom_components/sungrow/translations/fr.json
@@ -234,6 +234,11 @@
       "battery_mode": {
         "name": "Mode batterie"
       }
+    },
+    "sensor": {
+      "modbus_status": {
+        "name": "État Modbus"
+      }
     }
   },
   "exceptions": {

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -1036,3 +1036,162 @@ async def test_ess_partial_mppt_only_reported_sensors_created(hass: HomeAssistan
     assert by_code["mppt1_voltage"].device_class == SensorDeviceClass.VOLTAGE
     assert by_code["mppt2_current"].entity_category == EntityCategory.DIAGNOSTIC
     assert by_code["mppt2_current"].device_class == SensorDeviceClass.CURRENT
+
+
+# ---------------------------------------------------------------------------
+# SungrowModbusStatusSensor — Modbus-only diagnostic status text sensor (#361)
+# ---------------------------------------------------------------------------
+
+
+def _modbus_only_coordinator(*, modbus_diagnostics: dict | None = None, last_update_success: bool = True):
+    """Build a Modbus-only coordinator with an inverter device."""
+    devices = [
+        {
+            "uuid": "inv-1",
+            "device_name": "Inverter1",
+            "device_type": DeviceType.INVERTER,
+            "device_model_code": "SG3.6RS",
+            "device_sn": "A1",
+            "factory_name": "SUNGROW",
+        }
+    ]
+    coordinator = MagicMock()
+    coordinator.plant_id = "12345"
+    coordinator.plant_name = "Test Plant"
+    coordinator.data = {}
+    coordinator.plant_detail = {}
+    coordinator.devices = devices
+    coordinator.device_data = {}
+    coordinator.enable_device_sensors = False
+    coordinator.plants_service = None  # Modbus-only path
+    coordinator.via_plant_id = None
+    coordinator.local_configuration_url = "http://10.0.0.9"
+    coordinator.last_update_success = last_update_success
+    coordinator.modbus_diagnostics = (
+        modbus_diagnostics
+        if modbus_diagnostics is not None
+        else {
+            "device_family": "sg_rs",
+            "skipped_blocks": [],
+            "last_error": None,
+        }
+    )
+    return coordinator
+
+
+async def test_modbus_status_sensor_created_on_modbus_only_entry(hass: HomeAssistant):
+    """A local Modbus entry gets a per-inverter status sensor (#361)."""
+    from custom_components.sungrow.sensor import SungrowModbusStatusSensor, async_setup_entry
+
+    entry = MockConfigEntry(domain=DOMAIN, data=MOCK_CONFIG_DATA.copy())
+    entry.add_to_hass(hass)
+    coordinator = _modbus_only_coordinator()
+    entry.runtime_data = SungrowData(coordinators=[coordinator], control=None, devices={"12345": coordinator.devices})
+
+    added: list = []
+    await async_setup_entry(hass, entry, lambda entities: added.extend(entities))
+
+    status = next((e for e in added if isinstance(e, SungrowModbusStatusSensor)), None)
+    assert status is not None
+    assert status._attr_unique_id == "12345_inv-1_modbus_status"
+    # Disabled by default so it doesn't clutter the default UI.
+    assert status._attr_entity_registry_enabled_default is False
+    assert status._attr_translation_key == "modbus_status"
+
+
+async def test_modbus_status_sensor_state_is_ok_on_success(hass: HomeAssistant):
+    """A successful last poll reports ``"ok"`` — the actionable "no problem" signal."""
+    from custom_components.sungrow.sensor import SungrowModbusStatusSensor, async_setup_entry
+
+    entry = MockConfigEntry(domain=DOMAIN, data=MOCK_CONFIG_DATA.copy())
+    entry.add_to_hass(hass)
+    coordinator = _modbus_only_coordinator(last_update_success=True)
+    entry.runtime_data = SungrowData(coordinators=[coordinator], control=None, devices={})
+
+    added: list = []
+    await async_setup_entry(hass, entry, lambda entities: added.extend(entities))
+
+    status = next(e for e in added if isinstance(e, SungrowModbusStatusSensor))
+    assert status.native_value == "ok"
+
+
+async def test_modbus_status_sensor_state_is_last_error_on_failure(hass: HomeAssistant):
+    """A failed last poll surfaces the ``modbus_diagnostics["last_error"]`` string."""
+    from custom_components.sungrow.sensor import SungrowModbusStatusSensor, async_setup_entry
+
+    entry = MockConfigEntry(domain=DOMAIN, data=MOCK_CONFIG_DATA.copy())
+    entry.add_to_hass(hass)
+    coordinator = _modbus_only_coordinator(
+        modbus_diagnostics={"device_family": "sg_rs", "skipped_blocks": [], "last_error": "connection refused"},
+        last_update_success=False,
+    )
+    entry.runtime_data = SungrowData(coordinators=[coordinator], control=None, devices={})
+
+    added: list = []
+    await async_setup_entry(hass, entry, lambda entities: added.extend(entities))
+
+    status = next(e for e in added if isinstance(e, SungrowModbusStatusSensor))
+    assert status.native_value == "connection refused"
+
+
+async def test_modbus_status_sensor_state_falls_back_to_unknown(hass: HomeAssistant):
+    """Poll failed but no ``last_error`` was recorded — state is ``"unknown"``, not None.
+
+    HA renders ``None`` as "unknown" in the UI anyway, but returning an explicit
+    string keeps the state deterministic for automations that match on it.
+    """
+    from custom_components.sungrow.sensor import SungrowModbusStatusSensor, async_setup_entry
+
+    entry = MockConfigEntry(domain=DOMAIN, data=MOCK_CONFIG_DATA.copy())
+    entry.add_to_hass(hass)
+    coordinator = _modbus_only_coordinator(
+        modbus_diagnostics={"device_family": "sg_rs", "skipped_blocks": [], "last_error": None},
+        last_update_success=False,
+    )
+    entry.runtime_data = SungrowData(coordinators=[coordinator], control=None, devices={})
+
+    added: list = []
+    await async_setup_entry(hass, entry, lambda entities: added.extend(entities))
+
+    status = next(e for e in added if isinstance(e, SungrowModbusStatusSensor))
+    assert status.native_value == "unknown"
+
+
+async def test_modbus_status_sensor_attributes_expose_family_and_skipped_blocks(hass: HomeAssistant):
+    """Attributes carry ``device_family`` and non-empty ``skipped_blocks`` for triage."""
+    from custom_components.sungrow.sensor import SungrowModbusStatusSensor, async_setup_entry
+
+    entry = MockConfigEntry(domain=DOMAIN, data=MOCK_CONFIG_DATA.copy())
+    entry.add_to_hass(hass)
+    coordinator = _modbus_only_coordinator(
+        modbus_diagnostics={
+            "device_family": "sh_rt",
+            "skipped_blocks": [{"start": 13035, "count": 12}],
+            "last_error": None,
+        }
+    )
+    entry.runtime_data = SungrowData(coordinators=[coordinator], control=None, devices={})
+
+    added: list = []
+    await async_setup_entry(hass, entry, lambda entities: added.extend(entities))
+
+    status = next(e for e in added if isinstance(e, SungrowModbusStatusSensor))
+    attrs = status.extra_state_attributes
+    assert attrs["device_family"] == "sh_rt"
+    assert attrs["skipped_blocks"] == [{"start": 13035, "count": 12}]
+
+
+async def test_modbus_status_sensor_not_created_on_cloud_entry(hass: HomeAssistant):
+    """A cloud entry (plants_service present) never gets the Modbus status sensor (#361)."""
+    from custom_components.sungrow.sensor import SungrowModbusStatusSensor, async_setup_entry
+
+    entry = MockConfigEntry(domain=DOMAIN, data=MOCK_CONFIG_DATA.copy())
+    entry.add_to_hass(hass)
+    coordinator = _modbus_only_coordinator()
+    coordinator.plants_service = MagicMock()  # cloud path
+    entry.runtime_data = SungrowData(coordinators=[coordinator], control=None, devices={})
+
+    added: list = []
+    await async_setup_entry(hass, entry, lambda entities: added.extend(entities))
+
+    assert not any(isinstance(e, SungrowModbusStatusSensor) for e in added)


### PR DESCRIPTION
Closes #361.

## Problem

For Modbus-only entries, `modbus_diagnostics` (`device_family`, `skipped_blocks`, `last_error`) has only been reachable via `extra_state_attributes` on the connectivity binary sensor. Attributes:
- Don't show up in the recorder without a template sensor.
- Can't drive automation triggers directly.
- Aren't discoverable in the UI.

Users who want to alert on "last poll failed" have been writing template sensors to unpack the attributes.

## Change

New `SungrowModbusStatusSensor` — a per-inverter diagnostic text sensor whose state is:

- **`"ok"`** when `coordinator.last_update_success` is True.
- The **`modbus_diagnostics["last_error"]` string** otherwise, falling back to **`"unknown"`** when the coordinator reports failure but no error string was captured.

Attributes carry `device_family` and any non-empty `skipped_blocks` list for triage.

Wired into `_build_sensors` for Modbus-only coordinators (`plants_service is None`). Cloud entries never get this sensor.

**Disabled by default** (`entity_registry_enabled_default = False`) — the state is verbose and only matters to users diagnosing Modbus problems. Power users enable it in the entity registry when they want alerting on poll failure with the standard state-based automation primitives.

The existing attribute exposure on the connectivity binary sensor is retained — anyone with a template sensor built on those attributes keeps working.

## Translations

New key `sensor.modbus_status` in `strings.json` + all 5 locale files (`en` / `de` / `es` / `fr` / `cy`) so the key-parity test stays green.

## Tests

Six new tests in `test_sensor.py`:

- The sensor is created on a Modbus-only entry (per inverter).
- `last_update_success = True` produces state `"ok"`.
- `last_update_success = False` + `last_error` set produces the error string.
- Failure with no `last_error` produces the `"unknown"` sentinel.
- Attributes carry `device_family` + `skipped_blocks`.
- Cloud entries (`plants_service` present) never get the sensor.

## Verification

- `.venv/bin/python -m pytest tests/` — **815 passed** (+6 new)
- `.venv/bin/mypy` — clean (30 source files, strict)
- `.venv/bin/ruff check custom_components/ tests/` — clean
- `.venv/bin/ruff format --check custom_components/ tests/` — clean
