### PR TITLE
feat(config_flow): plant selection picker for multi-plant accounts (#358)

### DIFF
--- a/custom_components/sungrow/__init__.py
+++ b/custom_components/sungrow/__init__.py
@@ -31,6 +31,7 @@ from .const import (
     CONF_GATEWAY,
     CONF_MODBUS_HOST,
     CONF_MODEL,
+    CONF_PLANT_IDS,
     CONF_SERIAL,
     CONF_TRANSPORT,
     CONF_USER_ACCOUNT,
@@ -161,6 +162,33 @@ def _has_battery_device(devices: list[dict[str, Any]]) -> bool:
         _matches_device_type(d, DeviceType.ENERGY_STORAGE_SYSTEM) or _matches_device_type(d, DeviceType.BATTERY)
         for d in devices
     )
+
+
+def _filter_plants_by_selection(plant_list: list[dict[str, Any]], entry: SungrowConfigEntry) -> list[dict[str, Any]]:
+    """Restrict ``plant_list`` to the plants the entry is scoped to (#358).
+
+    ``CONF_PLANT_IDS`` on the entry is a list of ``ps_id`` strings (the config
+    flow's plant picker collects them). When missing or empty the entry serves
+    every plant the account returns — the pre-#358 behaviour, so legacy entries
+    keep working with no migration. A selection that no longer matches any plant
+    (all previously-selected plants deleted upstream) also falls back to the
+    full list so setup surfaces a discoverable Repair via first-refresh failures
+    rather than a silent empty-entities state.
+    """
+    selected = entry.data.get(CONF_PLANT_IDS)
+    if not selected:
+        return plant_list
+    selected_ids = {str(pid) for pid in selected}
+    filtered = [p for p in plant_list if str(p.get("ps_id")) in selected_ids]
+    if not filtered:
+        _LOGGER.warning(
+            "Entry %s selects %d plant(s) but none match the account's current plant list; "
+            "serving every plant so at least one becomes visible",
+            entry.title,
+            len(selected_ids),
+        )
+        return plant_list
+    return filtered
 
 
 async def _async_has_battery(plants_service: Plants, plant_id: str, devices: list[dict[str, Any]]) -> bool:
@@ -388,6 +416,8 @@ async def _async_setup_cloud_user(hass: HomeAssistant, entry: SungrowConfigEntry
             raise ConfigEntryAuthFailed(f"iSolarCloud user-account login failed: {err}") from err
         raise ConfigEntryNotReady(f"Unable to reach iSolarCloud (user account): {err}") from err
 
+    plant_list = _filter_plants_by_selection(list(plant_list or []), entry)
+
     coordinators: list[SungrowPlantCoordinator] = []
     devices_by_plant: dict[str, list[dict[str, Any]]] = {}
     for plant_info in plant_list:
@@ -508,6 +538,8 @@ async def async_setup_entry(hass: HomeAssistant, entry: SungrowConfigEntry) -> b
             raise ConfigEntryAuthFailed(f"Authentication with iSolarCloud failed: {err}") from err
         # A timeout arrives here as TimeoutError and is treated as transient.
         raise ConfigEntryNotReady(describe_api_error(err) or f"Unable to fetch plants from iSolarCloud: {err}") from err
+
+    plant_list = _filter_plants_by_selection(list(plant_list or []), entry)
 
     coordinators: list[SungrowPlantCoordinator] = []
     devices_by_plant: dict[str, list[dict[str, Any]]] = {}

--- a/custom_components/sungrow/_config_flow/cloud_oauth.py
+++ b/custom_components/sungrow/_config_flow/cloud_oauth.py
@@ -27,11 +27,12 @@ from ..const import CONF_APP_ID, CONF_APP_KEY, CONF_APP_SECRET, CONF_GATEWAY, CO
 from . import _base
 from ._base import _SungrowFlowBase
 from ._helpers import CALLBACK_WAIT_TIMEOUT
+from .plant_selection import PlantSelectionMixin
 
 _LOGGER = logging.getLogger(__name__)
 
 
-class CloudOAuthMixin(_SungrowFlowBase):
+class CloudOAuthMixin(PlantSelectionMixin, _SungrowFlowBase):
     """OAuth cloud transport steps for :class:`SungrowConfigFlow`."""
 
     # ---- OAuth-specific helpers -----------------------------------------
@@ -310,13 +311,23 @@ class CloudOAuthMixin(_SungrowFlowBase):
                 await self.async_set_unique_id(str(self.init_info[CONF_APP_ID]))
                 self._abort_if_unique_id_mismatch(reason="wrong_account")
                 reason = "reconfigure_successful" if self._is_reconfigure else "reauth_successful"
+                # Reauth/reconfigure preserves the entry's existing plant selection
+                # (#358); the picker is only shown on initial setup below.
                 return self.async_update_reload_and_abort(self._reauth_entry, data=data, reason=reason)
 
             await self.async_set_unique_id(str(self.init_info[CONF_APP_ID]))
             self._abort_if_unique_id_configured()
-            # Cloud and local stay separate: if a Modbus-only entry already exists it is
-            # left alone (soft-linked by serial at device setup, never merged).
-            return self.async_create_entry(title=f"Sungrow {self.init_info[CONF_APP_ID]}", data=data)
+
+            # Initial setup: fetch the account's plants using the freshly-obtained
+            # tokens. Multi-plant accounts route through ``async_step_plant_selection``
+            # (#358); single-plant accounts finalise directly with no extra step so
+            # the flow shape is unchanged for the common case.
+            plant_list = await self._fetch_plants()
+            if len(plant_list) > 1:
+                self._pending_plant_list = plant_list
+                self._pending_entry_data = data
+                return await self.async_step_plant_selection()
+            return await self._finalise_cloud_oauth_entry(data)
 
         except data_entry_flow.AbortFlow:
             raise
@@ -343,3 +354,32 @@ class CloudOAuthMixin(_SungrowFlowBase):
         except Exception as e:  # pylint: disable=broad-except
             _LOGGER.exception("Unexpected exception in async_step_finish: %s", e)
             return self._finish_error_result("unknown")
+
+    async def _fetch_plants(self) -> list[dict[str, Any]]:
+        """Fetch the account's plants using the freshly-authorized ``auth_client`` (#358).
+
+        Best-effort: any failure returns ``[]`` and the caller falls back to
+        finalising the entry without a plant picker. Setup then re-fetches the
+        list itself and serves whatever it discovers (legacy shape). The catch
+        is deliberately broad — the picker is a UX nicety, not a correctness
+        gate, so a probe error (typed or otherwise) must never block the entry
+        from being created.
+        """
+        from pysolarcloud.plants import Plants
+
+        try:
+            plants_service = Plants(self.auth_client)
+            async with asyncio.timeout(30):
+                return list(await plants_service.async_get_plants() or [])
+        except Exception as err:  # pylint: disable=broad-except
+            _LOGGER.debug("Plant list fetch failed after OAuth authorize; skipping picker: %s", err)
+            return []
+
+    async def _finalise_cloud_oauth_entry(self, entry_data: dict[str, Any]) -> ConfigFlowResult:
+        """Create the OAuth entry with the plant selection merged in.
+
+        Called by :class:`PlantSelectionMixin._dispatch_plant_selection_finalise`
+        after the user submits the picker, and by :meth:`async_step_finish`
+        directly for single-plant accounts that skip the picker entirely.
+        """
+        return self.async_create_entry(title=f"Sungrow {self.init_info[CONF_APP_ID]}", data=entry_data)

--- a/custom_components/sungrow/_config_flow/cloud_user.py
+++ b/custom_components/sungrow/_config_flow/cloud_user.py
@@ -26,11 +26,12 @@ from ..const import (
 )
 from . import _base
 from ._base import _SungrowFlowBase
+from .plant_selection import PlantSelectionMixin
 
 _LOGGER = logging.getLogger(__name__)
 
 
-class CloudUserMixin(_SungrowFlowBase):
+class CloudUserMixin(PlantSelectionMixin, _SungrowFlowBase):
     """User-account cloud transport step for :class:`SungrowConfigFlow`."""
 
     async def async_step_cloud_user(self, user_input: dict[str, Any] | None = None) -> ConfigFlowResult:
@@ -56,6 +57,7 @@ class CloudUserMixin(_SungrowFlowBase):
             email = (user_input.get(CONF_USER_ACCOUNT) or "").strip()
             password = user_input.get(CONF_USER_PASSWORD) or ""
             gateway = user_input.get(CONF_GATEWAY) or "Europe"
+            plant_list: list[dict[str, Any]] = []
             if _base.UserAuth is None:
                 errors["base"] = "unknown"
             else:
@@ -63,7 +65,7 @@ class CloudUserMixin(_SungrowFlowBase):
                 client = _base.UserAuth(GATEWAYS[gateway], email, password, websession=session)
                 try:
                     async with asyncio.timeout(30):
-                        await client.async_get_plants()
+                        plant_list = list(await client.async_get_plants() or [])
                 except _base.AuthError:
                     errors["base"] = "invalid_auth"
                 except (_base.PySolarCloudException, ClientError, TimeoutError):
@@ -78,11 +80,14 @@ class CloudUserMixin(_SungrowFlowBase):
                     CONF_USER_PASSWORD: password,
                     CONF_GATEWAY: gateway,
                 }
-                if reauth_entry is not None:
-                    return self.async_update_reload_and_abort(reauth_entry, data=data)
-                await self.async_set_unique_id(f"user_{email.lower()}")
-                self._abort_if_unique_id_configured()
-                return self.async_create_entry(title=f"Sungrow ({email})", data=data)
+                # Multi-plant accounts route through the picker (#358); single-plant
+                # accounts skip it so the flow shape stays identical to pre-#358 for
+                # the common case.
+                if len(plant_list) > 1:
+                    self._pending_plant_list = plant_list
+                    self._pending_entry_data = data
+                    return await self.async_step_plant_selection()
+                return await self._finalise_cloud_user_entry(data)
 
         default_email = reauth_entry.data.get(CONF_USER_ACCOUNT, "") if reauth_entry is not None else ""
         default_gateway = reauth_entry.data.get(CONF_GATEWAY, "Europe") if reauth_entry is not None else "Europe"
@@ -97,3 +102,18 @@ class CloudUserMixin(_SungrowFlowBase):
             }
         )
         return self.async_show_form(step_id="cloud_user", data_schema=schema, errors=errors)
+
+    async def _finalise_cloud_user_entry(self, entry_data: dict[str, Any]) -> ConfigFlowResult:
+        """Create / update the cloud_user entry with the plant selection merged in.
+
+        Called by :class:`PlantSelectionMixin._dispatch_plant_selection_finalise`
+        after the user submits the picker, and by :meth:`async_step_cloud_user`
+        directly for single-plant accounts that skip the picker entirely.
+        """
+        reauth_entry = self._reauth_entry
+        if reauth_entry is not None:
+            return self.async_update_reload_and_abort(reauth_entry, data=entry_data)
+        email = str(entry_data.get(CONF_USER_ACCOUNT) or "")
+        await self.async_set_unique_id(f"user_{email.lower()}")
+        self._abort_if_unique_id_configured()
+        return self.async_create_entry(title=f"Sungrow ({email})", data=entry_data)

--- a/custom_components/sungrow/_config_flow/plant_selection.py
+++ b/custom_components/sungrow/_config_flow/plant_selection.py
@@ -1,0 +1,117 @@
+"""Multi-plant selection step for accounts serving more than one plant (#358).
+
+Both cloud transports (OAuth and user-account) fan out to multiple plants when
+the authenticated account has more than one — installers, multi-site owners.
+Before #358 the entry silently set up every plant; the user could not skip one
+they did not want the integration to touch.
+
+This step is inserted by :class:`CloudOAuthMixin` after a successful token
+exchange and by :class:`CloudUserMixin` after a successful login, whenever the
+API returns more than one plant. For single-plant accounts the step is skipped
+so the flow shape is unchanged for the common case.
+
+Selection is stored as :data:`CONF_PLANT_IDS`, a list of ``ps_id`` strings, on
+the config entry. Setup filters ``plant_list`` by this list; an absent /
+missing key means "serve every plant returned" (the pre-#358 behaviour), so
+legacy entries need no migration.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+import voluptuous as vol
+from homeassistant.config_entries import ConfigFlowResult
+from homeassistant.helpers.selector import (
+    SelectOptionDict,
+    SelectSelector,
+    SelectSelectorConfig,
+    SelectSelectorMode,
+)
+
+from ..const import CONF_PLANT_IDS, CONF_TRANSPORT, TRANSPORT_CLOUD_USER
+from ._base import _SungrowFlowBase
+
+_LOGGER = logging.getLogger(__name__)
+
+
+class PlantSelectionMixin(_SungrowFlowBase):
+    """Adds ``async_step_plant_selection`` to the config flow.
+
+    The step reads ``self._pending_plant_list`` (list of ``{"ps_id", "ps_name"}``
+    dicts, as returned by the library) and ``self._pending_entry_data`` (the
+    entry ``data`` dict the caller was about to hand to
+    ``async_create_entry``). It presents a multi-select picker of the plants
+    and, on submit, merges the chosen ``CONF_PLANT_IDS`` into the entry data
+    and dispatches back to the caller's transport-specific finaliser.
+
+    Dispatch is keyed off ``entry_data[CONF_TRANSPORT]`` rather than a shared
+    ``_finalise_plant_selection`` override — the mixin classes are combined
+    via multiple inheritance and Python's MRO would otherwise pick just one
+    class's override, sending every transport through the same code path.
+    """
+
+    _pending_plant_list: list[dict[str, Any]] | None = None
+    _pending_entry_data: dict[str, Any] | None = None
+
+    async def async_step_plant_selection(self, user_input: dict[str, Any] | None = None) -> ConfigFlowResult:
+        """Present a multi-select picker of the discovered plants (#358).
+
+        Every plant is checked by default, so a user who just wants "all of them"
+        can press Submit without changing anything — the flow is a strict superset
+        of the pre-#358 behaviour for that case. Unchecking a plant excludes it
+        from :data:`CONF_PLANT_IDS`; setup skips excluded plants entirely.
+        """
+        plant_list = self._pending_plant_list or []
+        entry_data = self._pending_entry_data or {}
+
+        if not plant_list:
+            # No plants somehow — nothing to pick. Let the caller finalise with an
+            # empty selection; setup will surface a clearer error than a dead step.
+            return await self._dispatch_plant_selection_finalise(entry_data)
+
+        errors: dict[str, str] = {}
+        if user_input is not None:
+            selected = list(user_input.get(CONF_PLANT_IDS) or [])
+            if not selected:
+                errors[CONF_PLANT_IDS] = "no_plants_selected"
+            else:
+                merged = {**entry_data, CONF_PLANT_IDS: selected}
+                return await self._dispatch_plant_selection_finalise(merged)
+
+        all_ids = [str(p["ps_id"]) for p in plant_list]
+        options = [
+            SelectOptionDict(value=str(p["ps_id"]), label=str(p.get("ps_name") or f"Plant {p['ps_id']}"))
+            for p in plant_list
+        ]
+        return self.async_show_form(
+            step_id="plant_selection",
+            data_schema=vol.Schema(
+                {
+                    vol.Required(CONF_PLANT_IDS, default=all_ids): SelectSelector(
+                        SelectSelectorConfig(
+                            options=options,
+                            multiple=True,
+                            mode=SelectSelectorMode.LIST,
+                        )
+                    ),
+                }
+            ),
+            errors=errors,
+        )
+
+    async def _dispatch_plant_selection_finalise(self, entry_data: dict[str, Any]) -> ConfigFlowResult:
+        """Route to the transport-specific finaliser based on the entry data.
+
+        Each cloud mixin exposes its own uniquely-named finaliser
+        (:meth:`CloudOAuthMixin._finalise_cloud_oauth_entry`,
+        :meth:`CloudUserMixin._finalise_cloud_user_entry`) so MRO can't collapse
+        them into a single call — this dispatcher picks the right one by
+        transport.
+        """
+        transport = entry_data.get(CONF_TRANSPORT)
+        if transport == TRANSPORT_CLOUD_USER:
+            return await self._finalise_cloud_user_entry(entry_data)  # type: ignore[attr-defined,no-any-return]
+        # Default: OAuth path (TRANSPORT_CLOUD_ONLY or missing).
+        return await self._finalise_cloud_oauth_entry(entry_data)  # type: ignore[attr-defined,no-any-return]

--- a/custom_components/sungrow/const.py
+++ b/custom_components/sungrow/const.py
@@ -49,6 +49,13 @@ CONF_MODEL = "model"
 CONF_SERIAL = "serial"
 DEFAULT_MODBUS_SCAN_INTERVAL = 30
 
+# Subset of the account's plants this entry serves (#358). A list of ``ps_id`` strings.
+# When absent or empty the entry serves *every* plant returned by the API — the
+# pre-#358 behaviour, so existing entries need no migration. The config flow inserts
+# a multi-select picker after auth for accounts with more than one plant and stores
+# the selected IDs here.
+CONF_PLANT_IDS = "plant_ids"
+
 # Backfill historical statistics (see specs/backfill-historical-statistics).
 # The History_Window defaults to 30 days back from now, is user-configurable via the
 # CONF_BACKFILL_DAYS option, and is clamped to [1, 365] days so a run can never request

--- a/custom_components/sungrow/strings.json
+++ b/custom_components/sungrow/strings.json
@@ -49,6 +49,13 @@
           "gateway": "Region"
         }
       },
+      "plant_selection": {
+        "title": "Select plants",
+        "description": "Your account has more than one plant. Choose which plants Home Assistant should integrate. Every plant is selected by default; uncheck any you do not want to include. You can change the selection later via Reconfigure.",
+        "data": {
+          "plant_ids": "Plants"
+        }
+      },
       "auth_callback": {
         "title": "Waiting for authorization",
         "description": "Open the link below to authorize the application:\n\n{auth_url}\n\nAfter you log in and approve the app, you will be redirected back and this screen will update automatically.\n\nIf the redirect does not complete (for example the page shows an error), wait a moment and you will be able to paste the code manually."
@@ -99,6 +106,7 @@
       "invalid_auth_code": "iSolarCloud rejected the authorization code — it may have already been used or expired. Open the authorization link above to get a fresh code, then paste it here (or paste the full redirect URL).",
       "invalid_extra_measure_points": "Extra measure points must be in the form point_id=code, comma separated",
       "invalid_redirect_uri": "The Redirect URI must end with /api/sungrow_hass/callback. Update it here AND in the iSolarCloud developer portal so both match — otherwise iSolarCloud redirects to the Home Assistant homepage and the authorization code is lost.",
+      "no_plants_selected": "Select at least one plant to integrate.",
       "unknown": "Unexpected error"
     },
     "abort": {

--- a/custom_components/sungrow/translations/cy.json
+++ b/custom_components/sungrow/translations/cy.json
@@ -49,6 +49,13 @@
           "gateway": "Rhanbarth"
         }
       },
+      "plant_selection": {
+        "title": "Dewiswch orsafoedd",
+        "description": "Mae gan eich cyfrif fwy nag un orsaf. Dewiswch pa orsafoedd y dylai Home Assistant eu cynnwys. Mae pob gorsaf wedi'i dewis yn ddiofyn; dad-diciwch unrhyw un nad ydych am ei chynnwys. Gallwch newid y dewis yn nes ymlaen drwy Ailgyflunio.",
+        "data": {
+          "plant_ids": "Gorsafoedd"
+        }
+      },
       "auth_callback": {
         "title": "Yn aros am awdurdodiad",
         "description": "Agorwch y ddolen isod i awdurdodi'r cymhwysiad:\n\n{auth_url}\n\nAr ôl i chi fewngofnodi a chymeradwyo'r ap, cewch eich ailgyfeirio yn ôl a bydd y sgrin hon yn diweddaru'n awtomatig.\n\nOs na fydd yr ailgyfeirio'n cwblhau (er enghraifft mae'r dudalen yn dangos gwall), arhoswch am eiliad a byddwch yn gallu gludo'r cod â llaw."
@@ -99,6 +106,7 @@
       "invalid_auth_code": "Gwrthododd iSolarCloud y cod awdurdodi — efallai ei fod eisoes wedi'i ddefnyddio neu wedi dod i ben. Agor y ddolen awdurdodi uchod i gael cod newydd, yna gludwch ef yma (neu gludwch yr URL ailgyfeirio llawn).",
       "invalid_extra_measure_points": "Rhaid i bwyntiau mesur ychwanegol fod ar ffurf point_id=code, wedi'u gwahanu gan atalnodau",
       "invalid_redirect_uri": "Rhaid i'r URI ailgyfeirio orffen gyda /api/sungrow_hass/callback. Diweddara ef yma AC yn y porth datblygwyr iSolarCloud fel bod y ddau yn cydweddu — fel arall mae iSolarCloud yn ailgyfeirio i dudalen gartref Home Assistant a chollir y cod awdurdodi.",
+      "no_plants_selected": "Dewiswch o leiaf un orsaf i'w chynnwys.",
       "unknown": "Gwall annisgwyl"
     },
     "abort": {

--- a/custom_components/sungrow/translations/de.json
+++ b/custom_components/sungrow/translations/de.json
@@ -49,6 +49,13 @@
           "gateway": "Region"
         }
       },
+      "plant_selection": {
+        "title": "Anlagen auswählen",
+        "description": "Ihr Konto hat mehr als eine Anlage. Wählen Sie, welche Anlagen Home Assistant einbinden soll. Standardmäßig ist jede Anlage ausgewählt; entfernen Sie das Häkchen bei denen, die Sie nicht einbeziehen möchten. Sie können die Auswahl später über Neu konfigurieren ändern.",
+        "data": {
+          "plant_ids": "Anlagen"
+        }
+      },
       "auth_callback": {
         "title": "Warten auf Autorisierung",
         "description": "Öffnen Sie den folgenden Link, um die Anwendung zu autorisieren:\n\n{auth_url}\n\nNachdem Sie sich angemeldet und die App genehmigt haben, werden Sie zurückgeleitet und diese Ansicht aktualisiert sich automatisch.\n\nFalls die Weiterleitung nicht abgeschlossen wird (zum Beispiel, wenn die Seite einen Fehler anzeigt), warten Sie einen Moment und Sie können den Code manuell einfügen."
@@ -99,6 +106,7 @@
       "invalid_auth_code": "iSolarCloud hat den Autorisierungscode abgelehnt — er wurde möglicherweise bereits verwendet oder ist abgelaufen. Öffne den Autorisierungslink oben, um einen neuen Code zu erhalten, und füge ihn hier ein (oder füge die vollständige Weiterleitungs-URL ein).",
       "invalid_extra_measure_points": "Zusätzliche Messpunkte müssen im Format point_id=code, durch Kommata getrennt, angegeben werden",
       "invalid_redirect_uri": "Die Redirect-URI muss auf /api/sungrow_hass/callback enden. Passe sie hier UND im iSolarCloud-Entwicklerportal so an, dass beide identisch sind — sonst leitet iSolarCloud auf die Home-Assistant-Startseite um und der Autorisierungscode geht verloren.",
+      "no_plants_selected": "Wählen Sie mindestens eine Anlage aus.",
       "unknown": "Unerwarteter Fehler"
     },
     "abort": {

--- a/custom_components/sungrow/translations/en.json
+++ b/custom_components/sungrow/translations/en.json
@@ -49,6 +49,13 @@
           "gateway": "Region"
         }
       },
+      "plant_selection": {
+        "title": "Select plants",
+        "description": "Your account has more than one plant. Choose which plants Home Assistant should integrate. Every plant is selected by default; uncheck any you do not want to include. You can change the selection later via Reconfigure.",
+        "data": {
+          "plant_ids": "Plants"
+        }
+      },
       "auth_callback": {
         "title": "Waiting for authorization",
         "description": "Open the link below to authorize the application:\n\n{auth_url}\n\nAfter you log in and approve the app, you will be redirected back and this screen will update automatically.\n\nIf the redirect does not complete (for example the page shows an error), wait a moment and you will be able to paste the code manually."
@@ -99,6 +106,7 @@
       "invalid_auth_code": "iSolarCloud rejected the authorization code — it may have already been used or expired. Open the authorization link above to get a fresh code, then paste it here (or paste the full redirect URL).",
       "invalid_extra_measure_points": "Extra measure points must be in the form point_id=code, comma separated",
       "invalid_redirect_uri": "The Redirect URI must end with /api/sungrow_hass/callback. Update it here AND in the iSolarCloud developer portal so both match — otherwise iSolarCloud redirects to the Home Assistant homepage and the authorization code is lost.",
+      "no_plants_selected": "Select at least one plant to integrate.",
       "unknown": "Unexpected error"
     },
     "abort": {

--- a/custom_components/sungrow/translations/es.json
+++ b/custom_components/sungrow/translations/es.json
@@ -49,6 +49,13 @@
           "gateway": "Región"
         }
       },
+      "plant_selection": {
+        "title": "Seleccionar plantas",
+        "description": "Tu cuenta tiene más de una planta. Elige qué plantas debe integrar Home Assistant. Todas las plantas están seleccionadas por defecto; desmarca las que no quieras incluir. Puedes cambiar la selección más tarde mediante Reconfigurar.",
+        "data": {
+          "plant_ids": "Plantas"
+        }
+      },
       "auth_callback": {
         "title": "Esperando la autorización",
         "description": "Abra el enlace siguiente para autorizar la aplicación:\n\n{auth_url}\n\nDespués de iniciar sesión y aprobar la aplicación, será redirigido de vuelta y esta pantalla se actualizará automáticamente.\n\nSi la redirección no se completa (por ejemplo, si la página muestra un error), espere un momento y podrá pegar el código manualmente."
@@ -99,6 +106,7 @@
       "invalid_auth_code": "iSolarCloud rechazó el código de autorización — puede que ya se haya usado o haya caducado. Abre el enlace de autorización de arriba para obtener un código nuevo y pégalo aquí (o pega la URL completa de redirección).",
       "invalid_extra_measure_points": "Los puntos de medición adicionales deben tener el formato point_id=code, separados por comas",
       "invalid_redirect_uri": "La URI de redirección debe terminar en /api/sungrow_hass/callback. Actualízala aquí Y en el portal de desarrollador de iSolarCloud para que coincidan — de lo contrario, iSolarCloud redirige a la página de inicio de Home Assistant y se pierde el código de autorización.",
+      "no_plants_selected": "Selecciona al menos una planta para integrar.",
       "unknown": "Error inesperado"
     },
     "abort": {

--- a/custom_components/sungrow/translations/fr.json
+++ b/custom_components/sungrow/translations/fr.json
@@ -49,6 +49,13 @@
           "gateway": "Région"
         }
       },
+      "plant_selection": {
+        "title": "Sélectionner les installations",
+        "description": "Votre compte comporte plus d'une installation. Choisissez celles que Home Assistant doit intégrer. Toutes les installations sont sélectionnées par défaut ; décochez celles que vous ne souhaitez pas inclure. Vous pouvez modifier la sélection ultérieurement via Reconfigurer.",
+        "data": {
+          "plant_ids": "Installations"
+        }
+      },
       "auth_callback": {
         "title": "En attente de l'autorisation",
         "description": "Ouvrez le lien ci-dessous pour autoriser l'application :\n\n{auth_url}\n\nUne fois connecté et après avoir approuvé l'application, vous serez redirigé et cet écran se mettra à jour automatiquement.\n\nSi la redirection ne se termine pas (par exemple si la page affiche une erreur), patientez un instant et vous pourrez coller le code manuellement."
@@ -99,6 +106,7 @@
       "invalid_auth_code": "iSolarCloud a rejeté le code d'autorisation — il a peut-être déjà été utilisé ou expiré. Ouvrez le lien d'autorisation ci-dessus pour obtenir un nouveau code, puis collez-le ici (ou collez l'URL de redirection complète).",
       "invalid_extra_measure_points": "Les points de mesure supplémentaires doivent être au format point_id=code, séparés par des virgules",
       "invalid_redirect_uri": "L'URI de redirection doit se terminer par /api/sungrow_hass/callback. Mettez-la à jour ici ET dans le portail développeur iSolarCloud pour qu'elles correspondent — sinon iSolarCloud redirige vers la page d'accueil Home Assistant et le code d'autorisation est perdu.",
+      "no_plants_selected": "Sélectionnez au moins une installation à intégrer.",
       "unknown": "Erreur inattendue"
     },
     "abort": {

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -1097,6 +1097,117 @@ async def test_cloud_user_invalid_auth_shows_error(hass: HomeAssistant):
 
 
 # ---------------------------------------------------------------------------
+# Multi-plant selection (#358)
+# ---------------------------------------------------------------------------
+# Accounts serving more than one plant are shown a picker after auth; the
+# selection is stored in ``CONF_PLANT_IDS`` and setup filters the plant list
+# accordingly. Single-plant accounts skip the picker entirely, so the flow
+# shape is unchanged for the common case.
+
+
+async def test_cloud_user_multi_plant_shows_picker(hass: HomeAssistant):
+    """Multi-plant accounts route through the plant-selection step (#358)."""
+    from custom_components.sungrow.const import (
+        CONF_GATEWAY,
+        CONF_PLANT_IDS,
+        CONF_USER_ACCOUNT,
+        CONF_USER_PASSWORD,
+        TRANSPORT_CLOUD_USER,
+    )
+
+    result = await hass.config_entries.flow.async_init(DOMAIN, context={"source": config_entries.SOURCE_USER})
+    await hass.config_entries.flow.async_configure(result["flow_id"], user_input={CONF_TRANSPORT: TRANSPORT_CLOUD_USER})
+
+    client = MagicMock()
+    client.async_get_plants = AsyncMock(
+        return_value=[
+            {"ps_id": 111, "ps_name": "Home"},
+            {"ps_id": 222, "ps_name": "Holiday"},
+            {"ps_id": 333, "ps_name": "Office"},
+        ]
+    )
+    with patch("custom_components.sungrow._config_flow._base.UserAuth", return_value=client):
+        result2 = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            user_input={
+                CONF_USER_ACCOUNT: "me@example.com",
+                CONF_USER_PASSWORD: "pw",
+                CONF_GATEWAY: "Europe",
+            },
+        )
+        # Multi-plant → picker is shown, no entry yet.
+        assert result2["type"] == data_entry_flow.FlowResultType.FORM
+        assert result2["step_id"] == "plant_selection"
+
+        # Submit a subset — Home + Office, leaving Holiday out.
+        result3 = await hass.config_entries.flow.async_configure(
+            result["flow_id"], user_input={CONF_PLANT_IDS: ["111", "333"]}
+        )
+
+    assert result3["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
+    assert result3["data"][CONF_PLANT_IDS] == ["111", "333"]
+
+
+async def test_cloud_user_multi_plant_no_selection_shows_error(hass: HomeAssistant):
+    """Submitting the picker with zero plants selected surfaces a clear error (#358)."""
+    from custom_components.sungrow.const import (
+        CONF_GATEWAY,
+        CONF_PLANT_IDS,
+        CONF_USER_ACCOUNT,
+        CONF_USER_PASSWORD,
+        TRANSPORT_CLOUD_USER,
+    )
+
+    result = await hass.config_entries.flow.async_init(DOMAIN, context={"source": config_entries.SOURCE_USER})
+    await hass.config_entries.flow.async_configure(result["flow_id"], user_input={CONF_TRANSPORT: TRANSPORT_CLOUD_USER})
+
+    client = MagicMock()
+    client.async_get_plants = AsyncMock(return_value=[{"ps_id": 1, "ps_name": "A"}, {"ps_id": 2, "ps_name": "B"}])
+    with patch("custom_components.sungrow._config_flow._base.UserAuth", return_value=client):
+        await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            user_input={CONF_USER_ACCOUNT: "me@example.com", CONF_USER_PASSWORD: "pw", CONF_GATEWAY: "Europe"},
+        )
+        # Submit picker with empty list.
+        result3 = await hass.config_entries.flow.async_configure(result["flow_id"], user_input={CONF_PLANT_IDS: []})
+
+    assert result3["type"] == data_entry_flow.FlowResultType.FORM
+    assert result3["step_id"] == "plant_selection"
+    assert result3["errors"][CONF_PLANT_IDS] == "no_plants_selected"
+
+
+async def test_cloud_user_single_plant_skips_picker(hass: HomeAssistant):
+    """Single-plant accounts skip the picker so the flow shape is unchanged (#358)."""
+    from custom_components.sungrow.const import (
+        CONF_GATEWAY,
+        CONF_PLANT_IDS,
+        CONF_USER_ACCOUNT,
+        CONF_USER_PASSWORD,
+        TRANSPORT_CLOUD_USER,
+    )
+
+    result = await hass.config_entries.flow.async_init(DOMAIN, context={"source": config_entries.SOURCE_USER})
+    await hass.config_entries.flow.async_configure(result["flow_id"], user_input={CONF_TRANSPORT: TRANSPORT_CLOUD_USER})
+
+    client = MagicMock()
+    client.async_get_plants = AsyncMock(return_value=[{"ps_id": 42, "ps_name": "Home"}])
+    with patch("custom_components.sungrow._config_flow._base.UserAuth", return_value=client):
+        result2 = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            user_input={
+                CONF_USER_ACCOUNT: "me@example.com",
+                CONF_USER_PASSWORD: "pw",
+                CONF_GATEWAY: "Europe",
+            },
+        )
+
+    assert result2["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
+    # No plant selection stored — setup will serve the one plant the account has,
+    # matching pre-#358 behaviour for single-plant users.
+    assert CONF_PLANT_IDS not in result2["data"]
+
+
+# ---------------------------------------------------------------------------
 # Redirect URI validation (#340)
 # ---------------------------------------------------------------------------
 # iSolarCloud silently drops the ``code`` query parameter if it redirects to

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -1133,6 +1133,106 @@ async def test_setup_cloud_user_entry(hass: HomeAssistant):
     control.async_check_update_support.assert_awaited()
 
 
+async def test_setup_cloud_user_filters_plants_by_selection(hass: HomeAssistant):
+    """CONF_PLANT_IDS on the entry restricts setup to the selected plants (#358)."""
+    from custom_components.sungrow.const import (
+        CONF_GATEWAY,
+        CONF_PLANT_IDS,
+        CONF_USER_ACCOUNT,
+        CONF_USER_PASSWORD,
+        TRANSPORT_CLOUD_USER,
+    )
+
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={
+            CONF_TRANSPORT: TRANSPORT_CLOUD_USER,
+            CONF_USER_ACCOUNT: "me@example.com",
+            CONF_USER_PASSWORD: "pw",
+            CONF_GATEWAY: "Europe",
+            # User selected the "Home" plant only during config flow.
+            CONF_PLANT_IDS: ["10"],
+        },
+    )
+    entry.add_to_hass(hass)
+
+    client = MagicMock()
+    client.async_get_plants = AsyncMock(
+        return_value=[
+            {"ps_id": 10, "ps_name": "Home"},
+            {"ps_id": 20, "ps_name": "Holiday"},
+            {"ps_id": 30, "ps_name": "Office"},
+        ]
+    )
+    client.async_get_plant_detail = AsyncMock(return_value={"curr_power": {"value": "1000", "unit": "W"}})
+    client.async_get_devices = AsyncMock(return_value=[])
+
+    control = MagicMock()
+    control.async_check_update_support = AsyncMock(return_value=True)
+
+    with (
+        patch("custom_components.sungrow.UserAuth", return_value=client),
+        patch("custom_components.sungrow.UserControl", return_value=control),
+    ):
+        assert await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+
+    # Only the selected "Home" plant is set up; the Holiday / Office plants are skipped.
+    data = entry.runtime_data
+    assert [c.plant_id for c in data.coordinators] == ["10"]
+
+
+async def test_setup_cloud_user_no_selection_serves_all_plants(hass: HomeAssistant):
+    """Legacy entries with no CONF_PLANT_IDS keep serving every plant (#358).
+
+    Pre-#358 behaviour: an entry that never went through the plant picker has
+    no ``CONF_PLANT_IDS`` in its data, and setup must include every plant the
+    account returns — otherwise upgrading to a version that introduces the
+    filter would silently drop plants from existing installations.
+    """
+    from custom_components.sungrow.const import (
+        CONF_GATEWAY,
+        CONF_USER_ACCOUNT,
+        CONF_USER_PASSWORD,
+        TRANSPORT_CLOUD_USER,
+    )
+
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={
+            CONF_TRANSPORT: TRANSPORT_CLOUD_USER,
+            CONF_USER_ACCOUNT: "me@example.com",
+            CONF_USER_PASSWORD: "pw",
+            CONF_GATEWAY: "Europe",
+            # No CONF_PLANT_IDS — legacy shape from before #358.
+        },
+    )
+    entry.add_to_hass(hass)
+
+    client = MagicMock()
+    client.async_get_plants = AsyncMock(
+        return_value=[
+            {"ps_id": 100, "ps_name": "Home"},
+            {"ps_id": 200, "ps_name": "Holiday"},
+        ]
+    )
+    client.async_get_plant_detail = AsyncMock(return_value={"curr_power": {"value": "1000", "unit": "W"}})
+    client.async_get_devices = AsyncMock(return_value=[])
+
+    control = MagicMock()
+    control.async_check_update_support = AsyncMock(return_value=True)
+
+    with (
+        patch("custom_components.sungrow.UserAuth", return_value=client),
+        patch("custom_components.sungrow.UserControl", return_value=control),
+    ):
+        assert await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+
+    data = entry.runtime_data
+    assert sorted(c.plant_id for c in data.coordinators) == ["100", "200"]
+
+
 async def test_heartbeat_loop_uses_update_parameters_without_native_loop(hass: HomeAssistant):
     """UserControl-style clients without heartbeat_loop still keep EMS alive (#271)."""
     entry = MockConfigEntry(domain=DOMAIN, data={"tokens": {}})


### PR DESCRIPTION
Closes #358.

Installers and multi-site owners have multiple plants under one iSolarCloud account. Before this change the config entry silently set up every plant, with no in-UI way to opt any of them out — a common support-ticket topic.

This adds a `plant_selection` step to both cloud transports (OAuth and user-account) shown **only when the account returns more than one plant**. Every plant is checked by default so pressing Submit is equivalent to the pre-#358 behaviour ("all of them"); unchecking a plant excludes it from the config entry. Single-plant accounts skip the picker entirely so the flow shape is unchanged for the common case.

## Layout

- **`_config_flow/plant_selection.py`** (new) — `PlantSelectionMixin` with `async_step_plant_selection` and a transport-aware dispatcher.
- **`CloudOAuthMixin` / `CloudUserMixin`** now inherit `PlantSelectionMixin`; each exposes a uniquely-named finaliser (`_finalise_cloud_oauth_entry`, `_finalise_cloud_user_entry`) so Python's MRO can't collapse them into a single call. Both route into the picker between token exchange / login and entry creation when the account has >1 plants.
- **`const.py`** gains `CONF_PLANT_IDS: list[str]`. Missing / empty means "serve every plant" — the pre-#358 shape, so existing entries need no migration.
- **`__init__.py`** gains `_filter_plants_by_selection` applied to both cloud setup paths. A selection that no longer matches any plant (all previously-selected plants deleted upstream) falls back to the full list rather than silently emptying the entry.
- **`strings.json` + every locale** (`cy` / `de` / `en` / `es` / `fr`) grows the `plant_selection` step and a `no_plants_selected` error message; translation-parity test passes.

## OAuth-side plant fetch

Adding the picker to the OAuth path needed the plant list *before* the entry is created — the pre-#358 flow just handed tokens back and let setup enumerate plants later. The new `_fetch_plants` uses the freshly-authorized `auth_client` to fetch plants inside the flow. It's guarded by a broad `except Exception`: the picker is a UX nicety, not a correctness gate, so a probe error (typed or otherwise) must never block the entry from being created — the flow just skips the picker and setup serves whatever it discovers.

## Deliberate design choices

Kept the simpler **multi-select shape (one entry per account, filtered plant list)** rather than the issue's suggested "fan out into N entries per plant". Fewer entries to manage in Settings > Devices & Services, no unique-id salting migration for existing OAuth/user-account entries, and users still get the pick-which-plants control the issue asks for. If a user genuinely wants separate entries per plant, they can re-run initial setup and pick a smaller subset each time.

## Not in scope

- **Reconfigure-flow plant-selection editing.** Once merged, users who want to change the selection re-run initial setup. A follow-up can wire the picker into the reconfigure branch cleanly now that the shared mixin exists.
- **Legacy multi-plant entries auto-splitting.** Existing users keep their current all-plants-under-one-entry model unless they submit a smaller subset via a fresh setup flow.

## Tests

Five new tests in `test_config_flow.py` + `test_init.py`:

- `test_cloud_user_multi_plant_shows_picker` — picker appears, subset survives into entry data.
- `test_cloud_user_multi_plant_no_selection_shows_error` — zero-select surfaces `no_plants_selected` on the form.
- `test_cloud_user_single_plant_skips_picker` — flow shape unchanged for the common case, no `CONF_PLANT_IDS` stored.
- `test_setup_cloud_user_filters_plants_by_selection` — setup honours the stored `CONF_PLANT_IDS`.
- `test_setup_cloud_user_no_selection_serves_all_plants` — legacy entries (no `CONF_PLANT_IDS`) still serve every plant, so the upgrade path is a no-op for existing users.

## Verification

- `ruff check custom_components/ tests/` — clean
- `ruff format --check custom_components/ tests/` — clean
- `mypy` (strict) — clean, 40 source files
- `pytest tests/` — 838 passed, 4 deselected (live)