### PR TITLE
chore(model_specs): flag TCzerny-unverified rows and clamp their slider ceilings (#349)

### DIFF
--- a/custom_components/sungrow/model_specs.py
+++ b/custom_components/sungrow/model_specs.py
@@ -30,6 +30,16 @@ class ModelSpec:
     Fields are ``None`` when the datasheet does not apply (e.g. battery power on
     a PV-only string inverter). Callers must therefore treat any of the ``max_*``
     fields as optional and fall back to a conservative default.
+
+    ``unverified=True`` marks a row whose battery-side values have not been
+    cross-referenced against a Sungrow datasheet — either because TCzerny
+    flagged them as such upstream (see the MG hybrid family), or because the
+    model is a family estimate rather than a per-SKU datasheet lookup. The
+    battery-slider ceiling resolver
+    (:func:`~custom_components.sungrow.number._resolve_battery_rated_power`)
+    treats these rows conservatively: instead of trusting the possibly-wrong
+    battery values, it falls back to the AC-side rating so the slider never
+    exposes a ceiling above the inverter's nameplate.
     """
 
     phases: int
@@ -40,6 +50,8 @@ class ModelSpec:
     # Battery-side limits (SH hybrids only). None on SG string inverters.
     max_charge_power: int | None = None
     max_discharge_power: int | None = None
+    # True when the row is a family estimate / unverified against a datasheet (#349).
+    unverified: bool = False
 
 
 # Every SG-RS single-phase hybrid (SH*RS 3.0..6.0) shares the same battery power
@@ -79,7 +91,9 @@ MODEL_SPECS: dict[str, ModelSpec] = {
     "SH8.0RS": ModelSpec(1, 4, 1, 8000, 36, *_SH_RS_HIGH_BATTERY),
     "SH10RS": ModelSpec(1, 4, 1, 10600, 45, *_SH_RS_HIGH_BATTERY),
     # --- SH-RT three-phase hybrid (battery). RT / RT-20 / -V112 / -V122 share
-    # the same power schedule per Sungrow's datasheet family map.
+    # the same power schedule per Sungrow's datasheet family map. MG* rows below
+    # are unverified estimates flagged by TCzerny — kept for coverage; the
+    # battery-slider resolver falls back to the AC rating on unverified specs.
     **{
         model: ModelSpec(
             phases=3,
@@ -89,40 +103,41 @@ MODEL_SPECS: dict[str, ModelSpec] = {
             max_current=cur,
             max_charge_power=charge,
             max_discharge_power=discharge,
+            unverified=unverified,
         )
-        for model, ac, cur, charge, discharge in [
-            ("SH5.0RT", 5000, 8, 7500, 6000),
-            ("SH5.0RT-20", 5000, 8, 7500, 6000),
-            ("SH5.0RT-V112", 5000, 8, 7500, 6000),
-            ("SH5.0RT-V122", 5000, 8, 7500, 6000),
-            ("SH6.0RT", 6000, 10, 9000, 7200),
-            ("SH6.0RT-20", 6000, 10, 9000, 7200),
-            ("SH6.0RT-V112", 6000, 10, 9000, 7200),
-            ("SH6.0RT-V122", 6000, 10, 9000, 7200),
-            ("SH8.0RT", 8000, 13, 10600, 10600),
-            ("SH8.0RT-20", 8000, 13, 10600, 10600),
-            ("SH8.0RT-V112", 8000, 13, 10600, 10600),
-            ("SH8.0RT-V122", 8000, 13, 10600, 10600),
-            ("SH10RT", 10000, 17, 10600, 10600),
-            ("SH10RT-20", 10000, 17, 10600, 10600),
-            ("SH10RT-V112", 10000, 17, 10600, 10600),
-            ("SH10RT-V122", 10000, 17, 10600, 10600),
+        for model, ac, cur, charge, discharge, unverified in [
+            ("SH5.0RT", 5000, 8, 7500, 6000, False),
+            ("SH5.0RT-20", 5000, 8, 7500, 6000, False),
+            ("SH5.0RT-V112", 5000, 8, 7500, 6000, False),
+            ("SH5.0RT-V122", 5000, 8, 7500, 6000, False),
+            ("SH6.0RT", 6000, 10, 9000, 7200, False),
+            ("SH6.0RT-20", 6000, 10, 9000, 7200, False),
+            ("SH6.0RT-V112", 6000, 10, 9000, 7200, False),
+            ("SH6.0RT-V122", 6000, 10, 9000, 7200, False),
+            ("SH8.0RT", 8000, 13, 10600, 10600, False),
+            ("SH8.0RT-20", 8000, 13, 10600, 10600, False),
+            ("SH8.0RT-V112", 8000, 13, 10600, 10600, False),
+            ("SH8.0RT-V122", 8000, 13, 10600, 10600, False),
+            ("SH10RT", 10000, 17, 10600, 10600, False),
+            ("SH10RT-20", 10000, 17, 10600, 10600, False),
+            ("SH10RT-V112", 10000, 17, 10600, 10600, False),
+            ("SH10RT-V122", 10000, 17, 10600, 10600, False),
             # SH*T commercial three-phase hybrids. Battery limits scale with AC rating.
-            ("SH5T", 5000, 8, 7500, 6000),
-            ("SH6T", 6000, 10, 9000, 7200),
-            ("SH8T", 8000, 13, 10600, 10600),
-            ("SH10T", 10000, 17, 10600, 10600),
-            ("SH12T", 12000, 20, 12000, 12000),
-            ("SH15T", 15000, 25, 15000, 15000),
-            ("SH20T", 20000, 32, 20000, 20000),
-            ("SH25T", 25000, 40, 25000, 25000),
+            ("SH5T", 5000, 8, 7500, 6000, False),
+            ("SH6T", 6000, 10, 9000, 7200, False),
+            ("SH8T", 8000, 13, 10600, 10600, False),
+            ("SH10T", 10000, 17, 10600, 10600, False),
+            ("SH12T", 12000, 20, 12000, 12000, False),
+            ("SH15T", 15000, 25, 15000, 15000, False),
+            ("SH20T", 20000, 32, 20000, 20000, False),
+            ("SH25T", 25000, 40, 25000, 25000, False),
             # MG hybrid — battery limits estimated from RT scaling; TCzerny flags
-            # these as unverified against datasheet. Kept for coverage; downstream
-            # entities still clamp to the resolved ceiling.
-            ("MG5RL", 5000, 8, 7500, 6000),
-            ("MG6RL", 6000, 10, 9000, 7200),
-            ("MG8RL", 8000, 13, 10600, 10600),
-            ("MG10RL", 10000, 17, 10600, 10600),
+            # these as unverified against datasheet. The battery resolver picks a
+            # conservative AC-side fallback for these until a datasheet confirms.
+            ("MG5RL", 5000, 8, 7500, 6000, True),
+            ("MG6RL", 6000, 10, 9000, 7200, True),
+            ("MG8RL", 8000, 13, 10600, 10600, True),
+            ("MG10RL", 10000, 17, 10600, 10600, True),
         ]
     },
 }

--- a/custom_components/sungrow/number.py
+++ b/custom_components/sungrow/number.py
@@ -210,9 +210,16 @@ def _resolve_battery_rated_power(target: dict[str, Any]) -> int:
     AC rating for models without battery entries in the catalog, and finally to
     :data:`DEFAULT_MAX_DISPATCH_POWER` — same conservative floor as
     :func:`_resolve_ac_rated_power`.
+
+    Rows flagged ``unverified=True`` in the catalog (#349) are treated
+    conservatively: their battery values are TCzerny family estimates, not
+    datasheet lookups, so this resolver ignores them and falls back to the
+    AC-side rating. That keeps the slider ceiling at or below the inverter's
+    nameplate — never overshooting into an estimated-battery value that could
+    exceed real hardware.
     """
     spec = spec_for(str(target.get("device_model_code") or ""))
-    if spec is not None:
+    if spec is not None and not spec.unverified:
         battery_limits = [x for x in (spec.max_charge_power, spec.max_discharge_power) if x is not None]
         if battery_limits:
             return max(battery_limits)

--- a/tests/test_model_specs.py
+++ b/tests/test_model_specs.py
@@ -106,3 +106,75 @@ def test_catalog_covers_every_sh_family_code_in_family_map():
 
     missing = modern_names - set(MODEL_SPECS)
     assert not missing, f"models named in DEVICE_MODEL_NAMES without catalog entries: {sorted(missing)}"
+
+
+# ---------------------------------------------------------------------------
+# #349 unverified rows — audit / conservative-fallback semantics
+# ---------------------------------------------------------------------------
+
+
+# Every MG hybrid row is an unverified TCzerny estimate (per docstring on the
+# comprehension that builds them). The battery-slider resolver must fall back
+# to the AC rating for these until Sungrow datasheets confirm the values.
+UNVERIFIED_MODELS = frozenset({"MG5RL", "MG6RL", "MG8RL", "MG10RL"})
+
+
+@pytest.mark.parametrize("model", sorted(UNVERIFIED_MODELS))
+def test_unverified_rows_are_flagged(model):
+    """Every known-unverified row must carry ``unverified=True`` so the resolver clamps."""
+    spec = spec_for(model)
+    assert spec is not None, f"{model} missing from the catalog"
+    assert spec.unverified is True, f"{model} lost its unverified flag"
+
+
+def test_no_new_unverified_rows_slip_in_untracked():
+    """Any newly-added ``unverified=True`` row must be added to ``UNVERIFIED_MODELS``.
+
+    This is the audit guardrail — adding an unverified row without acknowledging
+    it here would let a family estimate through without the maintainer eyeballing
+    it. The reverse case (removing a row from ``UNVERIFIED_MODELS`` after a
+    datasheet check) is fine: the parametrised test above just runs fewer times.
+    """
+    unverified_in_catalog = {model for model, spec in MODEL_SPECS.items() if spec.unverified}
+    unexpected = unverified_in_catalog - UNVERIFIED_MODELS
+    assert not unexpected, (
+        f"catalog carries unverified rows not listed in tests.UNVERIFIED_MODELS: {sorted(unexpected)}. "
+        "If you added a new unverified row, add its model code to that set (and consider whether the "
+        "battery slider needs a specific ceiling test)."
+    )
+
+
+@pytest.mark.parametrize("model", sorted(UNVERIFIED_MODELS))
+def test_unverified_battery_slider_falls_back_to_ac_rating(model):
+    """Unverified rows must not drive a battery-slider ceiling above the AC nameplate.
+
+    Guards against a family-estimate battery value (potentially wrong for the
+    real hardware) leaking through to the dispatch slider. The resolver's
+    documented behavior on unverified specs is: fall back to the AC-side
+    rating so the ceiling never overshoots the inverter's nameplate.
+    """
+    from custom_components.sungrow.number import _resolve_ac_rated_power, _resolve_battery_rated_power
+
+    target = {"device_model_code": model}
+    ac_ceiling = _resolve_ac_rated_power(target)
+    battery_ceiling = _resolve_battery_rated_power(target)
+    # Same ceiling: the resolver ignored the datasheet's battery numbers.
+    assert battery_ceiling == ac_ceiling, (
+        f"{model}: unverified spec leaked a battery ceiling ({battery_ceiling} W) above the "
+        f"AC rating ({ac_ceiling} W) — the resolver must fall back on unverified rows"
+    )
+
+
+def test_verified_rows_use_their_datasheet_battery_ceiling():
+    """Guard the opposite direction: verified specs must NOT fall back to the AC rating.
+
+    Regression test in case someone flips ``unverified`` to True by mistake — the
+    slider ceiling would silently drop to the AC nameplate and users on SH-RS
+    with a 6.6 kW battery would suddenly see a 5 kW cap.
+    """
+    from custom_components.sungrow.number import _resolve_battery_rated_power
+
+    # SH5.0RS: AC 5000 W, battery 6600 W. The resolver must return the battery number.
+    assert _resolve_battery_rated_power({"device_model_code": "SH5.0RS"}) == 6600
+    # SH10RT-20: AC 10000 W, battery 10600 W.
+    assert _resolve_battery_rated_power({"device_model_code": "SH10RT-20"}) == 10600


### PR DESCRIPTION
Closes #349.

The catalog inherited its rows from [TCzerny/ha-modbus-manager](https://github.com/TCzerny/ha-modbus-manager)'s YAML templates, which carry `TODO: Verify from datasheet` provenance flags on family estimates. The docstring in `model_specs.py` called that out, but every row was still trusted the same way at the callsite — so a slider ceiling for an unverified battery value could clamp real hardware to the wrong number.

## Changes

* Add an `unverified: bool = False` field to `ModelSpec`. Existing callers see no behavior change; the flag is opt-in.
* Explicitly mark every `MG*RL` row (`MG5RL`, `MG6RL`, `MG8RL`, `MG10RL`) as `unverified=True`. These are the estimated small-hybrid rebrands TCzerny flags upstream; the RT-family scaling used to build them is a guess, not a datasheet lookup.
* Update `_resolve_battery_rated_power` to fall back to the AC-side rating on `unverified=True` rows. The battery slider on those models can never overshoot the inverter's nameplate now — no more silent false ceilings from a family estimate.

## Test guards

Three tests added to `test_model_specs.py`:

1. **`test_unverified_rows_are_flagged`** — every model in the `UNVERIFIED_MODELS` set carries `unverified=True`. Regression guard against a future accidental unflag.
2. **`test_no_new_unverified_rows_slip_in_untracked`** — the reverse guardrail: any row in the catalog with `unverified=True` must be listed in `UNVERIFIED_MODELS`. Adding a new unverified row without acknowledging it in the test file fails CI, so the maintainer has to consciously accept a family-estimate row.
3. **`test_verified_rows_use_their_datasheet_battery_ceiling`** — regression guard for verified specs: `SH5.0RS` returns 6600 W (battery), `SH10RT-20` returns 10600 W. If someone accidentally flips a verified row to `unverified=True`, the slider ceiling would silently drop to the AC nameplate — this test catches that.

## Deliberately not in scope

* **Wider datasheet cross-reference.** The issue mentions cross-referencing individual rows against Sungrow datasheets and optionally attaching a datasheet URL per row. That's a separate research task; this PR captures the `unverified` framework so the audit can proceed row-by-row without touching resolver code again.
* **Commercial KTL / CX / HX / MG (non-`RL`) models.** Same scope note as #332 — deliberately not in the catalog yet.

## Verification

* `ruff check` + `ruff format --check` — clean
* `mypy` (strict) — clean
* `pytest tests/` — 833 passed, 4 deselected (live)