### PR TITLE
refactor: narrow broad-except swallows to typed exceptions (#350)

### DIFF
--- a/custom_components/sungrow/__init__.py
+++ b/custom_components/sungrow/__init__.py
@@ -10,6 +10,7 @@ from dataclasses import dataclass, field
 from typing import Any
 
 import voluptuous as vol
+from aiohttp import ClientError
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import EVENT_HOMEASSISTANT_STARTED, Platform
 from homeassistant.core import HomeAssistant, callback
@@ -17,7 +18,7 @@ from homeassistant.exceptions import ConfigEntryAuthFailed, ConfigEntryNotReady
 from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.event import async_call_later
-from pysolarcloud import UserAuth, UserControl
+from pysolarcloud import PySolarCloudException, UserAuth, UserControl
 from pysolarcloud.control import Control
 from pysolarcloud.plants import DeviceType, Plants
 
@@ -147,7 +148,9 @@ async def _async_dispatch_supported(control: DispatchControl, devices: list[dict
         return True
     try:
         return bool(await control.async_check_update_support(str(target["uuid"])))
-    except Exception as err:  # pylint: disable=broad-except
+    except (PySolarCloudException, ClientError, TimeoutError) as err:
+        # Fail-open on typed transport failures. Cloud-only path here; the Modbus
+        # dispatch probe has its own tighter catch further down (#350).
         _LOGGER.debug("Could not check dispatch support for %s: %s", target.get("uuid"), err)
         return True
 
@@ -173,7 +176,7 @@ async def _async_has_battery(plants_service: Plants, plant_id: str, devices: lis
     try:
         async with asyncio.timeout(SETUP_TIMEOUT):
             details = await plants_service.async_get_plant_details(plant_id)
-    except Exception as err:  # pylint: disable=broad-except
+    except (PySolarCloudException, ClientError, TimeoutError) as err:
         _LOGGER.debug("Could not fetch plant details for %s; using device list for battery check: %s", plant_id, err)
         return _has_battery_device(devices)
     for entry in details or []:
@@ -306,11 +309,14 @@ async def _async_setup_modbus_only(hass: HomeAssistant, entry: SungrowConfigEntr
         modbus_control = ModbusControl(modbus_client, family=getattr(modbus_client, "model", None))
         if modbus_control.supported_parameters:
             # Probe once; fail-open to True only if the map is non-empty and readable.
+            from .modbus import SungrowModbusError
+            from .modbus_control import ModbusControlError
+
             try:
                 coordinator.dispatch_update_supported = await modbus_control.async_check_update_support(
                     str(inverter["uuid"])
                 )
-            except Exception as err:  # pylint: disable=broad-except
+            except (SungrowModbusError, ModbusControlError, TimeoutError) as err:
                 _LOGGER.debug("Modbus control support probe failed: %s", err)
                 coordinator.dispatch_update_supported = False
             if coordinator.dispatch_update_supported:
@@ -393,7 +399,7 @@ async def _async_setup_cloud_user(hass: HomeAssistant, entry: SungrowConfigEntry
         try:
             async with asyncio.timeout(SETUP_TIMEOUT):
                 devices = await user_auth.async_get_devices(plant_id)
-        except Exception as err:  # pylint: disable=broad-except
+        except (PySolarCloudException, ClientError, TimeoutError) as err:
             _LOGGER.warning("Could not fetch devices for plant %s (user account): %s", plant_name, err)
             devices = []
 

--- a/custom_components/sungrow/coordinator.py
+++ b/custom_components/sungrow/coordinator.py
@@ -7,6 +7,7 @@ import logging
 from datetime import timedelta
 from typing import Any, cast
 
+from aiohttp import ClientError
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryAuthFailed
@@ -45,6 +46,7 @@ from .const import (
     TRANSPORT_MODBUS_ONLY,
 )
 from .energy_units import normalize_energy_units, normalize_power_units, tag_source
+from .modbus import SungrowModbusError
 from .model_capabilities import mppt_points_for_model, resolve_capabilities
 
 # Upper bound on a single poll's cloud calls, so a hung request can neither stall
@@ -359,7 +361,7 @@ class SungrowPlantCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         try:
             async with asyncio.timeout(self._poll_timeout):
                 data = await self._modbus_client.async_read_realtime()
-        except Exception as err:  # pylint: disable=broad-except
+        except (SungrowModbusError, TimeoutError) as err:
             # Ride out a brief local blip the same way the cloud path does (#152).
             if self.data is not None and self._within_availability_grace():
                 _LOGGER.debug("Transient Modbus read failure for %s; keeping last-good data: %s", self.plant_name, err)
@@ -384,7 +386,7 @@ class SungrowPlantCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         try:
             async with asyncio.timeout(self._poll_timeout):
                 detail = await self._user_auth.async_get_plant_detail(self.plant_id)
-        except Exception as err:  # pylint: disable=broad-except
+        except (PySolarCloudException, ClientError, TimeoutError) as err:
             if is_auth_error(err):
                 raise ConfigEntryAuthFailed(f"iSolarCloud user-account login failed: {err}") from err
             if self.data is not None and self._within_availability_grace():
@@ -439,7 +441,7 @@ class SungrowPlantCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         try:
             async with asyncio.timeout(self._poll_timeout):
                 self.daily_yield_diagnostic = await self._modbus_client.async_read_daily_yield_diagnostic()
-        except Exception as err:  # pylint: disable=broad-except  (best-effort diagnostic)
+        except (SungrowModbusError, TimeoutError) as err:  # best-effort diagnostic
             _LOGGER.debug("daily_yield diagnostic capture failed for %s: %s", self.plant_name, err)
 
     def _within_availability_grace(self) -> bool:
@@ -517,7 +519,7 @@ class SungrowPlantCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         try:
             async with asyncio.timeout(self._poll_timeout):
                 devices = await self.plants_service.async_get_plant_devices(self.plant_id)
-        except Exception as err:  # pylint: disable=broad-except
+        except (PySolarCloudException, ClientError, TimeoutError) as err:
             _LOGGER.debug("Could not refresh devices for plant %s: %s", self.plant_id, err)
             return
         # Mutate in place so holders of this list (runtime_data.devices) see updates.
@@ -544,7 +546,7 @@ class SungrowPlantCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         try:
             async with asyncio.timeout(self._poll_timeout):
                 details = await self.plants_service.async_get_plant_details(self.plant_id)
-        except Exception as err:  # pylint: disable=broad-except
+        except (PySolarCloudException, ClientError, TimeoutError) as err:
             _LOGGER.debug("Could not refresh plant detail for plant %s: %s", self.plant_id, err)
             return
         for row in details or []:
@@ -663,7 +665,7 @@ class SungrowPlantCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                         ps_key_list=ps_keys or None,
                         extra_measure_points=extra or None,
                     )
-            except Exception as err:  # pylint: disable=broad-except
+            except (PySolarCloudException, ClientError, TimeoutError) as err:
                 _LOGGER.debug("Per-device realtime failed for plant %s type %s: %s", self.plant_id, type_id, err)
                 continue
             if not result:

--- a/custom_components/sungrow/diagnostics.py
+++ b/custom_components/sungrow/diagnostics.py
@@ -6,9 +6,11 @@ import asyncio
 import logging
 from typing import Any
 
+from aiohttp import ClientError
 from homeassistant.components.diagnostics import async_redact_data
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import issue_registry as ir
+from pysolarcloud import PySolarCloudException
 
 from . import SungrowConfigEntry, SungrowData
 from ._serialization import anonymise_device_keys, catalog_rows, jsonable
@@ -142,7 +144,7 @@ async def _probe_plant_devices(
     try:
         async with asyncio.timeout(PROBE_TIMEOUT):
             all_devices = await service.async_get_plant_devices(plant_id)
-    except Exception as err:  # pylint: disable=broad-except
+    except (PySolarCloudException, ClientError, TimeoutError) as err:
         _LOGGER.debug("Diagnostics: could not list devices for plant %s: %s", plant_id, err)
         return [{"error": str(err)}], {}, {}
 
@@ -169,7 +171,7 @@ async def _probe_plant_devices(
             async with asyncio.timeout(PROBE_TIMEOUT):
                 realtime = await service.async_get_device_realtime(plant_id, device_type)
             device_realtime[str(type_id)] = anonymise_device_keys(jsonable(realtime), uuid_map)
-        except Exception as err:  # pylint: disable=broad-except
+        except (PySolarCloudException, ClientError, TimeoutError) as err:
             _LOGGER.debug("Diagnostics: device realtime failed for type %s: %s", type_id, err)
             device_realtime[str(type_id)] = {"error": str(err)}
 

--- a/custom_components/sungrow/heartbeat.py
+++ b/custom_components/sungrow/heartbeat.py
@@ -10,10 +10,13 @@ import asyncio
 import logging
 from typing import TYPE_CHECKING
 
+from aiohttp import ClientError
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers import issue_registry as ir
+from pysolarcloud import PySolarCloudException
 
 from .const import DOMAIN
+from .modbus_control import ModbusControlError
 
 if TYPE_CHECKING:
     from . import SungrowConfigEntry
@@ -42,7 +45,12 @@ async def _stop_heartbeat(heartbeat: tuple[asyncio.Event, asyncio.Task[None]]) -
         task.cancel()
     except asyncio.CancelledError:
         pass
-    except Exception:  # pylint: disable=broad-except
+    except (PySolarCloudException, ClientError, ModbusControlError):
+        # ``await task`` re-raises the loop's stored exception; the done_callback
+        # (``_on_heartbeat_done``) is what raises the Repair, so at the stop path
+        # we just log the failure so it never propagates back out of unload (#350).
+        # ``TimeoutError`` is caught above as the ``asyncio.timeout`` firing on the
+        # stop wait itself, so no need to list it here.
         _LOGGER.exception("Heartbeat loop raised while stopping")
 
 
@@ -120,7 +128,7 @@ async def _heartbeat_loop(control: object, device_uuid: str, interval: int, stop
     while not stop_event.is_set():
         try:
             await update(device_uuid, {"external_ems_heartbeat": wire})
-        except Exception as err:  # pylint: disable=broad-except
+        except (PySolarCloudException, ClientError, ModbusControlError, TimeoutError) as err:
             _LOGGER.warning("EMS heartbeat failed for %s: %s", device_uuid, err)
         try:
             await asyncio.wait_for(stop_event.wait(), timeout=interval)

--- a/custom_components/sungrow/select.py
+++ b/custom_components/sungrow/select.py
@@ -578,7 +578,9 @@ class SungrowDispatchSelect(CoordinatorEntity[SungrowPlantCoordinator], RestoreE
         """
         try:
             params = await self.control.async_read_parameters(self.device_uuid, [_EMS_MODE_PARAM])
-        except Exception as err:  # pylint: disable=broad-except  (best-effort verification)
+        except (PySolarCloudException, ModbusControlError, TimeoutError) as err:
+            # Best-effort verification: cloud, user-account, and Modbus dispatch all
+            # come through here, so keep the union of their typed error surfaces.
             _LOGGER.debug("EMS-mode read-back failed for %s; skipping actuation check: %s", self.device_uuid, err)
             return None
         return self._reads_as_self_consumption(params)

--- a/custom_components/sungrow/services.py
+++ b/custom_components/sungrow/services.py
@@ -12,6 +12,7 @@ from datetime import datetime, time
 from typing import Any
 
 import voluptuous as vol
+from aiohttp import ClientError
 from homeassistant.config_entries import ConfigEntryState
 from homeassistant.const import ATTR_DEVICE_ID, ATTR_ENTITY_ID
 from homeassistant.core import HomeAssistant, ServiceCall
@@ -20,6 +21,7 @@ from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers import entity_registry as er
 from homeassistant.helpers.service import async_register_admin_service
 from homeassistant.util import dt as dt_util
+from pysolarcloud import PySolarCloudException
 
 from .const import CONF_TRANSPORT, DOMAIN, TRANSPORT_CLOUD_USER, TRANSPORT_MODBUS_ONLY
 
@@ -278,7 +280,7 @@ def async_setup_services(hass: HomeAssistant) -> None:
                 auth.tokens["expires_at"] = 0
                 try:
                     await auth.async_get_access_token()
-                except Exception as err:  # pylint: disable=broad-except
+                except (PySolarCloudException, ClientError, TimeoutError) as err:
                     _LOGGER.warning("Token refresh failed for entry %s: %s", entry.entry_id, err)
                     errors.append((entry.entry_id, str(err)))
                     continue

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,6 +10,7 @@ asyncio_mode = "auto"
 asyncio_default_fixture_loop_scope = "function"
 markers = [
     "live: marks tests that require live API credentials (deselect with '-m \"not live\"')",
+    "real_refresh: opt a coordinator test out of the auto-stubbed periodic-refresh fixture",
 ]
 # ``--import-mode=importlib`` skips pytest's legacy ``sys.path`` prepend hack, but
 # that hack was silently making ``custom_components/`` importable. Restore it

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -196,12 +196,20 @@ def mock_plants_service():
         plants_instance.async_get_plant_devices = AsyncMock(return_value=[])
         # Battery-presence detection (#148) fetches plant details during setup.
         plants_instance.async_get_plant_details = AsyncMock(return_value=[{"design_capacity_battery": 10.0}])
+        # Per-device realtime capture (#74): default to empty so tests that don't care
+        # about it don't leak an un-awaited-MagicMock TypeError now that the coordinator's
+        # per-device catch is narrowed (#350).
+        plants_instance.async_get_device_realtime = AsyncMock(return_value={})
         mock_plants_cls.return_value = plants_instance
 
         control_instance = MagicMock()
         control_instance.async_update_parameters = AsyncMock(return_value=[])
         control_instance.async_heartbeat = AsyncMock()
         control_instance.heartbeat_loop = AsyncMock()
+        # Dispatch-support probe is called during setup; stub True by default so tests
+        # that don't override see working dispatch entities (#350 narrowed the catch so
+        # an unstubbed MagicMock await now leaks a TypeError instead of being swallowed).
+        control_instance.async_check_update_support = AsyncMock(return_value=True)
         mock_control_cls.return_value = control_instance
 
         yield plants_instance

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -4,6 +4,7 @@ import asyncio
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+from aiohttp import ClientError
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryAuthFailed
 from homeassistant.helpers import issue_registry as ir
@@ -46,6 +47,24 @@ def _make_entry(options=None, data=None):
     entry.options = options or {}
     entry.data = data or {}
     return entry
+
+
+@pytest.fixture(autouse=True)
+def _stub_periodic_refresh(request, monkeypatch):
+    """Auto-stub the coordinator's device / plant-detail refresh methods.
+
+    ``_async_update_data`` calls these on every successful poll. The narrower
+    exception catches introduced by #350 no longer swallow the ``TypeError``
+    raised when an under-stubbed ``MagicMock`` plants_service is awaited, so
+    tests that don't care about periodic refresh would otherwise need to stub
+    both methods on every mock. Instead, they no-op by default; tests that do
+    test refresh behavior opt back into the real methods with
+    ``@pytest.mark.real_refresh`` (see ``test_refresh_devices_*`` below).
+    """
+    if request.node.get_closest_marker("real_refresh"):
+        return
+    monkeypatch.setattr(SungrowPlantCoordinator, "_async_maybe_refresh_devices", AsyncMock(return_value=None))
+    monkeypatch.setattr(SungrowPlantCoordinator, "_async_maybe_refresh_plant_detail", AsyncMock(return_value=None))
 
 
 # ---------------------------------------------------------------------------
@@ -370,11 +389,13 @@ async def test_update_data_keyerror_raises_update_failed(hass: HomeAssistant):
 # ---------------------------------------------------------------------------
 
 
+@pytest.mark.real_refresh
 async def test_refresh_devices_updates_list(hass: HomeAssistant):
     """Each poll refreshes the plant's device list so new devices are picked up."""
     plants = MagicMock()
     plants.async_get_realtime_data = AsyncMock(return_value={"12345": {}})
     plants.async_get_plant_devices = AsyncMock(return_value=[{"uuid": "new-dev"}])
+    plants.async_get_plant_details = AsyncMock(return_value=[])
 
     coordinator = SungrowPlantCoordinator(hass, _make_entry(), plants, "12345", "Test Plant", devices=[])
     await coordinator._async_update_data()
@@ -382,11 +403,13 @@ async def test_refresh_devices_updates_list(hass: HomeAssistant):
     assert coordinator.devices == [{"uuid": "new-dev"}]
 
 
+@pytest.mark.real_refresh
 async def test_refresh_devices_failure_keeps_previous_list(hass: HomeAssistant):
     """A device-list fetch failure keeps the previous list (best effort, non-fatal)."""
     plants = MagicMock()
     plants.async_get_realtime_data = AsyncMock(return_value={"12345": {}})
-    plants.async_get_plant_devices = AsyncMock(side_effect=ConnectionError("boom"))
+    plants.async_get_plant_devices = AsyncMock(side_effect=ClientError("boom"))
+    plants.async_get_plant_details = AsyncMock(return_value=[])
 
     coordinator = SungrowPlantCoordinator(
         hass, _make_entry(), plants, "12345", "Test Plant", devices=[{"uuid": "keep"}]
@@ -396,11 +419,13 @@ async def test_refresh_devices_failure_keeps_previous_list(hass: HomeAssistant):
     assert coordinator.devices == [{"uuid": "keep"}]
 
 
+@pytest.mark.real_refresh
 async def test_device_list_refresh_is_throttled(hass: HomeAssistant):
     """The device list is refreshed on the first poll, then only once the interval elapses (#115)."""
     plants = MagicMock()
     plants.async_get_realtime_data = AsyncMock(return_value={"12345": {}})
     plants.async_get_plant_devices = AsyncMock(return_value=[{"uuid": "dev"}])
+    plants.async_get_plant_details = AsyncMock(return_value=[])
 
     coordinator = SungrowPlantCoordinator(hass, _make_entry(), plants, "12345", "Test Plant", devices=[])
 
@@ -690,7 +715,7 @@ async def test_device_data_best_effort_on_error(hass: HomeAssistant):
 
     async def _realtime(plant_id, device_type, **kwargs):
         if getattr(device_type, "value", device_type) == 999:
-            raise RuntimeError("charger endpoint down")
+            raise ClientError("charger endpoint down")
         return {"inv-1": {"foo": {"code": "foo", "value": "1"}}}
 
     plants.async_get_device_realtime = AsyncMock(side_effect=_realtime)
@@ -862,10 +887,12 @@ async def test_device_data_dedupes_device_types(hass: HomeAssistant):
 # ---------------------------------------------------------------------------
 
 
+@pytest.mark.real_refresh
 async def test_plant_detail_fetched_and_stored(hass: HomeAssistant):
     """The plant-detail fields are fetched during a poll and stored on the coordinator (#178)."""
     plants = MagicMock()
     plants.async_get_realtime_data = AsyncMock(return_value=MOCK_REALTIME_DATA)
+    plants.async_get_plant_devices = AsyncMock(return_value=[])
     plants.async_get_plant_details = AsyncMock(
         return_value=[{"alarm_count": 0, "fault_count": 1, "install_power": 3600.0, "power_price_unit": "GBP"}]
     )
@@ -878,11 +905,13 @@ async def test_plant_detail_fetched_and_stored(hass: HomeAssistant):
     plants.async_get_plant_details.assert_awaited()
 
 
+@pytest.mark.real_refresh
 async def test_plant_detail_best_effort_on_error(hass: HomeAssistant):
     """A failing plant-detail fetch doesn't fail the whole poll (#178)."""
     plants = MagicMock()
     plants.async_get_realtime_data = AsyncMock(return_value=MOCK_REALTIME_DATA)
-    plants.async_get_plant_details = AsyncMock(side_effect=RuntimeError("detail endpoint down"))
+    plants.async_get_plant_devices = AsyncMock(return_value=[])
+    plants.async_get_plant_details = AsyncMock(side_effect=ClientError("detail endpoint down"))
     coordinator = SungrowPlantCoordinator(hass, _make_entry(), plants, "12345", "Test Plant", [])
 
     await coordinator._async_update_data()  # must not raise
@@ -1051,11 +1080,17 @@ async def test_modbus_only_update_no_client_raises(hass: HomeAssistant):
 
 
 async def test_modbus_only_update_keeps_last_good_within_grace(hass: HomeAssistant):
-    """A transient Modbus blip keeps serving the last-good data (availability grace)."""
+    """A transient Modbus blip keeps serving the last-good data (availability grace).
+
+    The Modbus client wraps raw pymodbus/OSError failures into ``SungrowModbusError``
+    before they reach the coordinator, so the test injects the wrapped type.
+    """
+    from custom_components.sungrow.modbus import SungrowModbusError
+
     coordinator = _modbus_only_coordinator(hass)
     coordinator.data = {"grid_frequency": {"value": 50.0}}
     coordinator._last_successful_update = hass.loop.time()  # fresh success
-    coordinator._modbus_client.async_read_realtime = AsyncMock(side_effect=OSError("connection reset"))
+    coordinator._modbus_client.async_read_realtime = AsyncMock(side_effect=SungrowModbusError("connection reset"))
 
     data = await coordinator._async_update_data()
 
@@ -1064,10 +1099,12 @@ async def test_modbus_only_update_keeps_last_good_within_grace(hass: HomeAssista
 
 async def test_modbus_only_update_raises_outside_grace(hass: HomeAssistant):
     """Once the last-good data is stale, a Modbus failure takes the entry unavailable."""
+    from custom_components.sungrow.modbus import SungrowModbusError
+
     coordinator = _modbus_only_coordinator(hass)
     coordinator.data = {"grid_frequency": {"value": 50.0}}
     coordinator._last_successful_update = None  # no recent success -> outside grace
-    coordinator._modbus_client.async_read_realtime = AsyncMock(side_effect=OSError("connection reset"))
+    coordinator._modbus_client.async_read_realtime = AsyncMock(side_effect=SungrowModbusError("connection reset"))
 
     with pytest.raises(UpdateFailed):
         await coordinator._async_update_data()
@@ -1418,7 +1455,7 @@ async def test_user_update_auth_error_triggers_reauth(hass: HomeAssistant):
 async def test_user_update_transient_rides_grace_window(hass: HomeAssistant):
     """A transient user-account failure keeps last-good data within the grace window (#268/#152)."""
     client = MagicMock()
-    client.async_get_plant_detail = AsyncMock(side_effect=RuntimeError("network blip"))
+    client.async_get_plant_detail = AsyncMock(side_effect=ClientError("network blip"))
     coordinator = SungrowPlantCoordinator(hass, _make_entry(), None, "12345", "Test Plant", user_auth=client)
     coordinator.data = {"total_active_power": {"value": "1.2"}}
     coordinator._last_successful_update = hass.loop.time()  # recent success

--- a/tests/test_diagnostics.py
+++ b/tests/test_diagnostics.py
@@ -3,6 +3,7 @@
 import json
 from unittest.mock import AsyncMock, MagicMock
 
+from aiohttp import ClientError
 from homeassistant.core import HomeAssistant
 from pysolarcloud.plants import DeviceType
 
@@ -113,7 +114,7 @@ async def test_diagnostics_device_probe_failure_is_captured(hass: HomeAssistant)
     entry.options = {}
 
     service = MagicMock()
-    service.async_get_plant_devices = AsyncMock(side_effect=RuntimeError("boom"))
+    service.async_get_plant_devices = AsyncMock(side_effect=ClientError("boom"))
     coordinator = _make_coordinator("1", "P", {}, plants_service=service)
     entry.runtime_data = SungrowData(coordinators=[coordinator], control=MagicMock(), devices={})
 
@@ -139,7 +140,7 @@ async def test_diagnostics_per_device_realtime_failure_is_captured(hass: HomeAss
             {"uuid": "chg-1", "device_type": 999},
         ]
     )
-    service.async_get_device_realtime = AsyncMock(side_effect=RuntimeError("nope"))
+    service.async_get_device_realtime = AsyncMock(side_effect=ClientError("nope"))
     coordinator = _make_coordinator("1", "P", {}, plants_service=service)
     entry.runtime_data = SungrowData(coordinators=[coordinator], control=MagicMock(), devices={})
 
@@ -374,7 +375,7 @@ async def test_points_catalog_handles_probe_error(hass: HomeAssistant):
     service.async_get_plant_devices = AsyncMock(
         return_value=[{"uuid": "chg-1", "device_type": 999, "device_model_code": "AC011E"}]
     )
-    service.async_get_device_realtime = AsyncMock(side_effect=RuntimeError("nope"))
+    service.async_get_device_realtime = AsyncMock(side_effect=ClientError("nope"))
     coordinator = _make_coordinator("1", "P", None, plants_service=service)
     entry.runtime_data = SungrowData(coordinators=[coordinator], control=MagicMock(), devices={})
 

--- a/tests/test_dispatch.py
+++ b/tests/test_dispatch.py
@@ -902,7 +902,7 @@ async def test_dispatch_supported_check_fails_open():
     assert await _async_dispatch_supported(control, []) is True
 
     # A failing check must not hide working controls.
-    control.async_check_update_support = AsyncMock(side_effect=Exception("boom"))
+    control.async_check_update_support = AsyncMock(side_effect=PySolarCloudException({"error": "server_busy"}))
     assert await _async_dispatch_supported(control, ess) is True
 
 

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -100,6 +100,9 @@ async def test_setup_persists_rotated_tokens(hass: HomeAssistant):
         async def async_get_plant_devices(self, *args, **kwargs):
             return []
 
+        async def async_get_plant_details(self, *args, **kwargs):
+            return []
+
     async def _fake_parent_get_token(self):
         # Simulate pysolarcloud assigning a brand-new tokens dict on refresh.
         self.tokens = rotated

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -243,11 +243,12 @@ async def test_refresh_tokens_service_rejects_cloud_user(hass: HomeAssistant):
 async def test_refresh_tokens_service_surfaces_refresh_failure(hass: HomeAssistant):
     """A failing refresh is re-raised as :class:`HomeAssistantError` for the UI to display."""
     from homeassistant.exceptions import HomeAssistantError
+    from pysolarcloud import PySolarCloudException
 
     from custom_components.sungrow.services import SERVICE_REFRESH_TOKENS
 
     async def _fail() -> str:
-        raise RuntimeError("upstream 500")
+        raise PySolarCloudException({"error": "upstream 500"})
 
     entry, auth = _make_oauth_entry_with_auth(hass, refresh_side_effect=_fail)
     async_setup_services(hass)


### PR DESCRIPTION
Closes #350.

Replaces the intentional `except Exception` best-effort sites across the integration with targeted unions built from the exception hierarchy the `sungrow-isolarcloud` 0.15.0 uplift now provides. Semantics unchanged: the same sites still ride out cloud/Modbus failures, they just no longer mask unexpected exception types (assertion errors, coding mistakes, un-awaited mocks) as debug-level noise.

## Narrowed sites

| File | Site | New catch |
| --- | --- | --- |
| `__init__.py` | `_async_dispatch_supported` | `(PySolarCloudException, ClientError, TimeoutError)` |
| `__init__.py` | `_async_has_battery` plant-detail | `(PySolarCloudException, ClientError, TimeoutError)` |
| `__init__.py` | Modbus control-support probe | `(SungrowModbusError, ModbusControlError, TimeoutError)` |
| `__init__.py` | `_async_setup_cloud_user` device fetch | `(PySolarCloudException, ClientError, TimeoutError)` |
| `coordinator.py` | `_async_modbus_only_update` | `(SungrowModbusError, TimeoutError)` |
| `coordinator.py` | `_async_user_update` | `(PySolarCloudException, ClientError, TimeoutError)` |
| `coordinator.py` | `_async_capture_daily_yield_diagnostic` | `(SungrowModbusError, TimeoutError)` |
| `coordinator.py` | `_async_refresh_devices` | `(PySolarCloudException, ClientError, TimeoutError)` |
| `coordinator.py` | `_async_refresh_plant_detail` | `(PySolarCloudException, ClientError, TimeoutError)` |
| `coordinator.py` | `_async_fetch_device_data` | `(PySolarCloudException, ClientError, TimeoutError)` |
| `diagnostics.py` | `_probe_plant_devices` list | `(PySolarCloudException, ClientError, TimeoutError)` |
| `diagnostics.py` | `_probe_plant_devices` per-device realtime | `(PySolarCloudException, ClientError, TimeoutError)` |
| `heartbeat.py` | `_stop_heartbeat` re-raise guard | `(PySolarCloudException, ClientError, ModbusControlError)` |
| `heartbeat.py` | `_heartbeat_loop` update | `(PySolarCloudException, ClientError, ModbusControlError, TimeoutError)` |
| `services.py` | `sungrow.refresh_tokens` per-entry refresh | `(PySolarCloudException, ClientError, TimeoutError)` |
| `select.py` | EMS-mode read-back verification | `(PySolarCloudException, ModbusControlError, TimeoutError)` |

`asyncio.CancelledError` is not caught anywhere here — task cancellation still propagates through the standard HA shutdown paths.

## Deliberately left untouched

* **`modbus.py`** — its final `except Exception` wraps unknown pymodbus internals into a typed `SungrowModbusError`; the typed pymodbus exceptions (`ConnectionException`, `ModbusException`, `OSError`, `TimeoutError`) are already caught just above. Narrowing further would enumerate the entire pymodbus surface and defeat the wrapping's purpose.
* **`modbus_control_probe.py`** — a probe utility running against duck-typed clients; a broad catch is the right shape for a diagnostic tool that must never crash the caller regardless of what the client raises.
* **`config_flow.py`** — the four "unknown" catches follow HA's standard config-flow idiom: log + surface as `unknown` error so the user gets a UI message instead of a traceback. Narrowing here would let unexpected exceptions escape the flow and become uncaught tracebacks in the setup dialog.

## Test updates

The narrower catches surface a class of test setups that used to pass by accident: bare `MagicMock` plants_service objects with only `async_get_realtime_data` stubbed would previously get their un-awaited-MagicMock TypeError swallowed by the broad-except when `_async_update_data` fell through to the periodic refresh calls. Fixed as follows:

* **Autouse fixture** in `test_coordinator.py` that no-ops `_async_maybe_refresh_devices` and `_async_maybe_refresh_plant_detail` on the coordinator for the ~40 tests that don't exercise refresh. The five refresh-behavior tests opt back in via `@pytest.mark.real_refresh` (marker registered in `pyproject.toml`).
* **Generic exception types replaced** with the realistic typed error the code path actually sees:
  * `ConnectionError` / `RuntimeError` in cloud-path tests → `aiohttp.ClientError` or `pysolarcloud.PySolarCloudException`
  * `OSError` in Modbus-only tests → `SungrowModbusError` (the client wraps raw pymodbus/OSError failures into this before they reach the coordinator anyway)
  * `Exception` in the `_async_dispatch_supported` fail-open test → `PySolarCloudException`
* **`mock_plants_service` / `mock_control_service` fixture** gains defaults for `async_get_device_realtime` and `async_check_update_support` so tests exercising full setup don't need to stub them piecemeal.

## Verification

* `ruff check custom_components/ tests/` — clean
* `ruff format --check custom_components/ tests/` — clean
* `mypy` — clean (strict mode)
* `python -m pytest tests/ --no-cov -q` — 823 passed, 4 deselected (live)