### PR TITLE
feat(services): sungrow.refresh_tokens for support triage

### DIFF
--- a/custom_components/sungrow/services.py
+++ b/custom_components/sungrow/services.py
@@ -21,12 +21,13 @@ from homeassistant.helpers import entity_registry as er
 from homeassistant.helpers.service import async_register_admin_service
 from homeassistant.util import dt as dt_util
 
-from .const import CONF_TRANSPORT, DOMAIN, TRANSPORT_MODBUS_ONLY
+from .const import CONF_TRANSPORT, DOMAIN, TRANSPORT_CLOUD_USER, TRANSPORT_MODBUS_ONLY
 
 _LOGGER = logging.getLogger(__name__)
 
 SERVICE_BACKFILL = "backfill"
 SERVICE_SET_BATTERY_MODE = "set_battery_mode"
+SERVICE_REFRESH_TOKENS = "refresh_tokens"
 ATTR_CONFIG_ENTRY = "config_entry"
 ATTR_START_DATE = "start_date"
 ATTR_MODE = "mode"
@@ -53,6 +54,12 @@ _SET_BATTERY_MODE_SCHEMA = vol.Schema(
     }
 )
 
+_REFRESH_TOKENS_SCHEMA = vol.Schema(
+    {
+        vol.Optional(ATTR_CONFIG_ENTRY): cv.string,
+    }
+)
+
 
 def _cloud_backfill_entries(hass: HomeAssistant) -> list[Any]:
     """Return every loaded cloud Sungrow config entry (those that own a manager)."""
@@ -74,6 +81,47 @@ def _resolve_entries(hass: HomeAssistant, entry_id: str | None) -> list[Any]:
         raise ServiceValidationError(f"Sungrow config entry '{entry_id}' is not loaded")
     if entry.data.get(CONF_TRANSPORT) == TRANSPORT_MODBUS_ONLY:
         raise ServiceValidationError(f"Config entry '{entry_id}' is a local Modbus entry; Backfill is cloud-only")
+    return [entry]
+
+
+def _oauth_cloud_entries(hass: HomeAssistant) -> list[Any]:
+    """Return every loaded OAuth cloud entry — those that own a token pair we can refresh.
+
+    Excludes ``cloud_user`` entries (email/password login, no OAuth refresh token) and
+    ``modbus_only`` entries (no cloud at all). Only loaded entries are eligible since
+    the auth client isn't reachable when an entry is failed/unloaded.
+    """
+    return [
+        entry
+        for entry in hass.config_entries.async_entries(DOMAIN)
+        if entry.state is ConfigEntryState.LOADED
+        and entry.data.get(CONF_TRANSPORT) not in (TRANSPORT_MODBUS_ONLY, TRANSPORT_CLOUD_USER)
+    ]
+
+
+def _resolve_oauth_entries(hass: HomeAssistant, entry_id: str | None) -> list[Any]:
+    """Resolve the addressed OAuth entries, defaulting to every loaded OAuth entry.
+
+    Raises :class:`ServiceValidationError` when a specific entry is targeted but
+    isn't loaded, isn't a Sungrow entry, or is a non-OAuth transport (``cloud_user``
+    or ``modbus_only``) that doesn't have refreshable OAuth tokens.
+    """
+    if entry_id is None:
+        return _oauth_cloud_entries(hass)
+    entry = hass.config_entries.async_get_entry(entry_id)
+    if entry is None or entry.domain != DOMAIN:
+        raise ServiceValidationError(f"No Sungrow config entry found for '{entry_id}'")
+    if entry.state is not ConfigEntryState.LOADED:
+        raise ServiceValidationError(f"Sungrow config entry '{entry_id}' is not loaded")
+    transport = entry.data.get(CONF_TRANSPORT)
+    if transport == TRANSPORT_MODBUS_ONLY:
+        raise ServiceValidationError(
+            f"Config entry '{entry_id}' is a local Modbus entry; there are no OAuth tokens to refresh"
+        )
+    if transport == TRANSPORT_CLOUD_USER:
+        raise ServiceValidationError(
+            f"Config entry '{entry_id}' uses user-account login; there is no OAuth refresh token to force"
+        )
     return [entry]
 
 
@@ -190,3 +238,61 @@ def async_setup_services(hass: HomeAssistant) -> None:
             schema=_SET_BATTERY_MODE_SCHEMA,
         )
         _LOGGER.debug("Registered %s.%s service", DOMAIN, SERVICE_SET_BATTERY_MODE)
+
+    if not hass.services.has_service(DOMAIN, SERVICE_REFRESH_TOKENS):
+
+        async def _handle_refresh_tokens(call: ServiceCall) -> None:
+            """Force an OAuth token refresh on every addressed cloud entry (#356).
+
+            Support flow: users report a "tokens went dead" symptom and the maintainer
+            asks them to invoke this service to see whether the refresh actually
+            runs — the outcome shows up in the log and in the persisted ``tokens``
+            on the config entry. Failures are re-raised as :class:`HomeAssistantError`
+            so the service call surfaces them in the UI.
+            """
+            entry_id = call.data.get(ATTR_CONFIG_ENTRY)
+            entries = _resolve_oauth_entries(hass, entry_id)
+            if not entries:
+                raise ServiceValidationError("No loaded OAuth Sungrow entries found to refresh")
+
+            errors: list[tuple[str, str]] = []
+            for entry in entries:
+                data = getattr(entry, "runtime_data", None)
+                coordinators = getattr(data, "coordinators", None) or []
+                # Every OAuth entry's coordinators share the same ``Auth`` instance
+                # via ``Plants(auth)``, so any coordinator gets us there.
+                auth = None
+                for coordinator in coordinators:
+                    service_client = getattr(coordinator, "plants_service", None)
+                    if service_client is not None:
+                        auth = getattr(service_client, "auth", None)
+                        break
+                if auth is None or getattr(auth, "tokens", None) is None:
+                    errors.append((entry.entry_id, "no auth client bound to the entry (not fully loaded?)"))
+                    continue
+                # Force the refresh path in ``Auth.async_get_access_token`` by
+                # invalidating the cached expiry. The lock + double-check in the
+                # library handles concurrent callers, and ``SungrowAuth`` persists
+                # the rotated tokens back to the entry via ``token_updater`` so
+                # they survive a restart.
+                auth.tokens["expires_at"] = 0
+                try:
+                    await auth.async_get_access_token()
+                except Exception as err:  # pylint: disable=broad-except
+                    _LOGGER.warning("Token refresh failed for entry %s: %s", entry.entry_id, err)
+                    errors.append((entry.entry_id, str(err)))
+                    continue
+                _LOGGER.info("Forced token refresh succeeded for entry %s", entry.entry_id)
+
+            if errors:
+                summary = "; ".join(f"{eid}: {msg}" for eid, msg in errors)
+                raise HomeAssistantError(f"Token refresh failed for {len(errors)} entry/entries: {summary}")
+
+        async_register_admin_service(
+            hass,
+            DOMAIN,
+            SERVICE_REFRESH_TOKENS,
+            _handle_refresh_tokens,
+            schema=_REFRESH_TOKENS_SCHEMA,
+        )
+        _LOGGER.debug("Registered %s.%s service", DOMAIN, SERVICE_REFRESH_TOKENS)

--- a/custom_components/sungrow/services.yaml
+++ b/custom_components/sungrow/services.yaml
@@ -47,3 +47,10 @@ set_battery_mode:
       selector:
         config_entry:
           integration: sungrow
+refresh_tokens:
+  fields:
+    config_entry:
+      required: false
+      selector:
+        config_entry:
+          integration: sungrow

--- a/custom_components/sungrow/strings.json
+++ b/custom_components/sungrow/strings.json
@@ -281,6 +281,16 @@
           "description": "Sungrow config entry to target."
         }
       }
+    },
+    "refresh_tokens": {
+      "name": "Refresh OAuth tokens",
+      "description": "Force an immediate OAuth token refresh on the addressed cloud entry (or every loaded cloud entry when none is specified). Useful for support triage when tokens appear stuck. Modbus-only and user-account entries have no OAuth tokens to refresh and are rejected.",
+      "fields": {
+        "config_entry": {
+          "name": "Integration",
+          "description": "Sungrow OAuth config entry to refresh. Leave empty to refresh every loaded cloud entry."
+        }
+      }
     }
   }
 }

--- a/custom_components/sungrow/translations/cy.json
+++ b/custom_components/sungrow/translations/cy.json
@@ -281,6 +281,16 @@
           "description": "Cofnod cyfluniad Sungrow."
         }
       }
+    },
+    "refresh_tokens": {
+      "name": "Adnewyddu tocynnau OAuth",
+      "description": "Yn gorfodi adnewyddiad tocyn OAuth ar unwaith ar y cofnod cwmwl a nodwyd (neu bob cofnod cwmwl wedi'i lwytho os na chaiff un ei nodi). Yn ddefnyddiol i gymorth ddiagnosio pan fydd tocynnau'n ymddangos yn sownd. Nid oes tocynnau OAuth gan gofnodion Modbus-yn-unig neu gyfrif defnyddiwr, ac maent yn cael eu gwrthod.",
+      "fields": {
+        "config_entry": {
+          "name": "Integreiddio",
+          "description": "Cofnod OAuth Sungrow i'w adnewyddu. Gadewch yn wag i adnewyddu pob cofnod cwmwl wedi'i lwytho."
+        }
+      }
     }
   }
 }

--- a/custom_components/sungrow/translations/de.json
+++ b/custom_components/sungrow/translations/de.json
@@ -281,6 +281,16 @@
           "description": "Sungrow-Konfigurationseintrag."
         }
       }
+    },
+    "refresh_tokens": {
+      "name": "OAuth-Tokens aktualisieren",
+      "description": "Erzwingt eine sofortige OAuth-Token-Aktualisierung für den angegebenen Cloud-Eintrag (oder alle geladenen Cloud-Einträge, wenn keiner angegeben ist). Nützlich für Support-Triage, wenn Tokens hängen. Modbus-only und Benutzerkonto-Einträge haben keine OAuth-Tokens und werden abgelehnt.",
+      "fields": {
+        "config_entry": {
+          "name": "Integration",
+          "description": "Sungrow-OAuth-Konfigurationseintrag zum Aktualisieren. Leer lassen, um alle geladenen Cloud-Einträge zu aktualisieren."
+        }
+      }
     }
   }
 }

--- a/custom_components/sungrow/translations/en.json
+++ b/custom_components/sungrow/translations/en.json
@@ -281,6 +281,16 @@
           "description": "Sungrow config entry to target."
         }
       }
+    },
+    "refresh_tokens": {
+      "name": "Refresh OAuth tokens",
+      "description": "Force an immediate OAuth token refresh on the addressed cloud entry (or every loaded cloud entry when none is specified). Useful for support triage when tokens appear stuck. Modbus-only and user-account entries have no OAuth tokens to refresh and are rejected.",
+      "fields": {
+        "config_entry": {
+          "name": "Integration",
+          "description": "Sungrow OAuth config entry to refresh. Leave empty to refresh every loaded cloud entry."
+        }
+      }
     }
   }
 }

--- a/custom_components/sungrow/translations/es.json
+++ b/custom_components/sungrow/translations/es.json
@@ -281,6 +281,16 @@
           "description": "Entrada de configuración Sungrow."
         }
       }
+    },
+    "refresh_tokens": {
+      "name": "Actualizar tokens OAuth",
+      "description": "Fuerza una actualización inmediata de los tokens OAuth en la entrada de nube indicada (o en todas las entradas de nube cargadas si no se especifica ninguna). Útil para triaje de soporte cuando los tokens parecen bloqueados. Las entradas Modbus-only y de cuenta de usuario no tienen tokens OAuth y se rechazan.",
+      "fields": {
+        "config_entry": {
+          "name": "Integración",
+          "description": "Entrada OAuth de Sungrow a actualizar. Dejar vacío para actualizar todas las entradas de nube cargadas."
+        }
+      }
     }
   }
 }

--- a/custom_components/sungrow/translations/fr.json
+++ b/custom_components/sungrow/translations/fr.json
@@ -281,6 +281,16 @@
           "description": "Entrée de configuration Sungrow."
         }
       }
+    },
+    "refresh_tokens": {
+      "name": "Actualiser les jetons OAuth",
+      "description": "Force une actualisation immédiate des jetons OAuth sur l'entrée cloud indiquée (ou sur toutes les entrées cloud chargées si aucune n'est spécifiée). Utile pour le triage support lorsque les jetons semblent bloqués. Les entrées Modbus-only et compte utilisateur n'ont pas de jetons OAuth et sont rejetées.",
+      "fields": {
+        "config_entry": {
+          "name": "Intégration",
+          "description": "Entrée OAuth Sungrow à actualiser. Laisser vide pour actualiser toutes les entrées cloud chargées."
+        }
+      }
     }
   }
 }

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -146,3 +146,127 @@ async def test_set_battery_mode_no_selects_raises(hass: HomeAssistant):
 
     with pytest.raises(ServiceValidationError, match="No Sungrow battery mode"):
         await hass.services.async_call(DOMAIN, SERVICE_SET_BATTERY_MODE, {"mode": "self_consumption"}, blocking=True)
+
+
+# ---------------------------------------------------------------------------
+# sungrow.refresh_tokens (#356)
+# ---------------------------------------------------------------------------
+
+
+def _make_oauth_entry_with_auth(hass, *, entry_id="test_entry", refresh_side_effect=None):
+    """Build a mocked cloud entry with a fake ``Auth`` accessible via ``plants_service``."""
+    from unittest.mock import MagicMock as _MagicMock
+
+    from custom_components.sungrow.const import TRANSPORT_CLOUD_ONLY
+
+    fake_auth = _MagicMock()
+    fake_auth.tokens = {"access_token": "old", "refresh_token": "r", "expires_at": 999999999999}
+    fake_auth.async_get_access_token = AsyncMock(side_effect=refresh_side_effect or (lambda: "new"))
+
+    coordinator = _MagicMock()
+    coordinator.plants_service = _MagicMock()
+    coordinator.plants_service.auth = fake_auth
+
+    entry = _MagicMock()
+    entry.entry_id = entry_id
+    entry.domain = DOMAIN
+    entry.state = ConfigEntryState.LOADED
+    entry.data = {**MOCK_CONFIG_DATA, CONF_TRANSPORT: TRANSPORT_CLOUD_ONLY}
+    entry.runtime_data = _MagicMock()
+    entry.runtime_data.coordinators = [coordinator]
+    return entry, fake_auth
+
+
+async def test_refresh_tokens_service_forces_refresh_on_targeted_entry(hass: HomeAssistant):
+    """The service invalidates the cached expiry and drives ``Auth.async_get_access_token`` (#356)."""
+    from custom_components.sungrow.services import SERVICE_REFRESH_TOKENS
+
+    entry, auth = _make_oauth_entry_with_auth(hass)
+    async_setup_services(hass)
+
+    with patch.object(hass.config_entries, "async_get_entry", return_value=entry):
+        await hass.services.async_call(DOMAIN, SERVICE_REFRESH_TOKENS, {"config_entry": entry.entry_id}, blocking=True)
+
+    # The refresh path was driven — ``expires_at`` was zeroed and access-token
+    # fetch was called (the ``Auth`` lock + double-check inside the library
+    # performs the actual refresh network call).
+    assert auth.tokens["expires_at"] == 0
+    auth.async_get_access_token.assert_awaited_once()
+
+
+async def test_refresh_tokens_service_defaults_to_all_cloud_entries(hass: HomeAssistant):
+    """With no ``config_entry`` target, every loaded OAuth entry is refreshed."""
+    from custom_components.sungrow.services import SERVICE_REFRESH_TOKENS
+
+    e1, a1 = _make_oauth_entry_with_auth(hass, entry_id="e1")
+    e2, a2 = _make_oauth_entry_with_auth(hass, entry_id="e2")
+    modbus = _make_entry(hass, entry_id="mb", transport=TRANSPORT_MODBUS_ONLY)
+    async_setup_services(hass)
+
+    with patch.object(hass.config_entries, "async_entries", return_value=[e1, e2, modbus]):
+        await hass.services.async_call(DOMAIN, SERVICE_REFRESH_TOKENS, {}, blocking=True)
+
+    # Both OAuth entries refreshed; the Modbus-only entry was excluded from the sweep.
+    a1.async_get_access_token.assert_awaited_once()
+    a2.async_get_access_token.assert_awaited_once()
+
+
+async def test_refresh_tokens_service_rejects_modbus_only(hass: HomeAssistant):
+    """A Modbus-only target raises ``ServiceValidationError`` — no tokens to refresh."""
+    from custom_components.sungrow.services import SERVICE_REFRESH_TOKENS
+
+    modbus = _make_entry(hass, transport=TRANSPORT_MODBUS_ONLY)
+    async_setup_services(hass)
+
+    with (
+        patch.object(hass.config_entries, "async_get_entry", return_value=modbus),
+        pytest.raises(ServiceValidationError, match="no OAuth tokens"),
+    ):
+        await hass.services.async_call(DOMAIN, SERVICE_REFRESH_TOKENS, {"config_entry": modbus.entry_id}, blocking=True)
+
+
+async def test_refresh_tokens_service_rejects_cloud_user(hass: HomeAssistant):
+    """A cloud_user target raises ``ServiceValidationError`` — no OAuth refresh token."""
+    from custom_components.sungrow.const import TRANSPORT_CLOUD_USER
+    from custom_components.sungrow.services import SERVICE_REFRESH_TOKENS
+
+    entry = _make_entry(hass, transport=TRANSPORT_CLOUD_USER)
+    async_setup_services(hass)
+
+    with (
+        patch.object(hass.config_entries, "async_get_entry", return_value=entry),
+        pytest.raises(ServiceValidationError, match="user-account"),
+    ):
+        await hass.services.async_call(DOMAIN, SERVICE_REFRESH_TOKENS, {"config_entry": entry.entry_id}, blocking=True)
+
+
+async def test_refresh_tokens_service_surfaces_refresh_failure(hass: HomeAssistant):
+    """A failing refresh is re-raised as :class:`HomeAssistantError` for the UI to display."""
+    from homeassistant.exceptions import HomeAssistantError
+
+    from custom_components.sungrow.services import SERVICE_REFRESH_TOKENS
+
+    async def _fail() -> str:
+        raise RuntimeError("upstream 500")
+
+    entry, auth = _make_oauth_entry_with_auth(hass, refresh_side_effect=_fail)
+    async_setup_services(hass)
+
+    with (
+        patch.object(hass.config_entries, "async_get_entry", return_value=entry),
+        pytest.raises(HomeAssistantError, match="upstream 500"),
+    ):
+        await hass.services.async_call(DOMAIN, SERVICE_REFRESH_TOKENS, {"config_entry": entry.entry_id}, blocking=True)
+
+
+async def test_refresh_tokens_service_no_entries_raises(hass: HomeAssistant):
+    """With no loaded OAuth entries at all, the service surfaces a clear validation error."""
+    from custom_components.sungrow.services import SERVICE_REFRESH_TOKENS
+
+    async_setup_services(hass)
+
+    with (
+        patch.object(hass.config_entries, "async_entries", return_value=[]),
+        pytest.raises(ServiceValidationError, match="No loaded OAuth"),
+    ):
+        await hass.services.async_call(DOMAIN, SERVICE_REFRESH_TOKENS, {}, blocking=True)


### PR DESCRIPTION
Closes #356.

## What

New admin service `sungrow.refresh_tokens` that forces an immediate OAuth token refresh on every addressed cloud entry — the missing "did the refresh actually run?" primitive for support triage.

```yaml
# All loaded OAuth entries
service: sungrow.refresh_tokens

# One specific entry
service: sungrow.refresh_tokens
data:
  config_entry: 01H8Z9V3XM7YQ5B0AK7JMWNQ4V
```

## How

Reuses the existing token-persistence path:

1. Zero out `auth.tokens["expires_at"]`.
2. Call `auth.async_get_access_token()` — the base `Auth` class's refresh lock and double-check-expiry logic drives the actual refresh network call; `SungrowAuth.token_updater` writes the rotated tokens back to `entry.data`.

No new persistence code, no bypass of the concurrency guards — the service just triggers the same path natural expiry uses.

`plants_service.auth` on any coordinator gets us the shared `Auth` instance (every entry's coordinators share one).

## Resolver behaviour

- **No target** → every loaded OAuth cloud entry (skips `modbus_only` and `cloud_user`).
- **`config_entry: <id>`** → that specific entry, rejecting non-OAuth transports with clear `ServiceValidationError` messages:
  - `modbus_only` → "no OAuth tokens to refresh"
  - `cloud_user` (email/password) → "no OAuth refresh token to force"
- **Failures** are aggregated across attempts and re-raised as a single `HomeAssistantError`, so a user targeting all entries sees every failure rather than stopping at the first.

Admin-only (`async_register_admin_service`), matching `sungrow.backfill`.

## Translations

New `services.refresh_tokens` stanza in `strings.json` + all 5 locale files (`en` / `de` / `es` / `fr` / `cy`) plus a schema entry in `services.yaml`. Key parity across locales preserved.

## Tests

Six new tests in `test_services.py`:

- Targeting a specific entry zeroes `expires_at` and drives `async_get_access_token`.
- Default sweep hits every loaded OAuth entry; Modbus-only entries are skipped.
- Targeting a Modbus-only entry raises `ServiceValidationError`.
- Targeting a `cloud_user` entry raises `ServiceValidationError`.
- A failing refresh is re-raised as `HomeAssistantError` with the underlying message.
- Zero loaded OAuth entries raises `ServiceValidationError`.

## Verification

- `.venv/bin/python -m pytest tests/` — **817 passed** (+6 new)
- `.venv/bin/mypy` — clean (30 source files, strict)
- `.venv/bin/ruff check custom_components/ tests/` — clean
- `.venv/bin/ruff format --check custom_components/ tests/` — clean
