### PR TITLE
feat(config_flow): clarify transport-mode selector labels

### DIFF
--- a/custom_components/sungrow/config_flow.py
+++ b/custom_components/sungrow/config_flow.py
@@ -112,9 +112,15 @@ class SungrowConfigFlow(
         from homeassistant.helpers.selector import SelectOptionDict, SelectSelector, SelectSelectorConfig
 
         transport_options = [
-            SelectOptionDict(value=TRANSPORT_CLOUD_ONLY, label="Cloud Only"),
-            SelectOptionDict(value=TRANSPORT_CLOUD_USER, label="Cloud (user account, unofficial)"),
-            SelectOptionDict(value=TRANSPORT_MODBUS_ONLY, label="Modbus Only"),
+            SelectOptionDict(
+                value=TRANSPORT_CLOUD_ONLY,
+                label="Cloud (Developer Account via Official OpenAPI - Cloud Polling)",
+            ),
+            SelectOptionDict(
+                value=TRANSPORT_CLOUD_USER,
+                label="Cloud (User Account via Unofficial API - Cloud Polling)",
+            ),
+            SelectOptionDict(value=TRANSPORT_MODBUS_ONLY, label="Modbus (Local Polling)"),
         ]
         return self.async_show_form(
             step_id="user",

--- a/custom_components/sungrow/strings.json
+++ b/custom_components/sungrow/strings.json
@@ -312,5 +312,14 @@
         }
       }
     }
+  },
+  "selector": {
+    "transport": {
+      "options": {
+        "cloud_only": "Cloud (Developer Account via Official OpenAPI - Cloud Polling)",
+        "cloud_user": "Cloud (User Account via Unofficial API - Cloud Polling)",
+        "modbus_only": "Modbus (Local Polling)"
+      }
+    }
   }
 }

--- a/custom_components/sungrow/translations/cy.json
+++ b/custom_components/sungrow/translations/cy.json
@@ -2,10 +2,10 @@
   "config": {
     "step": {
       "user": {
-        "title": "Cysylltu ag iSolarCloud",
-        "description": "Rhowch eich manylion mynediad API iSolarCloud. Gallwch ddod o hyd iddynt yma: [iSolarCloud]({url})\n\nAr ôl i chi gyflwyno, caiff yr hyb ei greu a bydd Home Assistant yn gofyn i chi ei awdurdodi yn eich porwr.",
+        "title": "Dewiswch Fodd Cludiant",
+        "description": "Dewiswch sut mae'r integreiddiad yn cysylltu â'ch gwrthdröydd Sungrow.",
         "data": {
-          "transport": "Transport mode"
+          "transport": "Modd cludiant"
         }
       },
       "cloud_credentials": {
@@ -310,6 +310,15 @@
           "name": "Integreiddio",
           "description": "Cofnod OAuth Sungrow i'w adnewyddu. Gadewch yn wag i adnewyddu pob cofnod cwmwl wedi'i lwytho."
         }
+      }
+    }
+  },
+  "selector": {
+    "transport": {
+      "options": {
+        "cloud_only": "Cloud (Developer Account via Official OpenAPI - Cloud Polling)",
+        "cloud_user": "Cloud (User Account via Unofficial API - Cloud Polling)",
+        "modbus_only": "Modbus (Local Polling)"
       }
     }
   }

--- a/custom_components/sungrow/translations/cy.json
+++ b/custom_components/sungrow/translations/cy.json
@@ -316,9 +316,9 @@
   "selector": {
     "transport": {
       "options": {
-        "cloud_only": "Cloud (Developer Account via Official OpenAPI - Cloud Polling)",
-        "cloud_user": "Cloud (User Account via Unofficial API - Cloud Polling)",
-        "modbus_only": "Modbus (Local Polling)"
+        "cloud_only": "Cwmwl (Cyfrif Datblygwr drwy OpenAPI Swyddogol - Holi'r Cwmwl)",
+        "cloud_user": "Cwmwl (Cyfrif Defnyddiwr drwy API Answyddogol - Holi'r Cwmwl)",
+        "modbus_only": "Modbus (Holi Lleol)"
       }
     }
   }

--- a/custom_components/sungrow/translations/de.json
+++ b/custom_components/sungrow/translations/de.json
@@ -2,10 +2,10 @@
   "config": {
     "step": {
       "user": {
-        "title": "Mit iSolarCloud verbinden",
-        "description": "Geben Sie Ihre iSolarCloud-API-Zugangsdaten ein. Sie finden diese hier: [iSolarCloud]({url})\n\nNach dem Absenden wird der Hub erstellt und Home Assistant fordert Sie auf, ihn in Ihrem Browser zu autorisieren.",
+        "title": "Transportmodus wählen",
+        "description": "Wählen Sie, wie die Integration eine Verbindung zu Ihrem Sungrow-Wechselrichter herstellt.",
         "data": {
-          "transport": "Transport mode"
+          "transport": "Transportmodus"
         }
       },
       "cloud_credentials": {
@@ -310,6 +310,15 @@
           "name": "Integration",
           "description": "Sungrow-OAuth-Konfigurationseintrag zum Aktualisieren. Leer lassen, um alle geladenen Cloud-Einträge zu aktualisieren."
         }
+      }
+    }
+  },
+  "selector": {
+    "transport": {
+      "options": {
+        "cloud_only": "Cloud (Developer Account via Official OpenAPI - Cloud Polling)",
+        "cloud_user": "Cloud (User Account via Unofficial API - Cloud Polling)",
+        "modbus_only": "Modbus (Local Polling)"
       }
     }
   }

--- a/custom_components/sungrow/translations/de.json
+++ b/custom_components/sungrow/translations/de.json
@@ -316,9 +316,9 @@
   "selector": {
     "transport": {
       "options": {
-        "cloud_only": "Cloud (Developer Account via Official OpenAPI - Cloud Polling)",
-        "cloud_user": "Cloud (User Account via Unofficial API - Cloud Polling)",
-        "modbus_only": "Modbus (Local Polling)"
+        "cloud_only": "Cloud (Entwicklerkonto über offizielle OpenAPI - Cloud-Abfrage)",
+        "cloud_user": "Cloud (Benutzerkonto über inoffizielle API - Cloud-Abfrage)",
+        "modbus_only": "Modbus (lokale Abfrage)"
       }
     }
   }

--- a/custom_components/sungrow/translations/en.json
+++ b/custom_components/sungrow/translations/en.json
@@ -312,5 +312,14 @@
         }
       }
     }
+  },
+  "selector": {
+    "transport": {
+      "options": {
+        "cloud_only": "Cloud (Developer Account via Official OpenAPI - Cloud Polling)",
+        "cloud_user": "Cloud (User Account via Unofficial API - Cloud Polling)",
+        "modbus_only": "Modbus (Local Polling)"
+      }
+    }
   }
 }

--- a/custom_components/sungrow/translations/es.json
+++ b/custom_components/sungrow/translations/es.json
@@ -2,10 +2,10 @@
   "config": {
     "step": {
       "user": {
-        "title": "Conectar con iSolarCloud",
-        "description": "Introduzca sus credenciales de la API de iSolarCloud. Puede encontrarlas aquí: [iSolarCloud]({url})\n\nDespués de enviarlas, se crea el concentrador y Home Assistant le pedirá que lo autorice en su navegador.",
+        "title": "Elegir modo de transporte",
+        "description": "Seleccione cómo la integración se conecta a su inversor Sungrow.",
         "data": {
-          "transport": "Transport mode"
+          "transport": "Modo de transporte"
         }
       },
       "cloud_credentials": {
@@ -310,6 +310,15 @@
           "name": "Integración",
           "description": "Entrada OAuth de Sungrow a actualizar. Dejar vacío para actualizar todas las entradas de nube cargadas."
         }
+      }
+    }
+  },
+  "selector": {
+    "transport": {
+      "options": {
+        "cloud_only": "Cloud (Developer Account via Official OpenAPI - Cloud Polling)",
+        "cloud_user": "Cloud (User Account via Unofficial API - Cloud Polling)",
+        "modbus_only": "Modbus (Local Polling)"
       }
     }
   }

--- a/custom_components/sungrow/translations/es.json
+++ b/custom_components/sungrow/translations/es.json
@@ -316,9 +316,9 @@
   "selector": {
     "transport": {
       "options": {
-        "cloud_only": "Cloud (Developer Account via Official OpenAPI - Cloud Polling)",
-        "cloud_user": "Cloud (User Account via Unofficial API - Cloud Polling)",
-        "modbus_only": "Modbus (Local Polling)"
+        "cloud_only": "Nube (Cuenta de desarrollador vía OpenAPI oficial - Sondeo en la nube)",
+        "cloud_user": "Nube (Cuenta de usuario vía API no oficial - Sondeo en la nube)",
+        "modbus_only": "Modbus (Sondeo local)"
       }
     }
   }

--- a/custom_components/sungrow/translations/fr.json
+++ b/custom_components/sungrow/translations/fr.json
@@ -316,9 +316,9 @@
   "selector": {
     "transport": {
       "options": {
-        "cloud_only": "Cloud (Developer Account via Official OpenAPI - Cloud Polling)",
-        "cloud_user": "Cloud (User Account via Unofficial API - Cloud Polling)",
-        "modbus_only": "Modbus (Local Polling)"
+        "cloud_only": "Cloud (Compte développeur via l'OpenAPI officielle - Interrogation cloud)",
+        "cloud_user": "Cloud (Compte utilisateur via API non officielle - Interrogation cloud)",
+        "modbus_only": "Modbus (Interrogation locale)"
       }
     }
   }

--- a/custom_components/sungrow/translations/fr.json
+++ b/custom_components/sungrow/translations/fr.json
@@ -2,10 +2,10 @@
   "config": {
     "step": {
       "user": {
-        "title": "Se connecter à iSolarCloud",
-        "description": "Saisissez vos identifiants d'API iSolarCloud. Vous pouvez les trouver ici : [iSolarCloud]({url})\n\nAprès validation, le hub est créé et Home Assistant vous invitera à l'autoriser dans votre navigateur.",
+        "title": "Choisir le mode de transport",
+        "description": "Sélectionnez comment l'intégration se connecte à votre onduleur Sungrow.",
         "data": {
-          "transport": "Transport mode"
+          "transport": "Mode de transport"
         }
       },
       "cloud_credentials": {
@@ -310,6 +310,15 @@
           "name": "Intégration",
           "description": "Entrée OAuth Sungrow à actualiser. Laisser vide pour actualiser toutes les entrées cloud chargées."
         }
+      }
+    }
+  },
+  "selector": {
+    "transport": {
+      "options": {
+        "cloud_only": "Cloud (Developer Account via Official OpenAPI - Cloud Polling)",
+        "cloud_user": "Cloud (User Account via Unofficial API - Cloud Polling)",
+        "modbus_only": "Modbus (Local Polling)"
       }
     }
   }

--- a/docs/local-modbus.md
+++ b/docs/local-modbus.md
@@ -52,14 +52,14 @@ the cloud plant in the device registry (`via_device`) — a soft “related to�
 
 | Mode | Data source | Cloud account | Control (dispatch) | Best for |
 | --- | --- | --- | --- | --- |
-| **Cloud-only** | iSolarCloud OpenAPI | Developer app (App Key/Secret/ID) | ✅ Yes | Full plant sensors and battery/dispatch controls. |
-| **Cloud (user account)** *(unofficial)* | iSolarCloud app/web API | Just email + password | ✅ Yes (experimental) | No developer app — sensors + dispatch. See caveats below. |
-| **Modbus-only** *(local)* | Local Modbus only | **Not needed** | ✅ Active power limit (SG string) | Fast local metrics + limited local control; offline / privacy-first. |
+| **Cloud (Developer Account via Official OpenAPI - Cloud Polling)** | iSolarCloud OpenAPI | Developer app (App Key/Secret/ID) | ✅ Yes | Full plant sensors and battery/dispatch controls. |
+| **Cloud (User Account via Unofficial API - Cloud Polling)** | iSolarCloud app/web API | Just email + password | ✅ Yes (experimental) | No developer app — sensors + dispatch. See caveats below. |
+| **Modbus (Local Polling)** | Local Modbus only | **Not needed** | ✅ Active power limit (SG string) | Fast local metrics + limited local control; offline / privacy-first. |
 | **Both** *(two entries)* | Each entry its own source | Cloud entry only | Full dispatch via **cloud**; local active-power on local entry | Compare or use cloud + local side by side. |
 
 ### Cloud user account (unofficial)
 
-If you don't have (or don't want to register) an iSolarCloud **developer application**, you can connect with the **normal email + password** you use in the iSolarCloud app/web portal. Choose **Cloud (user account, unofficial)** as the transport and enter your email, password and region.
+If you don't have (or don't want to register) an iSolarCloud **developer application**, you can connect with the **normal email + password** you use in the iSolarCloud app/web portal. Choose **Cloud (User Account via Unofficial API - Cloud Polling)** as the transport and enter your email, password and region.
 
 !!! warning "Unofficial and experimental"
     This uses Sungrow's **undocumented app/web API**, not the official OpenAPI. It may change or stop working without notice, and its use may be subject to Sungrow's terms of service. Your password is stored in the Home Assistant config entry and is never logged. Prefer the developer **Cloud-only** transport if you can.


### PR DESCRIPTION
## Summary

Renames the three transport-mode selector options in the initial config flow so each label states account type, API surface, and delivery mode explicitly, and wires them through the translation system so non-English HA users actually see localised labels.

| Before | After |
| --- | --- |
| `Cloud Only` | `Cloud (Developer Account via Official OpenAPI - Cloud Polling)` |
| `Cloud (user account, unofficial)` | `Cloud (User Account via Unofficial API - Cloud Polling)` |
| `Modbus Only` | `Modbus (Local Polling)` |

The old shorthand made it hard to tell why the "user account" option is called unofficial (undocumented app/web API, not the OpenAPI), and gave no signal about polling vs. push. The new labels borrow Home Assistant's own [iot_class terminology](https://www.home-assistant.io/blog/2016/02/12/classifying-the-internet-of-things/) (`Cloud Polling`, `Local Polling`) so the delivery model is legible to anyone familiar with HA integrations.

## Changes

**Commit 1 — label rename**

- `custom_components/sungrow/config_flow.py` — three `label=` values on the transport `SelectSelector`.
- `docs/local-modbus.md` — transport comparison table + prose reference to the user-account transport.

**Commit 2 — translation-system routing**

- `custom_components/sungrow/strings.json` — new top-level `selector.transport.options.*` block so the frontend translates option labels instead of always rendering the hardcoded English `label=` fallback.
- `translations/{en,cy,de,es,fr}.json` — matching keys added for parity (test enforced). Option strings kept in English across languages for now (matches the existing "Transport mode" untranslated-fallback pattern), so a follow-up localisation PR can translate them without further code changes.
- Fixes pre-existing drift where `translations/{cy,de,es,fr}.json` `user.title` / `user.description` still described the pre-#216 credentials step — now reflect the current transport-selector purpose, and the `data.transport` field label is translated per-locale.

## Non-changes

- No transport values (`cloud_only` / `cloud_user` / `modbus_only`) or config-entry data shape changed — purely presentation.
- No test hardcoded the old label strings; existing tests assert on `value`, not `label`.
- Hardcoded `label=` values kept in `config_flow.py` as fallbacks if translations ever fail to load.
- Cloud MQTT push is out of scope here. Empirical probing during this work confirmed it is scoped to hybrid/ESS inverters *and* per-appkey manual Sungrow approval, so surfacing "MQTT Push" in a top-level selector label would misrepresent it for the vast majority of developer-account users. Findings + future-dev references logged on #183.

## Verification

- `ruff check` / `ruff format --check` — clean
- `mypy --strict` — clean
- `pytest tests/test_strings.py --no-cov` — 14/14 pass (strings + translation parity)
- `pytest tests/ --no-cov` — 864 passed, 4 deselected
