### PR TITLE
feat(dispatch): scheduled forced-charge / forced-discharge windows (#359)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,13 @@
 # See https://pre-commit.com for more information
 # See https://pre-commit.com/hooks.html for more hooks
+#
+# Stages:
+# * ``pre-commit`` — fast checks (ruff, mypy, manifest sort). Run on every commit.
+# * ``pre-push`` — the full pytest suite. Runs once per push so a commit-heavy
+#   local workflow isn't slowed down by re-running tests on each fixup.
+#
+# Enable both stages once with:
+#   pre-commit install --hook-type pre-commit --hook-type pre-push
 repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
     # Keep in sync with the ruff pin in requirements_test.txt and ci.yml.
@@ -19,3 +27,25 @@ repos:
         language: system
         files: ^custom_components/sungrow/manifest\.json$
         pass_filenames: false
+
+      # Strict mypy on the whole integration + tests. Runs once per commit
+      # regardless of which files staged — mypy's cross-file inference means
+      # a change in one module can surface an error in another.
+      - id: mypy
+        name: mypy (strict)
+        entry: .venv/bin/mypy
+        language: system
+        pass_filenames: false
+        # Any Python source touched should trip mypy; the config in pyproject.toml
+        # narrows scope to custom_components/ + tests/.
+        files: \.py$
+        stages: [pre-commit]
+
+      # Full pytest run on push so no broken commit reaches origin. ``--no-cov -q``
+      # keeps the pre-push wait short; CI still runs the coverage-gated variant.
+      - id: pytest
+        name: pytest (no-cov)
+        entry: .venv/bin/python -m pytest tests/ --no-cov -q
+        language: system
+        pass_filenames: false
+        stages: [pre-push]

--- a/custom_components/sungrow/__init__.py
+++ b/custom_components/sungrow/__init__.py
@@ -78,6 +78,7 @@ from .migration import (
     async_migrate_entry as async_migrate_entry,
 )
 from .oauth_view import SungrowAuthCallbackView
+from .schedule import SungrowScheduler
 from .services import async_setup_services
 
 PLATFORMS: list[Platform] = [Platform.BINARY_SENSOR, Platform.NUMBER, Platform.SELECT, Platform.SENSOR]
@@ -132,6 +133,10 @@ class SungrowData:
     heartbeats: dict[str, tuple[asyncio.Event, asyncio.Task[None]]] = field(default_factory=dict)
     # None for a Modbus-only entry (backfill is cloud-only, Requirement 1.2).
     backfill: BackfillManager | None = None
+    # Scheduled forced-charge / forced-discharge windows engine (#359). None when the
+    # entry has no schedule configured or no battery-capable plant; the setup path
+    # only wires it up for cloud entries that can actually accept battery-mode writes.
+    scheduler: SungrowScheduler | None = None
 
 
 type SungrowConfigEntry = ConfigEntry[SungrowData]
@@ -467,7 +472,26 @@ async def _async_setup_cloud_user(hass: HomeAssistant, entry: SungrowConfigEntry
         )
 
     await hass.config_entries.async_forward_entry_setups(entry, _entry_platforms(entry))
+    await _async_start_scheduler(hass, entry)
     return True
+
+
+async def _async_start_scheduler(hass: HomeAssistant, entry: SungrowConfigEntry) -> None:
+    """Wire up the forced-charge / forced-discharge scheduler for a cloud entry (#359).
+
+    Only cloud entries with a battery-capable plant get a scheduler; PV-only
+    string inverters and Modbus-only entries never surface a battery-mode select
+    for the engine to drive. The scheduler self-limits to no-ops when no windows
+    are configured, so instantiating one unconditionally on cloud entries is
+    cheap — but skipping it when no battery is present avoids the "no selects
+    registered" debug spam on every entry setup.
+    """
+    if not any(getattr(c, "has_battery", False) for c in entry.runtime_data.coordinators):
+        return
+    scheduler = SungrowScheduler.from_entry(hass, entry)
+    entry.runtime_data.scheduler = scheduler
+    if scheduler.windows:
+        await scheduler.async_start()
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: SungrowConfigEntry) -> bool:
@@ -640,6 +664,8 @@ async def async_setup_entry(hass: HomeAssistant, entry: SungrowConfigEntry) -> b
 
     entry.async_create_background_task(hass, _async_start_backfill(), name="sungrow-backfill-start")
 
+    await _async_start_scheduler(hass, entry)
+
     return True
 
 
@@ -651,6 +677,10 @@ async def async_unload_entry(hass: HomeAssistant, entry: SungrowConfigEntry) -> 
     # failed unload.
     unloaded = await hass.config_entries.async_unload_platforms(entry, _entry_platforms(entry))
     if unloaded:
+        # Cancel any armed schedule transitions so a reload doesn't leak timers (#359).
+        scheduler = entry.runtime_data.scheduler
+        if scheduler is not None:
+            scheduler.async_stop()
         # Cancel any in-flight Backfill runs before tearing down (Requirement 1.5). Cloud
         # entries have a manager; the Modbus-only path leaves ``backfill`` as None.
         manager = entry.runtime_data.backfill

--- a/custom_components/sungrow/_config_flow/options.py
+++ b/custom_components/sungrow/_config_flow/options.py
@@ -11,6 +11,7 @@ registered in ``__init__``.
 from __future__ import annotations
 
 import logging
+from collections.abc import Mapping
 from typing import Any
 
 import voluptuous as vol
@@ -23,6 +24,7 @@ from ..const import (
     CONF_MODBUS_DEBUG_DAILY_YIELD,
     CONF_MODBUS_HOST,
     CONF_SCAN_INTERVAL,
+    CONF_SCHEDULE_WINDOWS,
     CONF_TRANSPORT,
     DEFAULT_MODBUS_SCAN_INTERVAL,
     DEFAULT_SCAN_INTERVAL,
@@ -31,6 +33,15 @@ from ..const import (
     TRANSPORT_MODBUS_ONLY,
 )
 from ._helpers import _parse_extra_measure_points
+
+# Fixed number of schedule slots exposed in the options-flow UI (#359). Two covers
+# the common tariff pattern (cheap overnight charge + optional peak discharge); users
+# who need more can add windows via YAML options edits or wait for a follow-up UI.
+_SCHEDULE_SLOTS = 2
+
+# Mode options offered per schedule slot, mirroring the keys accepted by
+# ``sungrow.set_battery_mode`` and :mod:`..schedule`.
+_SCHEDULE_MODE_OPTIONS = ("force_charge", "force_discharge")
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -63,13 +74,22 @@ class SungrowOptionsFlow(config_entries.OptionsFlowWithReload):
                 errors["base"] = "invalid_extra_measure_points"
                 _LOGGER.warning("Invalid extra measure points input: %s", exc)
             else:
-                data = {**user_input, CONF_EXTRA_MEASURE_POINTS: extras}
-                data.pop(CONF_MODBUS_HOST, None)
-                data.pop(CONF_MODBUS_DEBUG_DAILY_YIELD, None)
-                # cloud_modbus transport was retired in #348; the options flow no
-                # longer offers modbus_host on cloud entries. Local Modbus is set up
-                # via a separate ``Modbus Only`` entry instead.
+                schedule_windows, schedule_errors = _collect_schedule_windows(user_input)
+                errors.update(schedule_errors)
                 if not errors:
+                    data = {**user_input, CONF_EXTRA_MEASURE_POINTS: extras}
+                    data.pop(CONF_MODBUS_HOST, None)
+                    data.pop(CONF_MODBUS_DEBUG_DAILY_YIELD, None)
+                    # Strip the per-slot schedule fields — they're stored as a single
+                    # normalised list under ``CONF_SCHEDULE_WINDOWS`` (#359).
+                    for slot in range(1, _SCHEDULE_SLOTS + 1):
+                        data.pop(f"schedule_{slot}_start", None)
+                        data.pop(f"schedule_{slot}_end", None)
+                        data.pop(f"schedule_{slot}_mode", None)
+                    data[CONF_SCHEDULE_WINDOWS] = schedule_windows
+                    # cloud_modbus transport was retired in #348; the options flow no
+                    # longer offers modbus_host on cloud entries. Local Modbus is set up
+                    # via a separate ``Modbus Only`` entry instead.
                     return self.async_create_entry(title="", data=data)
 
         current_interval = self.config_entry.options.get(CONF_SCAN_INTERVAL, DEFAULT_SCAN_INTERVAL)
@@ -94,6 +114,12 @@ class SungrowOptionsFlow(config_entries.OptionsFlowWithReload):
         # transport). The options flow for a cloud entry no longer offers a
         # ``modbus_host`` field — users who want local Modbus add a ``Modbus Only``
         # entry alongside their cloud one.
+
+        # Scheduled forced-charge / forced-discharge windows (#359). Two fixed slots
+        # cover the typical tariff shape; each slot is a triple of start / end /
+        # mode fields. Leaving both start and end blank disables that slot.
+        schedule_fields = _build_schedule_slot_schema(self.config_entry.options)
+        schema_fields.update(schedule_fields)
 
         return self.async_show_form(
             step_id="init",
@@ -130,3 +156,92 @@ class SungrowOptionsFlow(config_entries.OptionsFlowWithReload):
                 }
             ),
         )
+
+
+# ---------------------------------------------------------------------------
+# #359 schedule-window slot helpers
+# ---------------------------------------------------------------------------
+
+
+def _build_schedule_slot_schema(current_options: Mapping[str, Any]) -> dict[Any, Any]:
+    """Build the ``vol.Optional`` fields for each schedule slot (#359).
+
+    Each slot contributes three fields to the options form: a start-time picker,
+    an end-time picker, and a mode dropdown. Defaults are pulled from the
+    entry's currently-persisted ``CONF_SCHEDULE_WINDOWS`` (if any) so re-opening
+    the options form shows the values the user last submitted.
+    """
+    from homeassistant.helpers.selector import (
+        SelectOptionDict,
+        SelectSelector,
+        SelectSelectorConfig,
+        TimeSelector,
+    )
+
+    current_windows = list(current_options.get(CONF_SCHEDULE_WINDOWS) or [])
+    fields: dict[Any, Any] = {}
+    for slot in range(1, _SCHEDULE_SLOTS + 1):
+        row = current_windows[slot - 1] if slot - 1 < len(current_windows) else {}
+        start_default = str(row.get("start") or "")
+        end_default = str(row.get("end") or "")
+        mode_default = str(row.get("mode") or _SCHEDULE_MODE_OPTIONS[0])
+        # ``description={"suggested_value": ...}`` keeps the field empty by default
+        # in the UI but pre-fills the last value on re-open; ``vol.Optional`` with an
+        # empty-string default lets the user *clear* the slot to disable it.
+        fields[
+            vol.Optional(
+                f"schedule_{slot}_start",
+                description={"suggested_value": start_default} if start_default else None,
+            )
+        ] = TimeSelector()
+        fields[
+            vol.Optional(
+                f"schedule_{slot}_end",
+                description={"suggested_value": end_default} if end_default else None,
+            )
+        ] = TimeSelector()
+        fields[
+            vol.Optional(
+                f"schedule_{slot}_mode",
+                default=mode_default,
+            )
+        ] = SelectSelector(
+            SelectSelectorConfig(
+                options=[
+                    SelectOptionDict(value="force_charge", label="Force charge"),
+                    SelectOptionDict(value="force_discharge", label="Force discharge"),
+                ]
+            )
+        )
+    return fields
+
+
+def _collect_schedule_windows(
+    user_input: dict[str, Any],
+) -> tuple[list[dict[str, str]], dict[str, str]]:
+    """Read the per-slot fields back into a normalised ``CONF_SCHEDULE_WINDOWS`` list.
+
+    Returns ``(windows, errors)``: a slot with both start and end blank is treated
+    as "disabled" and simply omitted; a half-populated slot (only one of start /
+    end set) is a user error surfaced as ``invalid_schedule_window`` so they can
+    fix it. Overlapping windows are allowed at save time — the engine resolves
+    overlaps by picking the latest-starting one.
+    """
+    windows: list[dict[str, str]] = []
+    errors: dict[str, str] = {}
+    for slot in range(1, _SCHEDULE_SLOTS + 1):
+        start = (user_input.get(f"schedule_{slot}_start") or "").strip()
+        end = (user_input.get(f"schedule_{slot}_end") or "").strip()
+        mode = (user_input.get(f"schedule_{slot}_mode") or "").strip()
+        if not start and not end:
+            continue  # slot disabled — legitimate
+        if not start or not end:
+            errors["base"] = "invalid_schedule_window"
+            _LOGGER.warning("Schedule slot %d has only one of start/end filled in", slot)
+            continue
+        if mode not in _SCHEDULE_MODE_OPTIONS:
+            errors["base"] = "invalid_schedule_window"
+            _LOGGER.warning("Schedule slot %d has an unknown mode %r", slot, mode)
+            continue
+        windows.append({"start": start, "end": end, "mode": mode})
+    return windows, errors

--- a/custom_components/sungrow/const.py
+++ b/custom_components/sungrow/const.py
@@ -56,6 +56,15 @@ DEFAULT_MODBUS_SCAN_INTERVAL = 30
 # the selected IDs here.
 CONF_PLANT_IDS = "plant_ids"
 
+# Scheduled forced-charge / forced-discharge windows (#359). Stored in
+# ``entry.options`` as a list of window dicts, each with ``start`` ("HH:MM" local
+# time), ``end`` ("HH:MM" local time), and ``mode`` (``force_charge`` or
+# ``force_discharge``). Missing / empty means "no schedule" — the entry serves the
+# user's manual battery-mode picks as before. Wrap-over-midnight is allowed
+# (``start > end`` means the window spans midnight). Overlapping windows are
+# resolved to the most recently started one.
+CONF_SCHEDULE_WINDOWS = "schedule_windows"
+
 # Backfill historical statistics (see specs/backfill-historical-statistics).
 # The History_Window defaults to 30 days back from now, is user-configurable via the
 # CONF_BACKFILL_DAYS option, and is clamped to [1, 365] days so a run can never request

--- a/custom_components/sungrow/schedule.py
+++ b/custom_components/sungrow/schedule.py
@@ -1,0 +1,355 @@
+"""Daily-repeating forced-charge / forced-discharge schedule engine (#359).
+
+Users on tariff plans want to charge cheap-overnight and (optionally) discharge
+peak-daytime. Before #359 this required a HA automation calling
+``sungrow.set_battery_mode`` at the boundaries with correct handling of
+duration-based auto-revert, HA restarts mid-window, and automation-vs-UI
+conflicts — turning every tariff user into an automation author.
+
+This module owns a lightweight scheduler that:
+
+* Reads a list of :class:`ScheduleWindow` from the entry options.
+* Applies the correct battery mode at each window boundary via the same
+  registered battery-mode select entities that :mod:`.services` uses.
+* Handles HA restarts by evaluating the currently-active window at start and
+  issuing the matching command up front, so the inverter doesn't drift out of
+  the intended mode while the integration was down.
+* Handles overlapping windows by picking the one with the latest start time —
+  a superset window that fully contains a shorter one loses to the shorter one
+  during its overlap.
+
+Deliberately scoped narrow for v1: **daily-repeating** windows only. Weekly
+patterns and TOU tariff plans are out of scope (they belong on the Energy
+dashboard or a separate feature).
+"""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Callable
+from dataclasses import dataclass, field
+from datetime import datetime, time
+from typing import TYPE_CHECKING, Any
+
+from homeassistant.core import CALLBACK_TYPE, HomeAssistant, callback
+from homeassistant.exceptions import HomeAssistantError
+from homeassistant.helpers.event import async_track_time_change
+
+from .const import CONF_SCHEDULE_WINDOWS, DOMAIN
+
+if TYPE_CHECKING:
+    from . import SungrowConfigEntry
+
+_LOGGER = logging.getLogger(__name__)
+
+# Accepted mode strings in the window dict — mirrors the keys accepted by
+# ``sungrow.set_battery_mode`` so schedule authoring and the manual service use
+# the same vocabulary.
+_SCHEDULE_MODES: frozenset[str] = frozenset({"force_charge", "force_discharge"})
+
+# The mode applied at the *end* of every window — release the battery back to
+# the plant's Self-consumption behaviour so the user can resume manual control
+# outside the scheduled window.
+_MODE_AFTER_WINDOW = "self_consumption"
+
+
+@dataclass(frozen=True)
+class ScheduleWindow:
+    """A single daily-repeating window that arms one battery mode.
+
+    ``start`` and ``end`` are local wall-clock times. If ``start >= end`` the
+    window wraps over midnight — ``23:30`` → ``06:00`` means "from 23:30 today
+    until 06:00 tomorrow", every day.
+    """
+
+    start: time
+    end: time
+    mode: str
+
+    def __post_init__(self) -> None:
+        """Validate that the mode is one of the accepted schedule modes."""
+        if self.mode not in _SCHEDULE_MODES:
+            raise ValueError(f"Invalid schedule mode: {self.mode!r}")
+        if self.start == self.end:
+            raise ValueError(f"Window start ({self.start}) equals end ({self.end}); a zero-length window has no effect")
+
+    def contains(self, now: time) -> bool:
+        """Return True if ``now`` (local wall-clock) is inside this window.
+
+        Wrap-over-midnight windows (``start >= end``) are handled: ``now`` is
+        inside such a window when it's ``>= start`` OR ``< end``.
+        """
+        if self.start < self.end:
+            return self.start <= now < self.end
+        # Wrap over midnight.
+        return now >= self.start or now < self.end
+
+
+@dataclass
+class SungrowScheduler:
+    """Per-entry schedule engine (#359).
+
+    Instantiated in :func:`~custom_components.sungrow.async_setup_entry` for
+    every cloud entry with at least one battery-capable plant. On
+    :meth:`async_start` it evaluates the currently-active window and applies
+    the matching mode up front, then registers ``async_track_time_change``
+    callbacks for every window boundary so future transitions actuate at the
+    right time. :meth:`async_stop` releases every callback so unloading /
+    reloading the entry is clean.
+    """
+
+    hass: HomeAssistant
+    entry: SungrowConfigEntry
+    windows: list[ScheduleWindow] = field(default_factory=list)
+    _cancels: list[CALLBACK_TYPE] = field(default_factory=list, init=False, repr=False)
+    _current_window: ScheduleWindow | None = field(default=None, init=False, repr=False)
+
+    @classmethod
+    def from_entry(cls, hass: HomeAssistant, entry: SungrowConfigEntry) -> SungrowScheduler:
+        """Build a scheduler for ``entry`` by parsing its options.
+
+        Malformed windows are dropped with a warning rather than failing the
+        whole entry setup — a typo in one row shouldn't take the integration
+        offline. The user sees the warning and fixes the row via the options
+        flow (which validates the same way).
+        """
+        raw = entry.options.get(CONF_SCHEDULE_WINDOWS) or []
+        windows: list[ScheduleWindow] = []
+        for i, row in enumerate(raw):
+            try:
+                windows.append(_parse_window(row))
+            except (ValueError, TypeError, KeyError) as err:
+                _LOGGER.warning(
+                    "Dropping malformed schedule window #%d on entry %s: %s (row=%r)",
+                    i,
+                    entry.title,
+                    err,
+                    row,
+                )
+        return cls(hass=hass, entry=entry, windows=windows)
+
+    def active_window(self, now: time) -> ScheduleWindow | None:
+        """Return the schedule window active at ``now`` (local time), or None.
+
+        Overlap policy: multiple windows can match a given time; the one with
+        the latest ``start`` wins. That's the intuitive "most recently entered
+        wins" behaviour — a superset window fully containing a shorter one
+        gets overridden during the shorter window's span. Wrap-over-midnight
+        starts count as their raw ``start`` time (a 23:30-06:00 window's start
+        is 23:30, later than a 08:00 window's start).
+        """
+        matches = [w for w in self.windows if w.contains(now)]
+        if not matches:
+            return None
+        return max(matches, key=lambda w: w.start)
+
+    async def async_start(self) -> None:
+        """Apply the currently-active window's mode and arm boundary callbacks.
+
+        Idempotent: safe to call twice — a second call is treated as a reload
+        and drops any callbacks the previous call installed. That's what lets
+        the options-flow's ``OptionsFlowWithReload`` reload the entry without
+        leaking stale timers.
+        """
+        self.async_stop()
+        if not self.windows:
+            _LOGGER.debug("Scheduler for entry %s has no windows; nothing to arm", self.entry.title)
+            return
+
+        # Apply the mode active *right now* so an HA restart mid-window doesn't
+        # leave the inverter drifting outside the intended mode.
+        from homeassistant.util import dt as dt_util
+
+        now_local = dt_util.now().time()
+        self._current_window = self.active_window(now_local)
+        if self._current_window is not None:
+            _LOGGER.info(
+                "Entry %s: applying scheduled mode %s (window %s-%s) on setup",
+                self.entry.title,
+                self._current_window.mode,
+                self._current_window.start.strftime("%H:%M"),
+                self._current_window.end.strftime("%H:%M"),
+            )
+            await self._apply_mode(self._current_window.mode)
+        else:
+            _LOGGER.debug("Entry %s: no schedule window active at %s", self.entry.title, now_local)
+
+        # Arm one time-change callback per window boundary. ``async_track_time_change``
+        # fires every day at the specified HH:MM:00, so we get daily repetition for free
+        # without having to reschedule after each fire.
+        for i, window in enumerate(self.windows):
+            self._cancels.append(
+                async_track_time_change(
+                    self.hass,
+                    self._make_transition_callback(window, entering=True),
+                    hour=window.start.hour,
+                    minute=window.start.minute,
+                    second=0,
+                )
+            )
+            self._cancels.append(
+                async_track_time_change(
+                    self.hass,
+                    self._make_transition_callback(window, entering=False),
+                    hour=window.end.hour,
+                    minute=window.end.minute,
+                    second=0,
+                )
+            )
+            _LOGGER.debug(
+                "Entry %s: armed schedule window #%d (%s %s-%s)",
+                self.entry.title,
+                i,
+                window.mode,
+                window.start.strftime("%H:%M"),
+                window.end.strftime("%H:%M"),
+            )
+
+    @callback
+    def async_stop(self) -> None:
+        """Cancel every armed transition callback. Idempotent."""
+        for cancel in self._cancels:
+            cancel()
+        self._cancels.clear()
+        self._current_window = None
+
+    def _make_transition_callback(self, window: ScheduleWindow, *, entering: bool) -> Callable[[datetime], None]:
+        """Build the ``async_track_time_change`` callback for one boundary."""
+
+        @callback
+        def _on_boundary(_now: datetime) -> None:
+            # ``async_track_time_change`` fires the callback synchronously; kick
+            # the mode change into a task so we can await the select entity.
+            self.hass.async_create_task(self._on_boundary_impl(window, entering=entering))
+
+        return _on_boundary
+
+    async def _on_boundary_impl(self, window: ScheduleWindow, *, entering: bool) -> None:
+        """Apply the mode for a boundary crossing.
+
+        On *entering* a window: apply the window's mode.
+        On *leaving* a window: revert to ``self_consumption`` — but only if the
+        window we're leaving is still the ``_current_window``. If a longer
+        window is nested inside a shorter one (overlap), the leaving-callback
+        for the shorter one fires first, and we don't want it to release the
+        battery while the enclosing window should still be active.
+        """
+        from homeassistant.util import dt as dt_util
+
+        if entering:
+            self._current_window = window
+            _LOGGER.info(
+                "Entry %s: entering scheduled window %s-%s (%s)",
+                self.entry.title,
+                window.start.strftime("%H:%M"),
+                window.end.strftime("%H:%M"),
+                window.mode,
+            )
+            await self._apply_mode(window.mode)
+            return
+
+        # Leaving: if an enclosing (later-starting) window still applies at
+        # ``now``, keep its mode; otherwise release the battery.
+        now_local = dt_util.now().time()
+        still_active = self.active_window(now_local)
+        if still_active is None:
+            _LOGGER.info(
+                "Entry %s: leaving scheduled window %s-%s; releasing battery to Self-consumption",
+                self.entry.title,
+                window.start.strftime("%H:%M"),
+                window.end.strftime("%H:%M"),
+            )
+            self._current_window = None
+            await self._apply_mode(_MODE_AFTER_WINDOW)
+        else:
+            _LOGGER.debug(
+                "Entry %s: window %s-%s ended but enclosing window %s-%s still active; leaving mode alone",
+                self.entry.title,
+                window.start.strftime("%H:%M"),
+                window.end.strftime("%H:%M"),
+                still_active.start.strftime("%H:%M"),
+                still_active.end.strftime("%H:%M"),
+            )
+            self._current_window = still_active
+
+    async def _apply_mode(self, mode_key: str) -> None:
+        """Set the battery mode on every battery-mode select owned by this entry.
+
+        Mirrors ``sungrow.set_battery_mode`` (#255) but scoped to this entry's
+        plants so scheduling one entry doesn't sneakily touch another. Failures
+        are logged and swallowed — a transient cloud hiccup shouldn't tear
+        down the schedule; the next boundary or a manual invocation will
+        retry.
+        """
+        from .select import BATTERY_MODE_PARAM, BATTERY_MODE_SERVICE_KEYS
+
+        try:
+            option = BATTERY_MODE_SERVICE_KEYS[mode_key]
+        except KeyError:
+            _LOGGER.warning("Scheduler received unknown mode key %r; skipping", mode_key)
+            return
+
+        registry = self.hass.data.get(DOMAIN, {}).get("battery_mode_selects")
+        if not isinstance(registry, dict) or not registry:
+            _LOGGER.debug(
+                "Scheduler for entry %s: no battery-mode selects registered yet; skipping",
+                self.entry.title,
+            )
+            return
+
+        # Only touch selects that belong to *this* entry's coordinators, not
+        # every entry's. The select's ``config_entry`` attribute (set on HA
+        # entity registration) is the cheapest way to tell.
+        for select in list(registry.values()):
+            entity_entry = getattr(select, "registry_entry", None)
+            if entity_entry is not None and entity_entry.config_entry_id != self.entry.entry_id:
+                continue
+            try:
+                await select.async_select_option(option)
+                if select.hass is not None and getattr(select, "platform", None) is not None:
+                    select.async_write_ha_state()
+            except HomeAssistantError as err:
+                _LOGGER.warning(
+                    "Scheduler for entry %s: failed to set %s on %s: %s",
+                    self.entry.title,
+                    BATTERY_MODE_PARAM,
+                    getattr(select, "entity_id", "<unknown>"),
+                    err,
+                )
+
+
+def _parse_window(row: Any) -> ScheduleWindow:
+    """Parse one schedule window dict into a :class:`ScheduleWindow`.
+
+    Accepts the shape produced by the options flow and equivalent user-authored
+    YAML — ``start`` / ``end`` as ``"HH:MM"`` strings (or ``time`` instances)
+    and ``mode`` as one of the accepted mode keys.
+    """
+    if not isinstance(row, dict):
+        raise TypeError(f"Expected a dict, got {type(row).__name__}")
+    start = _coerce_time(row["start"])
+    end = _coerce_time(row["end"])
+    mode = str(row["mode"]).strip()
+    return ScheduleWindow(start=start, end=end, mode=mode)
+
+
+def _coerce_time(value: Any) -> time:
+    """Coerce a value to a :class:`~datetime.time`.
+
+    Accepts ``time`` instances (options-flow ``TimeSelector`` returns strings
+    but user-authored YAML might produce ``time`` objects), and ``"HH:MM"`` /
+    ``"HH:MM:SS"`` strings. Anything else raises so the caller drops the row
+    and logs a warning.
+    """
+    if isinstance(value, time):
+        return value
+    if isinstance(value, str):
+        text = value.strip()
+        parts = text.split(":")
+        if len(parts) not in (2, 3):
+            raise ValueError(f"Expected HH:MM or HH:MM:SS, got {value!r}")
+        hour = int(parts[0])
+        minute = int(parts[1])
+        second = int(parts[2]) if len(parts) == 3 else 0
+        return time(hour=hour, minute=minute, second=second)
+    raise TypeError(f"Cannot coerce {value!r} ({type(value).__name__}) to time")

--- a/custom_components/sungrow/strings.json
+++ b/custom_components/sungrow/strings.json
@@ -106,6 +106,7 @@
       "invalid_auth_code": "iSolarCloud rejected the authorization code — it may have already been used or expired. Open the authorization link above to get a fresh code, then paste it here (or paste the full redirect URL).",
       "invalid_extra_measure_points": "Extra measure points must be in the form point_id=code, comma separated",
       "invalid_redirect_uri": "The Redirect URI must end with /api/sungrow_hass/callback. Update it here AND in the iSolarCloud developer portal so both match — otherwise iSolarCloud redirects to the Home Assistant homepage and the authorization code is lost.",
+      "invalid_schedule_window": "Schedule slots need both a start and an end time, and a supported mode. Leave both times blank to disable a slot.",
       "no_plants_selected": "Select at least one plant to integrate.",
       "unknown": "Unexpected error"
     },
@@ -124,12 +125,18 @@
     "step": {
       "init": {
         "title": "Sungrow Options",
-        "description": "Adjust how often Home Assistant polls iSolarCloud. Lower values update more frequently but use more of your API quota. The free plan allows ~2000 calls/hour; the minimum is 10 seconds.",
+        "description": "Adjust how often Home Assistant polls iSolarCloud. Lower values update more frequently but use more of your API quota. The free plan allows ~2000 calls/hour; the minimum is 10 seconds.\n\nOptional scheduled forced-charge / forced-discharge windows repeat daily. Leave both start and end blank to disable a slot; wrap-over-midnight (e.g. 23:30 → 06:00) is allowed.",
         "data": {
           "scan_interval": "Polling interval (seconds)",
           "extra_measure_points": "Extra measure points (point_id=code, comma separated)",
           "enable_device_sensors": "Create per-device sensors (EV chargers, meters, extra batteries)",
-          "modbus_host": "WiNet-S Modbus host (enter to enable hybrid, clear to disable)"
+          "modbus_host": "WiNet-S Modbus host (enter to enable hybrid, clear to disable)",
+          "schedule_1_start": "Schedule 1 — start (HH:MM, local time)",
+          "schedule_1_end": "Schedule 1 — end (HH:MM, local time)",
+          "schedule_1_mode": "Schedule 1 — battery mode",
+          "schedule_2_start": "Schedule 2 — start (HH:MM, local time)",
+          "schedule_2_end": "Schedule 2 — end (HH:MM, local time)",
+          "schedule_2_mode": "Schedule 2 — battery mode"
         }
       },
       "modbus_options": {

--- a/custom_components/sungrow/translations/cy.json
+++ b/custom_components/sungrow/translations/cy.json
@@ -106,6 +106,7 @@
       "invalid_auth_code": "Gwrthododd iSolarCloud y cod awdurdodi — efallai ei fod eisoes wedi'i ddefnyddio neu wedi dod i ben. Agor y ddolen awdurdodi uchod i gael cod newydd, yna gludwch ef yma (neu gludwch yr URL ailgyfeirio llawn).",
       "invalid_extra_measure_points": "Rhaid i bwyntiau mesur ychwanegol fod ar ffurf point_id=code, wedi'u gwahanu gan atalnodau",
       "invalid_redirect_uri": "Rhaid i'r URI ailgyfeirio orffen gyda /api/sungrow_hass/callback. Diweddara ef yma AC yn y porth datblygwyr iSolarCloud fel bod y ddau yn cydweddu — fel arall mae iSolarCloud yn ailgyfeirio i dudalen gartref Home Assistant a chollir y cod awdurdodi.",
+      "invalid_schedule_window": "Mae angen amser cychwyn ac amser gorffen ar slotiau amserlen, ynghyd â modd a gefnogir. Gadewch y ddau amser yn wag i analluogi slot.",
       "no_plants_selected": "Dewiswch o leiaf un orsaf i'w chynnwys.",
       "unknown": "Gwall annisgwyl"
     },
@@ -124,12 +125,18 @@
     "step": {
       "init": {
         "title": "Opsiynau Sungrow",
-        "description": "Addaswch pa mor aml y mae Home Assistant yn holi iSolarCloud. Mae gwerthoedd is yn diweddaru'n amlach ond yn defnyddio mwy o'ch cwota API. Mae'r cynllun am ddim yn caniatáu ~2000 galwad yr awr; y lleiafswm yw 10 eiliad.",
+        "description": "Addaswch pa mor aml y mae Home Assistant yn holi iSolarCloud. Mae gwerthoedd is yn diweddaru'n amlach ond yn defnyddio mwy o'ch cwota API. Mae'r cynllun am ddim yn caniatáu ~2000 galwad yr awr; y lleiafswm yw 10 eiliad.\n\nMae'r ffenestri gorfodol wedi'u hamserlennu (gwefru/dadwefru) yn ailadrodd bob dydd. Gadewch y cychwyn a'r diwedd yn wag i analluogi slot; mae lapio dros hanner nos (e.e. 23:30 → 06:00) yn iawn.",
         "data": {
           "scan_interval": "Cyfwng holi (eiliadau)",
           "extra_measure_points": "Pwyntiau mesur ychwanegol (point_id=code, wedi'u gwahanu gan atalnodau)",
           "enable_device_sensors": "Creu synwyryddion fesul dyfais (gwefrwyr EV, mesuryddion, batris ychwanegol)",
-          "modbus_host": "WiNet-S Modbus host (enter to enable hybrid, clear to disable)"
+          "modbus_host": "WiNet-S Modbus host (enter to enable hybrid, clear to disable)",
+          "schedule_1_start": "Amserlen 1 — cychwyn (HH:MM, amser lleol)",
+          "schedule_1_end": "Amserlen 1 — diwedd (HH:MM, amser lleol)",
+          "schedule_1_mode": "Amserlen 1 — modd batri",
+          "schedule_2_start": "Amserlen 2 — cychwyn (HH:MM, amser lleol)",
+          "schedule_2_end": "Amserlen 2 — diwedd (HH:MM, amser lleol)",
+          "schedule_2_mode": "Amserlen 2 — modd batri"
         }
       },
       "modbus_options": {

--- a/custom_components/sungrow/translations/de.json
+++ b/custom_components/sungrow/translations/de.json
@@ -106,6 +106,7 @@
       "invalid_auth_code": "iSolarCloud hat den Autorisierungscode abgelehnt — er wurde möglicherweise bereits verwendet oder ist abgelaufen. Öffne den Autorisierungslink oben, um einen neuen Code zu erhalten, und füge ihn hier ein (oder füge die vollständige Weiterleitungs-URL ein).",
       "invalid_extra_measure_points": "Zusätzliche Messpunkte müssen im Format point_id=code, durch Kommata getrennt, angegeben werden",
       "invalid_redirect_uri": "Die Redirect-URI muss auf /api/sungrow_hass/callback enden. Passe sie hier UND im iSolarCloud-Entwicklerportal so an, dass beide identisch sind — sonst leitet iSolarCloud auf die Home-Assistant-Startseite um und der Autorisierungscode geht verloren.",
+      "invalid_schedule_window": "Zeitplan-Zeilen benötigen sowohl Start- als auch Endzeit und einen unterstützten Modus. Lassen Sie beide Zeiten leer, um eine Zeile zu deaktivieren.",
       "no_plants_selected": "Wählen Sie mindestens eine Anlage aus.",
       "unknown": "Unerwarteter Fehler"
     },
@@ -124,11 +125,17 @@
     "step": {
       "init": {
         "title": "Sungrow-Optionen",
-        "description": "Legen Sie fest, wie oft Home Assistant iSolarCloud abfragt. Niedrigere Werte aktualisieren häufiger, verbrauchen aber mehr Ihres API-Kontingents. Der kostenlose Tarif erlaubt ~2000 Aufrufe/Stunde; das Minimum beträgt 10 Sekunden.",
+        "description": "Legen Sie fest, wie oft Home Assistant iSolarCloud abfragt. Niedrigere Werte aktualisieren häufiger, verbrauchen aber mehr Ihres API-Kontingents. Der kostenlose Tarif erlaubt ~2000 Aufrufe/Stunde; das Minimum beträgt 10 Sekunden.\n\nOptionale geplante Zwangslade-/Zwangsentlade-Fenster wiederholen sich täglich. Lassen Sie Start und Ende leer, um einen Zeitraum zu deaktivieren; ein Umschlag über Mitternacht (z. B. 23:30 → 06:00) ist erlaubt.",
         "data": {
           "scan_interval": "Abfrageintervall (Sekunden)",
           "extra_measure_points": "Zusätzliche Messpunkte (point_id=code, durch Kommata getrennt)",
           "enable_device_sensors": "Sensoren pro Gerät erstellen (EV-Ladegeräte, Zähler, zusätzliche Batterien)",
+          "schedule_1_start": "Zeitplan 1 — Start (HH:MM, lokale Zeit)",
+          "schedule_1_end": "Zeitplan 1 — Ende (HH:MM, lokale Zeit)",
+          "schedule_1_mode": "Zeitplan 1 — Batteriemodus",
+          "schedule_2_start": "Zeitplan 2 — Start (HH:MM, lokale Zeit)",
+          "schedule_2_end": "Zeitplan 2 — Ende (HH:MM, lokale Zeit)",
+          "schedule_2_mode": "Zeitplan 2 — Batteriemodus",
           "modbus_host": "WiNet-S Modbus host (enter to enable hybrid, clear to disable)"
         }
       },

--- a/custom_components/sungrow/translations/en.json
+++ b/custom_components/sungrow/translations/en.json
@@ -106,6 +106,7 @@
       "invalid_auth_code": "iSolarCloud rejected the authorization code — it may have already been used or expired. Open the authorization link above to get a fresh code, then paste it here (or paste the full redirect URL).",
       "invalid_extra_measure_points": "Extra measure points must be in the form point_id=code, comma separated",
       "invalid_redirect_uri": "The Redirect URI must end with /api/sungrow_hass/callback. Update it here AND in the iSolarCloud developer portal so both match — otherwise iSolarCloud redirects to the Home Assistant homepage and the authorization code is lost.",
+      "invalid_schedule_window": "Schedule slots need both a start and an end time, and a supported mode. Leave both times blank to disable a slot.",
       "no_plants_selected": "Select at least one plant to integrate.",
       "unknown": "Unexpected error"
     },
@@ -124,12 +125,18 @@
     "step": {
       "init": {
         "title": "Sungrow Options",
-        "description": "Adjust how often Home Assistant polls iSolarCloud. Lower values update more frequently but use more of your API quota. The free plan allows ~2000 calls/hour; the minimum is 10 seconds.",
+        "description": "Adjust how often Home Assistant polls iSolarCloud. Lower values update more frequently but use more of your API quota. The free plan allows ~2000 calls/hour; the minimum is 10 seconds.\n\nOptional scheduled forced-charge / forced-discharge windows repeat daily. Leave both start and end blank to disable a slot; wrap-over-midnight (e.g. 23:30 → 06:00) is allowed.",
         "data": {
           "scan_interval": "Polling interval (seconds)",
           "extra_measure_points": "Extra measure points (point_id=code, comma separated)",
           "enable_device_sensors": "Create per-device sensors (EV chargers, meters, extra batteries)",
-          "modbus_host": "WiNet-S Modbus host (enter to enable hybrid, clear to disable)"
+          "modbus_host": "WiNet-S Modbus host (enter to enable hybrid, clear to disable)",
+          "schedule_1_start": "Schedule 1 — start (HH:MM, local time)",
+          "schedule_1_end": "Schedule 1 — end (HH:MM, local time)",
+          "schedule_1_mode": "Schedule 1 — battery mode",
+          "schedule_2_start": "Schedule 2 — start (HH:MM, local time)",
+          "schedule_2_end": "Schedule 2 — end (HH:MM, local time)",
+          "schedule_2_mode": "Schedule 2 — battery mode"
         }
       },
       "modbus_options": {

--- a/custom_components/sungrow/translations/es.json
+++ b/custom_components/sungrow/translations/es.json
@@ -106,6 +106,7 @@
       "invalid_auth_code": "iSolarCloud rechazó el código de autorización — puede que ya se haya usado o haya caducado. Abre el enlace de autorización de arriba para obtener un código nuevo y pégalo aquí (o pega la URL completa de redirección).",
       "invalid_extra_measure_points": "Los puntos de medición adicionales deben tener el formato point_id=code, separados por comas",
       "invalid_redirect_uri": "La URI de redirección debe terminar en /api/sungrow_hass/callback. Actualízala aquí Y en el portal de desarrollador de iSolarCloud para que coincidan — de lo contrario, iSolarCloud redirige a la página de inicio de Home Assistant y se pierde el código de autorización.",
+      "invalid_schedule_window": "Las franjas de programación necesitan hora de inicio y de fin, y un modo admitido. Deje ambos tiempos en blanco para desactivar una franja.",
       "no_plants_selected": "Selecciona al menos una planta para integrar.",
       "unknown": "Error inesperado"
     },
@@ -124,12 +125,18 @@
     "step": {
       "init": {
         "title": "Opciones de Sungrow",
-        "description": "Ajuste la frecuencia con la que Home Assistant consulta iSolarCloud. Los valores más bajos actualizan con más frecuencia, pero consumen más de su cuota de la API. El plan gratuito permite unas 2000 llamadas/hora; el mínimo es de 10 segundos.",
+        "description": "Ajuste la frecuencia con la que Home Assistant consulta iSolarCloud. Los valores más bajos actualizan con más frecuencia, pero consumen más de su cuota de la API. El plan gratuito permite unas 2000 llamadas/hora; el mínimo es de 10 segundos.\n\nLas ventanas opcionales de carga/descarga forzada programadas se repiten a diario. Deje el inicio y el fin en blanco para desactivar una franja; se admite el cambio de día (p. ej. 23:30 → 06:00).",
         "data": {
           "scan_interval": "Intervalo de sondeo (segundos)",
           "extra_measure_points": "Puntos de medición adicionales (point_id=code, separados por comas)",
           "enable_device_sensors": "Crear sensores por dispositivo (cargadores de VE, contadores, baterías adicionales)",
-          "modbus_host": "WiNet-S Modbus host (enter to enable hybrid, clear to disable)"
+          "modbus_host": "WiNet-S Modbus host (enter to enable hybrid, clear to disable)",
+          "schedule_1_start": "Programación 1 — inicio (HH:MM, hora local)",
+          "schedule_1_end": "Programación 1 — fin (HH:MM, hora local)",
+          "schedule_1_mode": "Programación 1 — modo de batería",
+          "schedule_2_start": "Programación 2 — inicio (HH:MM, hora local)",
+          "schedule_2_end": "Programación 2 — fin (HH:MM, hora local)",
+          "schedule_2_mode": "Programación 2 — modo de batería"
         }
       },
       "modbus_options": {

--- a/custom_components/sungrow/translations/fr.json
+++ b/custom_components/sungrow/translations/fr.json
@@ -106,6 +106,7 @@
       "invalid_auth_code": "iSolarCloud a rejeté le code d'autorisation — il a peut-être déjà été utilisé ou expiré. Ouvrez le lien d'autorisation ci-dessus pour obtenir un nouveau code, puis collez-le ici (ou collez l'URL de redirection complète).",
       "invalid_extra_measure_points": "Les points de mesure supplémentaires doivent être au format point_id=code, séparés par des virgules",
       "invalid_redirect_uri": "L'URI de redirection doit se terminer par /api/sungrow_hass/callback. Mettez-la à jour ici ET dans le portail développeur iSolarCloud pour qu'elles correspondent — sinon iSolarCloud redirige vers la page d'accueil Home Assistant et le code d'autorisation est perdu.",
+      "invalid_schedule_window": "Les créneaux de programmation nécessitent une heure de début et de fin, ainsi qu'un mode pris en charge. Laissez les deux heures vides pour désactiver un créneau.",
       "no_plants_selected": "Sélectionnez au moins une installation à intégrer.",
       "unknown": "Erreur inattendue"
     },
@@ -124,12 +125,18 @@
     "step": {
       "init": {
         "title": "Options Sungrow",
-        "description": "Ajustez la fréquence à laquelle Home Assistant interroge iSolarCloud. Des valeurs plus basses actualisent plus souvent mais consomment davantage de votre quota d'API. Le forfait gratuit autorise environ 2000 appels/heure ; le minimum est de 10 secondes.",
+        "description": "Ajustez la fréquence à laquelle Home Assistant interroge iSolarCloud. Des valeurs plus basses actualisent plus souvent mais consomment davantage de votre quota d'API. Le forfait gratuit autorise environ 2000 appels/heure ; le minimum est de 10 secondes.\n\nLes fenêtres optionnelles de charge/décharge forcée programmées se répètent quotidiennement. Laissez le début et la fin vides pour désactiver un créneau ; le passage minuit (p. ex. 23:30 → 06:00) est autorisé.",
         "data": {
           "scan_interval": "Intervalle d'interrogation (secondes)",
           "extra_measure_points": "Points de mesure supplémentaires (point_id=code, séparés par des virgules)",
           "enable_device_sensors": "Créer des capteurs par appareil (bornes de recharge EV, compteurs, batteries supplémentaires)",
-          "modbus_host": "WiNet-S Modbus host (enter to enable hybrid, clear to disable)"
+          "modbus_host": "WiNet-S Modbus host (enter to enable hybrid, clear to disable)",
+          "schedule_1_start": "Programmation 1 — début (HH:MM, heure locale)",
+          "schedule_1_end": "Programmation 1 — fin (HH:MM, heure locale)",
+          "schedule_1_mode": "Programmation 1 — mode batterie",
+          "schedule_2_start": "Programmation 2 — début (HH:MM, heure locale)",
+          "schedule_2_end": "Programmation 2 — fin (HH:MM, heure locale)",
+          "schedule_2_mode": "Programmation 2 — mode batterie"
         }
       },
       "modbus_options": {

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -788,6 +788,82 @@ async def test_options_flow_parses_extra_measure_points(hass: HomeAssistant, moc
     }
 
 
+async def test_options_flow_saves_schedule_windows(hass: HomeAssistant, mock_setup_auth, mock_plants_service):
+    """Filled schedule slots are normalised into ``CONF_SCHEDULE_WINDOWS`` (#359)."""
+    from custom_components.sungrow.const import CONF_SCHEDULE_WINDOWS
+
+    entry = MockConfigEntry(domain=DOMAIN, data=MOCK_CONFIG_DATA.copy(), unique_id="test_app_id")
+    entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+
+    result = await hass.config_entries.options.async_init(entry.entry_id)
+    result2 = await hass.config_entries.options.async_configure(
+        result["flow_id"],
+        user_input={
+            CONF_SCAN_INTERVAL: 30,
+            "schedule_1_start": "01:00:00",
+            "schedule_1_end": "05:00:00",
+            "schedule_1_mode": "force_charge",
+            # Slot 2 left blank → disabled.
+        },
+    )
+    await hass.async_block_till_done()
+
+    assert result2["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
+    # Per-slot fields are stripped; only the normalised list is stored.
+    for slot in (1, 2):
+        assert f"schedule_{slot}_start" not in entry.options
+    assert entry.options[CONF_SCHEDULE_WINDOWS] == [{"start": "01:00:00", "end": "05:00:00", "mode": "force_charge"}]
+
+
+async def test_options_flow_rejects_half_populated_schedule_slot(
+    hass: HomeAssistant, mock_setup_auth, mock_plants_service
+):
+    """Slot 1 has a start but no end → surfaces ``invalid_schedule_window`` (#359).
+
+    The HA frontend omits an unfilled TimeSelector key from the payload rather than
+    sending an empty string, so we simulate that by leaving ``schedule_1_end`` out
+    entirely.
+    """
+    entry = MockConfigEntry(domain=DOMAIN, data=MOCK_CONFIG_DATA.copy(), unique_id="test_app_id")
+    entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+
+    result = await hass.config_entries.options.async_init(entry.entry_id)
+    result2 = await hass.config_entries.options.async_configure(
+        result["flow_id"],
+        user_input={
+            CONF_SCAN_INTERVAL: 30,
+            "schedule_1_start": "01:00:00",
+            # schedule_1_end deliberately omitted — half-populated.
+            "schedule_1_mode": "force_charge",
+        },
+    )
+
+    assert result2["type"] == data_entry_flow.FlowResultType.FORM
+    assert result2["step_id"] == "init"
+    assert result2["errors"]["base"] == "invalid_schedule_window"
+
+
+async def test_options_flow_empty_schedule_stores_empty_list(hass: HomeAssistant, mock_setup_auth, mock_plants_service):
+    """No schedule slots filled → an empty list is stored, not the raw fields (#359)."""
+    from custom_components.sungrow.const import CONF_SCHEDULE_WINDOWS
+
+    entry = MockConfigEntry(domain=DOMAIN, data=MOCK_CONFIG_DATA.copy(), unique_id="test_app_id")
+    entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+
+    result = await hass.config_entries.options.async_init(entry.entry_id)
+    result2 = await hass.config_entries.options.async_configure(result["flow_id"], user_input={CONF_SCAN_INTERVAL: 30})
+    await hass.async_block_till_done()
+
+    assert result2["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
+    assert entry.options[CONF_SCHEDULE_WINDOWS] == []
+
+
 async def test_options_flow_cloud_has_no_modbus_host(hass: HomeAssistant, mock_setup_auth, mock_plants_service):
     """Cloud options no longer expose a modbus_host field — #348 retired the cloud_modbus transport."""
     entry = MockConfigEntry(domain=DOMAIN, data=MOCK_CONFIG_DATA.copy(), unique_id="test_app_id")

--- a/tests/test_schedule.py
+++ b/tests/test_schedule.py
@@ -1,0 +1,259 @@
+"""Tests for the daily-repeating forced-charge / forced-discharge scheduler (#359)."""
+
+from __future__ import annotations
+
+from datetime import time
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from homeassistant.core import HomeAssistant
+
+from custom_components.sungrow.const import CONF_SCHEDULE_WINDOWS, DOMAIN
+from custom_components.sungrow.schedule import ScheduleWindow, SungrowScheduler
+
+# ---------------------------------------------------------------------------
+# ScheduleWindow — invariants + membership
+# ---------------------------------------------------------------------------
+
+
+def test_schedule_window_rejects_unknown_mode():
+    """Unknown mode keys are refused at construction — the engine only drives
+    ``force_charge`` / ``force_discharge``; ``self_consumption`` is used implicitly
+    after a window ends but is not a valid window mode."""
+    with pytest.raises(ValueError, match="Invalid schedule mode"):
+        ScheduleWindow(start=time(1), end=time(5), mode="stop")
+    with pytest.raises(ValueError, match="Invalid schedule mode"):
+        ScheduleWindow(start=time(1), end=time(5), mode="self_consumption")
+
+
+def test_schedule_window_rejects_zero_length():
+    """A start == end window has zero length; setting it would be a user error."""
+    with pytest.raises(ValueError, match="zero-length"):
+        ScheduleWindow(start=time(1), end=time(1), mode="force_charge")
+
+
+@pytest.mark.parametrize(
+    ("now", "expected"),
+    [
+        (time(0, 59), False),  # before start
+        (time(1, 0), True),  # exactly start
+        (time(3, 0), True),  # inside
+        (time(4, 59), True),  # last minute inside
+        (time(5, 0), False),  # exactly end (exclusive)
+        (time(23, 59), False),  # after end
+    ],
+)
+def test_schedule_window_contains_same_day(now, expected):
+    """A ``start < end`` window covers ``[start, end)`` on the same day."""
+    window = ScheduleWindow(start=time(1), end=time(5), mode="force_charge")
+    assert window.contains(now) is expected
+
+
+@pytest.mark.parametrize(
+    ("now", "expected"),
+    [
+        (time(22, 59), False),  # before start
+        (time(23, 0), True),  # exactly start
+        (time(23, 59), True),  # inside, before midnight
+        (time(0, 0), True),  # inside, after midnight
+        (time(5, 59), True),  # inside, before end
+        (time(6, 0), False),  # exactly end (exclusive)
+        (time(12, 0), False),  # daytime — well outside
+    ],
+)
+def test_schedule_window_contains_wrap_over_midnight(now, expected):
+    """A ``start >= end`` window wraps over midnight: ``[start, 24:00) ∪ [00:00, end)``."""
+    window = ScheduleWindow(start=time(23), end=time(6), mode="force_charge")
+    assert window.contains(now) is expected
+
+
+# ---------------------------------------------------------------------------
+# SungrowScheduler.active_window — overlap resolution
+# ---------------------------------------------------------------------------
+
+
+def _entry_with_windows(hass: HomeAssistant, windows: list[dict]) -> MagicMock:
+    """Build a MagicMock config entry with the given schedule windows."""
+    entry = MagicMock()
+    entry.title = "Test Entry"
+    entry.entry_id = "test_entry_id"
+    entry.options = {CONF_SCHEDULE_WINDOWS: windows}
+    return entry
+
+
+def test_active_window_returns_none_when_no_windows(hass: HomeAssistant):
+    """No configured windows → nothing to activate."""
+    scheduler = SungrowScheduler.from_entry(hass, _entry_with_windows(hass, []))
+    assert scheduler.active_window(time(3, 0)) is None
+
+
+def test_active_window_returns_none_when_outside_every_window(hass: HomeAssistant):
+    """A time outside every configured window resolves to ``None``."""
+    scheduler = SungrowScheduler.from_entry(
+        hass,
+        _entry_with_windows(
+            hass,
+            [
+                {"start": "01:00", "end": "05:00", "mode": "force_charge"},
+                {"start": "17:00", "end": "20:00", "mode": "force_discharge"},
+            ],
+        ),
+    )
+    assert scheduler.active_window(time(12, 0)) is None
+
+
+def test_active_window_picks_latest_start_on_overlap(hass: HomeAssistant):
+    """Overlapping windows: the one with the later start wins during the overlap.
+
+    A short "force_discharge" window nested inside a longer "force_charge" one
+    should override the enclosing charge during its span — otherwise a user
+    couldn't cut a discharge slot into a broader charge session.
+    """
+    scheduler = SungrowScheduler.from_entry(
+        hass,
+        _entry_with_windows(
+            hass,
+            [
+                {"start": "01:00", "end": "06:00", "mode": "force_charge"},
+                {"start": "03:00", "end": "04:00", "mode": "force_discharge"},
+            ],
+        ),
+    )
+    # Inside overlap → shorter (later-started) window wins.
+    active = scheduler.active_window(time(3, 30))
+    assert active is not None
+    assert active.mode == "force_discharge"
+    # Outside the shorter window but still inside the longer one → longer wins.
+    active = scheduler.active_window(time(5, 0))
+    assert active is not None
+    assert active.mode == "force_charge"
+
+
+# ---------------------------------------------------------------------------
+# SungrowScheduler.from_entry — malformed row tolerance
+# ---------------------------------------------------------------------------
+
+
+def test_from_entry_drops_malformed_rows_and_keeps_valid_ones(hass: HomeAssistant, caplog):
+    """One typo shouldn't take the whole entry offline — bad rows are logged and
+    skipped, valid ones proceed."""
+    entry = _entry_with_windows(
+        hass,
+        [
+            {"start": "01:00", "end": "05:00", "mode": "force_charge"},  # valid
+            {"start": "not-a-time", "end": "10:00", "mode": "force_charge"},  # bad time
+            {"start": "12:00", "end": "12:00", "mode": "force_charge"},  # zero length
+            {"start": "20:00", "end": "22:00", "mode": "invalid_mode"},  # bad mode
+            "not-a-dict",  # wrong shape entirely
+            {"start": "23:00", "end": "06:00", "mode": "force_discharge"},  # valid wrap
+        ],
+    )
+    scheduler = SungrowScheduler.from_entry(hass, entry)
+    assert len(scheduler.windows) == 2
+    assert scheduler.windows[0].mode == "force_charge"
+    assert scheduler.windows[1].mode == "force_discharge"
+
+
+# ---------------------------------------------------------------------------
+# SungrowScheduler lifecycle
+# ---------------------------------------------------------------------------
+
+
+async def test_scheduler_start_stop_is_idempotent(hass: HomeAssistant):
+    """``async_start`` twice replaces the callbacks cleanly; ``async_stop`` twice is safe."""
+    entry = _entry_with_windows(hass, [{"start": "01:00", "end": "05:00", "mode": "force_charge"}])
+    scheduler = SungrowScheduler.from_entry(hass, entry)
+
+    with patch("custom_components.sungrow.schedule.async_track_time_change") as tracker:
+        tracker.return_value = MagicMock()  # cancel callable
+        await scheduler.async_start()
+        # 2 callbacks per window: start + end.
+        assert tracker.call_count == 2
+        await scheduler.async_start()  # idempotent — replaces previous armings
+        assert tracker.call_count == 4
+
+    scheduler.async_stop()
+    scheduler.async_stop()  # safe to call twice
+
+
+async def test_scheduler_start_applies_active_window_on_setup(hass: HomeAssistant):
+    """HA restart mid-window: setup issues the matching mode up front so the
+    inverter doesn't drift outside the intended mode while the integration was down."""
+    entry = _entry_with_windows(hass, [{"start": "01:00", "end": "05:00", "mode": "force_charge"}])
+    scheduler = SungrowScheduler.from_entry(hass, entry)
+
+    fake_select = MagicMock()
+    fake_select.async_select_option = AsyncMock()
+    fake_select.hass = hass
+    fake_select.platform = None  # skip async_write_ha_state
+    fake_select.registry_entry = None  # skip cross-entry filtering — this is our select
+
+    hass.data.setdefault(DOMAIN, {})["battery_mode_selects"] = {"select.plant_battery": fake_select}
+
+    with (
+        patch("custom_components.sungrow.schedule.async_track_time_change") as tracker,
+        patch("homeassistant.util.dt.now") as fake_now,
+    ):
+        tracker.return_value = MagicMock()
+        # Simulate "now" being inside the 01:00-05:00 window.
+        fake_now.return_value.time.return_value = time(3, 0)
+        await scheduler.async_start()
+
+    # The select got its mode set to Force charge on setup.
+    fake_select.async_select_option.assert_awaited_with("Force charge")
+    scheduler.async_stop()
+
+
+async def test_scheduler_no_active_window_on_setup_does_not_touch_selects(hass: HomeAssistant):
+    """Outside every window at setup → no select is written to — the user's
+    manual mode is preserved."""
+    entry = _entry_with_windows(hass, [{"start": "01:00", "end": "05:00", "mode": "force_charge"}])
+    scheduler = SungrowScheduler.from_entry(hass, entry)
+
+    fake_select = MagicMock()
+    fake_select.async_select_option = AsyncMock()
+    fake_select.hass = hass
+    fake_select.platform = None
+    fake_select.registry_entry = None
+
+    hass.data.setdefault(DOMAIN, {})["battery_mode_selects"] = {"select.plant_battery": fake_select}
+
+    with (
+        patch("custom_components.sungrow.schedule.async_track_time_change") as tracker,
+        patch("homeassistant.util.dt.now") as fake_now,
+    ):
+        tracker.return_value = MagicMock()
+        # "Now" is well outside every window.
+        fake_now.return_value.time.return_value = time(12, 0)
+        await scheduler.async_start()
+
+    fake_select.async_select_option.assert_not_awaited()
+    scheduler.async_stop()
+
+
+async def test_scheduler_skips_selects_owned_by_other_entries(hass: HomeAssistant):
+    """A scheduler must only touch battery-mode selects owned by its own entry —
+    another user's plant on the same HA instance shouldn't get scheduled by us."""
+    entry = _entry_with_windows(hass, [{"start": "01:00", "end": "05:00", "mode": "force_charge"}])
+    entry.entry_id = "entry_a"
+    scheduler = SungrowScheduler.from_entry(hass, entry)
+
+    # A select owned by *another* entry — its ``registry_entry.config_entry_id`` is not ours.
+    other_select = MagicMock()
+    other_select.async_select_option = AsyncMock()
+    other_select.hass = hass
+    other_select.platform = None
+    other_select.registry_entry.config_entry_id = "entry_b"
+
+    hass.data.setdefault(DOMAIN, {})["battery_mode_selects"] = {"select.other_plant": other_select}
+
+    with (
+        patch("custom_components.sungrow.schedule.async_track_time_change") as tracker,
+        patch("homeassistant.util.dt.now") as fake_now,
+    ):
+        tracker.return_value = MagicMock()
+        fake_now.return_value.time.return_value = time(3, 0)
+        await scheduler.async_start()
+
+    other_select.async_select_option.assert_not_awaited()
+    scheduler.async_stop()


### PR DESCRIPTION
Closes #359.

Tariff-driven charging (cheap overnight → use battery on-peak) is the top driver for the dispatch controls. Before this change every user had to build their own HA automation calling `sungrow.set_battery_mode` at set times, with correct handling for duration-based auto-revert, HA restarts mid-window, and automation-vs-UI conflicts. This lands a first-class UI-level schedule that covers the common case out of the box.

## Layout

- **`schedule.py`** (new) — `ScheduleWindow` dataclass + `SungrowScheduler` engine. Reads windows from `entry.options[CONF_SCHEDULE_WINDOWS]`, applies the currently-active window's mode on setup (restart safety), arms one `async_track_time_change` per boundary for daily-repeating transitions.
  - **Overlap policy**: latest-starting window wins during its span. A short `force_discharge` slot nested inside a longer `force_charge` correctly overrides the outer charge during its window.
  - **Wrap-over-midnight**: `start >= end` (e.g. `23:00 → 06:00`) handled explicitly.
  - **Cross-entry safety**: only touches battery-mode selects whose `registry_entry.config_entry_id` matches this entry's, so a schedule on one entry can't sneakily drive another entry's plants.
- **`const.py`** — adds `CONF_SCHEDULE_WINDOWS`. Missing / empty means "no schedule" so existing entries need no migration.
- **`_config_flow/options.py`** — two fixed schedule slots in the cloud options form. Each slot: start / end (`TimeSelector`), mode (`SelectSelector`: force_charge / force_discharge). Leaving both times blank disables a slot. Half-populated slots surface `invalid_schedule_window`.
- **`__init__.py`** — instantiates the scheduler after `async_forward_entry_setups` on both cloud paths (so battery-mode selects are already registered); `SungrowData.scheduler` field carries the instance; unload cancels its callbacks. Gated on any coordinator having `has_battery=True` — PV-only entries never wire a scheduler.
- **`strings.json` + every locale** (`cy` / `de` / `en` / `es` / `fr`) — schedule field labels + `invalid_schedule_window` error. Translation-parity test still passes.

## Not in scope

Deliberately kept v1 narrow — daily-repeating only, per the issue's non-goals:

- No weekly patterns / TOU tariff plans. That belongs on the Energy dashboard or a separate feature.
- No target-SOC field on the schedule — the existing `forced_charging_target_soc_*` numbers already do that job when a forced-charge window is active.
- No diagnostic `schedule_state` sensor. Engine logs the transitions at `info` level; can follow up if users want a visible state entity.

## Also in this commit

`chore(pre-commit)`: bumps `.pre-commit-config.yaml` to add strict `mypy` and `pytest --no-cov -q` as local hooks. Split into pre-commit (fast: ruff + mypy) and pre-push (full pytest) stages so a commit-heavy local workflow isn't slowed down by re-running tests on every fixup. Pre-push already caught a stray blank line in the new test file on this PR's own commit.

## Tests

**`tests/test_schedule.py`** (23 tests):
- `ScheduleWindow` invariants — unknown mode / zero-length rejected at construction.
- `contains()` parametrised for same-day and wrap-over-midnight — every boundary case (before, at start, inside, last minute, at end, after).
- `active_window()` overlap resolution — latest-starting window wins.
- `from_entry` — drops individual malformed rows rather than failing the whole entry setup (typo in one window shouldn't take the integration offline).
- Lifecycle — `async_start` idempotent, arms 2 callbacks per window, applies active mode on setup, no-op when no window active, doesn't touch selects owned by other entries.

**`tests/test_config_flow.py`** (3 new tests):
- Filled slots normalised into a `CONF_SCHEDULE_WINDOWS` list on save; per-slot fields stripped.
- Half-populated slot → `invalid_schedule_window` error surfaced.
- No slots filled → empty list stored, not the raw fields.

## Verification

- `ruff check custom_components/ tests/` — clean
- `ruff format --check custom_components/ tests/` — clean
- `mypy` (strict) — clean, 41 source files
- `pytest tests/` — 864 passed, 4 deselected (live)