### PR TITLE
fix(tests): stop leaking coroutines in reachability property test

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,14 @@ markers = [
     "live: marks tests that require live API credentials (deselect with '-m \"not live\"')",
     "real_refresh: opt a coordinator test out of the auto-stubbed periodic-refresh fixture",
 ]
+# Fail the suite on leaked coroutines. AsyncMock returns a coroutine every time
+# it's called; if it's passed into another async-mocked callable that ignores
+# its argument, the coroutine is never awaited and only shows up as a noisy
+# RuntimeWarning at GC time (see #375). Promoting that specific warning to an
+# error keeps future regressions from hiding in the log.
+filterwarnings = [
+    "error:coroutine .* was never awaited:RuntimeWarning",
+]
 # ``--import-mode=importlib`` skips pytest's legacy ``sys.path`` prepend hack, but
 # that hack was silently making ``custom_components/`` importable. Restore it
 # explicitly via ``pythonpath`` so ``from custom_components.sungrow.const import ...``

--- a/tests/test_reachability_properties.py
+++ b/tests/test_reachability_properties.py
@@ -26,15 +26,33 @@ async def test_reachability_uses_correct_port_and_timeout(host: str):
     mock_writer.close = lambda: None
     mock_writer.wait_closed = AsyncMock()
 
-    with patch("custom_components.sungrow.helpers.asyncio.open_connection", new_callable=AsyncMock) as mock_conn:
-        mock_conn.return_value = (AsyncMock(), mock_writer)
+    captured: dict[str, object] = {}
 
-        with patch("custom_components.sungrow.helpers.asyncio.wait_for", new_callable=AsyncMock) as mock_wait:
-            mock_wait.return_value = (AsyncMock(), mock_writer)
-            await async_test_modbus_host(host)
-            mock_wait.assert_called_once()
-            args, kwargs = mock_wait.call_args
-            assert kwargs.get("timeout") == 5.0 or (len(args) >= 2 and args[1] == 5.0)
+    async def _spy_wait_for(coro, *, timeout):
+        # Actually consume the coroutine returned by open_connection so it
+        # doesn't leak as an unawaited coroutine (RuntimeWarning noise).
+        captured["timeout"] = timeout
+        return await coro
+
+    with (
+        patch(
+            "custom_components.sungrow.helpers.asyncio.open_connection",
+            new_callable=AsyncMock,
+            return_value=(AsyncMock(), mock_writer),
+        ) as mock_conn,
+        patch(
+            "custom_components.sungrow.helpers.asyncio.wait_for",
+            side_effect=_spy_wait_for,
+        ) as mock_wait,
+    ):
+        await async_test_modbus_host(host)
+
+    mock_wait.assert_called_once()
+    assert captured["timeout"] == 5.0
+    # open_connection was called with (host, port=502) via wait_for's spy.
+    mock_conn.assert_awaited_once()
+    conn_args, _ = mock_conn.call_args
+    assert conn_args == (host, 502)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #375.

## What

`tests/test_reachability_properties.py::test_reachability_uses_correct_port_and_timeout` was patching **both** `asyncio.open_connection` and `asyncio.wait_for` as `AsyncMock`s. Inside the helper:

```python
reader, writer = await asyncio.wait_for(
    asyncio.open_connection(host, port),
    timeout=timeout,
)
```

`open_connection(host, port)` returns a coroutine (because it's an `AsyncMock`), that coroutine is handed to `wait_for`, and the patched `wait_for` ignores its argument and short-circuits to `return_value`. The coroutine is never awaited. With Hypothesis running ~100 examples per run, that produced 20+ `RuntimeWarning: coroutine 'AsyncMockMixin._execute_mock_call' was never awaited` messages per CI job.

## How

- Replace the `wait_for` `AsyncMock` with a spy `async` function that actually awaits the passed coroutine and captures the `timeout` kwarg — so the assertion is preserved and the `open_connection` coroutine is consumed.
- Add `filterwarnings = ["error:coroutine .* was never awaited:RuntimeWarning"]` under `[tool.pytest.ini_options]` so future regressions fail the suite instead of hiding in the log.

## Verification

- `pytest tests/test_reachability_properties.py` — both properties pass, no warnings.
- `pytest tests/` — 864 passed, 4 deselected, 0 warnings.
- `ruff check` + `ruff format --check` — clean.
- `mypy` (strict) — clean.
- Pre-commit ran on commit and push, all hooks passed.
