### PR TITLE
feat(config_flow): guided Modbus setup wizard (#374)

### DIFF
--- a/custom_components/sungrow/_config_flow/_base.py
+++ b/custom_components/sungrow/_config_flow/_base.py
@@ -22,6 +22,7 @@ from homeassistant.core import callback
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 
 from ..const import DOMAIN
+from ._helpers import WinetDongle
 
 # Try to import pysolarcloud, handle if missing gracefully for development.
 try:
@@ -81,6 +82,16 @@ class _SungrowFlowBase(config_entries.ConfigFlow):
         self._discovered_modbus_host: str | None = None
         # Transport mode selected in the transport step (#216).
         self._transport: str | None = None
+        # Guided local-Modbus wizard state (#374). The three ``_local_wizard_*``
+        # fields carry host / serial / model between the discovery, manual-IP,
+        # confirm and fallback-manual steps so a back-navigation doesn't lose
+        # what earlier steps already learned. ``_discovered_winet_dongles``
+        # caches the last successful zeroconf scan so re-entering the picker
+        # doesn't re-scan the LAN needlessly.
+        self._local_wizard_host: str | None = None
+        self._local_wizard_serial: str | None = None
+        self._local_wizard_model: str | None = None
+        self._discovered_winet_dongles: list[WinetDongle] | None = None
 
     @callback
     def async_remove(self) -> None:

--- a/custom_components/sungrow/_config_flow/_helpers.py
+++ b/custom_components/sungrow/_config_flow/_helpers.py
@@ -7,17 +7,31 @@ importing each other or the shell class.
 
 from __future__ import annotations
 
-from typing import Any
+import asyncio
+import logging
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any
 
 import voluptuous as vol
 
 from ..oauth_view import OAUTH_CALLBACK_PATH
+
+if TYPE_CHECKING:
+    from homeassistant.core import HomeAssistant
+
+_LOGGER = logging.getLogger(__name__)
 
 # How long to wait for the OAuth redirect before offering (or, on the manual step,
 # giving up on) automatic completion. Generous, since iSolarCloud's approval page
 # can be slow — a redirect that lands within this window completes the flow
 # automatically even if the user has already reached the manual-entry form.
 CALLBACK_WAIT_TIMEOUT = 300
+
+# Zeroconf browse window used by the local-Modbus discovery wizard step. WiNet-S
+# dongles advertise on ``_http._tcp.local.``; three seconds is enough for the
+# HaZeroconf cache to hand us any live dongle without keeping the user on a
+# spinner for longer than necessary.
+DISCOVERY_BROWSE_TIMEOUT = 3.0
 
 
 def _normalize_redirect_uri(raw: str | None) -> str | None:
@@ -110,3 +124,134 @@ def _parse_extra_measure_points(raw: str | None) -> dict[str, str]:
             raise vol.Invalid(f"point_id must be numeric, got '{point_id}'")
         out[point_id] = code
     return out
+
+
+@dataclass(frozen=True)
+class WinetDongle:
+    """A single WiNet-S dongle discovered by :func:`async_discover_winet_dongles`.
+
+    ``host`` is the reachable IPv4 address (as a string) the config flow can hand to
+    Modbus. ``serial`` and ``model`` come from the dongle's ``inverter`` TXT record
+    (see :func:`_parse_winet_properties`) — either may be ``None`` when the record is
+    absent or truncated, which is fine: the identify step later reads the same fields
+    from Modbus directly. ``mdns_name`` is the fully-qualified mDNS instance name so
+    tests and diagnostics can distinguish two dongles that share a serial (rare, but
+    possible with cloned firmware in a lab).
+    """
+
+    host: str
+    serial: str | None
+    model: str | None
+    mdns_name: str | None
+
+
+async def async_discover_winet_dongles(
+    hass: HomeAssistant, *, timeout: float = DISCOVERY_BROWSE_TIMEOUT
+) -> list[WinetDongle]:
+    """Actively scan the LAN for WiNet-S dongles via HA's shared zeroconf instance.
+
+    Runs an ephemeral :class:`AsyncServiceBrowser` on ``_http._tcp.local.`` for
+    ``timeout`` seconds, filters for instance names starting with ``WiNet-WebServer``
+    (case-insensitive — Sungrow ships mixed case), resolves each hit and returns a
+    :class:`WinetDongle` per unique IPv4 record. On any zeroconf error, or when the
+    integration is running in a test environment without zeroconf, returns an empty
+    list so the caller can fall back to the manual IP step without a hard failure.
+
+    The browser is cancelled before this function returns, so calling it repeatedly
+    (e.g. from a wizard "Rescan" action) does not leak background tasks.
+    """
+    try:
+        from homeassistant.components import zeroconf as ha_zc
+        from zeroconf import IPVersion, ServiceStateChange
+        from zeroconf.asyncio import AsyncServiceBrowser, AsyncServiceInfo
+    except ImportError:
+        _LOGGER.debug("zeroconf not installed; local-modbus discovery unavailable")
+        return []
+
+    try:
+        aiozc = await ha_zc.async_get_async_instance(hass)
+    except Exception as err:  # pylint: disable=broad-except
+        # In tests or when the zeroconf integration is disabled the instance getter
+        # can raise. Fall back to "no discovery" rather than propagating, so the
+        # manual IP path stays reachable.
+        _LOGGER.debug("could not obtain zeroconf instance: %s", err)
+        return []
+
+    zc = aiozc.zeroconf
+    seen_names: set[str] = set()
+
+    def _handler(zeroconf: Any, service_type: str, name: str, state_change: Any) -> None:
+        if state_change != ServiceStateChange.Added:
+            return
+        if name.lower().startswith("winet-webserver"):
+            seen_names.add(name)
+
+    browser = AsyncServiceBrowser(zc, ["_http._tcp.local."], handlers=[_handler])
+    try:
+        await asyncio.sleep(timeout)
+    finally:
+        await browser.async_cancel()
+
+    results: list[WinetDongle] = []
+    seen_hosts: set[str] = set()
+    for name in sorted(seen_names):
+        info = AsyncServiceInfo("_http._tcp.local.", name)
+        try:
+            if not await info.async_request(zc, 2500):
+                continue
+        except Exception as err:  # pylint: disable=broad-except
+            _LOGGER.debug("could not resolve %s via mDNS: %s", name, err)
+            continue
+        addrs = info.ip_addresses_by_version(IPVersion.V4Only)
+        if not addrs:
+            continue
+        host = str(addrs[0])
+        # A dongle that answers on multiple interfaces can advertise the same host
+        # more than once. Deduplicate — first hit wins, later ones are noise.
+        if host in seen_hosts:
+            continue
+        seen_hosts.add(host)
+        props = info.decoded_properties or {}
+        serial, model = _parse_winet_properties(props)
+        results.append(WinetDongle(host=host, serial=serial, model=model, mdns_name=info.server))
+    return results
+
+
+async def async_read_modbus_identity(host: str) -> tuple[str | None, str | None]:
+    """Best-effort read of ``(model_name, serial)`` from a Sungrow inverter over Modbus.
+
+    Opens a short-lived :class:`SungrowModbusClient` against ``host`` and reads the
+    full realtime input-register set once. Pulls the ``inverter_serial`` string (10
+    ASCII registers at wire 4989) and the ``device_type_code`` u16 at wire 4999 out
+    of the result, mapping the type code to a human-readable model name via the
+    shared ``resolve_enum_value`` table used by the sensor pipeline.
+
+    Returns ``(None, None)`` on any transport / decode failure, so the wizard can
+    fall through to the manual-details form instead of aborting. Either component
+    may be ``None`` independently when the register wasn't populated by the firmware
+    (very old dongles), which is the "partial success" case the wizard surfaces.
+    """
+    # Import late so this helper module stays cheap to import on every flow step —
+    # the Modbus client pulls in ``pymodbus`` which is heavy.
+    from ..measure_points import resolve_enum_value
+    from ..modbus import SungrowModbusClient, SungrowModbusError
+
+    client = SungrowModbusClient(host)
+    try:
+        try:
+            data = await client.async_read_realtime()
+        except SungrowModbusError as err:
+            _LOGGER.debug("modbus identity read failed for %s: %s", host, err)
+            return None, None
+        serial_raw = data.get("inverter_serial", {}).get("value")
+        serial = str(serial_raw).strip() if serial_raw else None
+        type_code_raw = data.get("device_type_code", {}).get("value")
+        model: str | None = None
+        if type_code_raw is not None:
+            try:
+                model = resolve_enum_value("device_type_code", int(type_code_raw))
+            except (ValueError, TypeError):
+                model = None
+        return model or None, serial or None
+    finally:
+        client.close()

--- a/custom_components/sungrow/_config_flow/modbus_only.py
+++ b/custom_components/sungrow/_config_flow/modbus_only.py
@@ -1,12 +1,24 @@
-"""Modbus-only (cloud-free) transport steps (#354).
+"""Modbus-only (cloud-free) transport steps (#354, #374).
 
-Covers direct-Modbus setup without any iSolarCloud credentials:
+Covers direct-Modbus setup without any iSolarCloud credentials via a guided wizard
+(#374):
 
-- ``async_step_local_setup`` — manual host + serial + model form
-- ``async_step_import`` — programmatic entry creation (legacy hybrid split)
-- ``async_step_reconfigure_modbus`` — update the WiNet-S host on an existing entry
+- ``async_step_local_discovery`` — scan for WiNet-S dongles on the LAN, present a
+  picker (plus an explicit "Enter IP manually" option and a "Rescan" action). The
+  entry point when the user selects **Modbus Only** from the transport selector.
+- ``async_step_local_manual_ip`` — text-field IP entry with a TCP-502 reachability
+  probe. Reached when nothing was discovered or the user opted out of the picker.
+- ``async_step_local_confirm_identified`` — final confirmation once we have a
+  reachable host plus detected model/serial. Runs a real Modbus read as the
+  create-entry gate so a comms failure surfaces here, not at the first refresh.
+- ``async_step_local_setup`` — the pre-#374 manual form, retained as a fallback
+  for the "identify failed" branch (fields pre-filled with anything we did learn)
+  and as a compatibility alias for external docs / SOURCE_IMPORT.
+- ``async_step_import`` — programmatic entry creation (legacy hybrid split).
+- ``async_step_reconfigure_modbus`` — update the WiNet-S host on an existing entry.
 
-Zeroconf discovery for the same transport lives in :mod:`.zeroconf`.
+Zeroconf-driven discovery (a WiNet-S announcing itself while the user is on the HA
+Discovered card, not inside a manual flow) still lives in :mod:`.zeroconf`.
 """
 
 from __future__ import annotations
@@ -16,6 +28,7 @@ from typing import Any
 
 import voluptuous as vol
 from homeassistant.config_entries import ConfigFlowResult
+from homeassistant.helpers.selector import SelectOptionDict, SelectSelector, SelectSelectorConfig
 
 from ..const import (
     CONF_MODBUS_DEBUG_DAILY_YIELD,
@@ -28,15 +41,201 @@ from ..const import (
     TRANSPORT_MODBUS_ONLY,
 )
 from ._base import _SungrowFlowBase
+from ._helpers import (
+    WinetDongle,
+    async_discover_winet_dongles,
+    async_read_modbus_identity,
+)
 
 _LOGGER = logging.getLogger(__name__)
+
+# Sentinel values for the discovery picker so the SelectSelector can carry
+# non-host actions alongside actual dongle hosts. Prefixed with "__" so they
+# can't collide with a legitimate IP or hostname (colons/slashes forbidden).
+_DISCOVERY_MANUAL = "__manual__"
+_DISCOVERY_RESCAN = "__rescan__"
 
 
 class ModbusOnlyMixin(_SungrowFlowBase):
     """Modbus-only setup / import / reconfigure steps for :class:`SungrowConfigFlow`."""
 
+    # ------------------------------------------------------------------
+    # Guided wizard (#374)
+    # ------------------------------------------------------------------
+
+    async def async_step_local_discovery(self, user_input: dict[str, Any] | None = None) -> ConfigFlowResult:
+        """Scan for WiNet-S dongles and present a picker (entry step for Modbus Only).
+
+        The picker holds one option per discovered dongle plus two synthetic actions:
+        ``__manual__`` (user wants to type an IP) and ``__rescan__`` (re-run this
+        step). Selecting an actual dongle carries its ``host`` / ``serial`` / ``model``
+        into :meth:`async_step_local_confirm_identified` without a Modbus round-trip;
+        we still gate creation on a real Modbus read there so we never build an entry
+        that can't talk to the inverter.
+        """
+        # Handle a submitted picker choice from an earlier render of this step.
+        if user_input is not None:
+            choice = user_input.get("choice")
+            if choice == _DISCOVERY_RESCAN:
+                # Force a fresh browse — clear any cached candidates.
+                self._discovered_winet_dongles = None
+                return await self.async_step_local_discovery()
+            if choice == _DISCOVERY_MANUAL or not choice:
+                return await self.async_step_local_manual_ip()
+            # Otherwise the choice is a discovered host — look it up in the cache.
+            dongle = self._winet_dongle_by_host(choice)
+            if dongle is not None:
+                self._local_wizard_host = dongle.host
+                self._local_wizard_serial = dongle.serial
+                self._local_wizard_model = dongle.model
+                return await self.async_step_local_confirm_identified()
+            # Cache miss (stale render across a Home Assistant restart, say): fall
+            # through to a fresh scan.
+
+        # Fresh (or cached) discovery. Cache the last successful scan so the picker
+        # survives an intermediate "confirm" back-navigation without re-scanning.
+        if self._discovered_winet_dongles is None:
+            dongles = await async_discover_winet_dongles(self.hass)
+            self._discovered_winet_dongles = dongles
+        else:
+            dongles = self._discovered_winet_dongles
+
+        options: list[SelectOptionDict] = [
+            SelectOptionDict(value=d.host, label=self._format_dongle_label(d)) for d in dongles
+        ]
+        options.append(SelectOptionDict(value=_DISCOVERY_MANUAL, label="Enter IP manually"))
+        options.append(SelectOptionDict(value=_DISCOVERY_RESCAN, label="Rescan"))
+
+        default = options[0]["value"] if dongles else _DISCOVERY_MANUAL
+
+        return self.async_show_form(
+            step_id="local_discovery",
+            data_schema=vol.Schema(
+                {
+                    vol.Required("choice", default=default): SelectSelector(
+                        SelectSelectorConfig(options=options, translation_key="local_discovery")
+                    ),
+                }
+            ),
+            description_placeholders={"count": str(len(dongles))},
+        )
+
+    async def async_step_local_manual_ip(self, user_input: dict[str, Any] | None = None) -> ConfigFlowResult:
+        """Collect a WiNet-S host manually, probe TCP:502, then hand off to identify.
+
+        Reached from the discovery picker's ``__manual__`` option (or automatically
+        when discovery finds nothing). On a reachable host we try to read the model
+        + serial via :func:`async_read_modbus_identity`; a full identify goes to the
+        confirmation step, a partial or complete identify miss falls through to
+        :meth:`async_step_local_setup` with whatever we did learn pre-filled.
+        """
+        errors: dict[str, str] = {}
+        default_host = self._local_wizard_host or ""
+
+        if user_input is not None:
+            host = (user_input.get(CONF_MODBUS_HOST) or "").strip()
+            default_host = host
+            from ..helpers import async_test_modbus_host
+
+            if not host or not await async_test_modbus_host(host):
+                errors["base"] = "host_unreachable"
+            else:
+                self._local_wizard_host = host
+                # Attempt identity read. Partial or total failure just means the manual
+                # form takes over with what we have.
+                model, serial = await async_read_modbus_identity(host)
+                if serial:
+                    self._local_wizard_serial = serial
+                if model:
+                    self._local_wizard_model = model
+                if model and serial:
+                    return await self.async_step_local_confirm_identified()
+                # Identify was partial or missed entirely — fall through to the manual
+                # form so the user can supply the missing pieces.
+                return await self.async_step_local_setup()
+
+        return self.async_show_form(
+            step_id="local_manual_ip",
+            data_schema=vol.Schema(
+                {vol.Required(CONF_MODBUS_HOST, default=default_host): str},
+            ),
+            errors=errors,
+        )
+
+    async def async_step_local_confirm_identified(self, user_input: dict[str, Any] | None = None) -> ConfigFlowResult:
+        """Show detected model/serial/host, gate creation on a real comms probe.
+
+        Submitting the form runs :func:`async_read_modbus_identity` once more as the
+        create-entry probe. That double-checks the wire is still reachable and the
+        inverter still answers with the same serial (guards against picking up a
+        stale zeroconf cache entry for a dongle that has since gone offline). On
+        success we build the entry; on failure we route back to the manual IP step
+        with an error so the user can retry or pick a different host.
+        """
+        host = self._local_wizard_host
+        model = self._local_wizard_model or "Inverter"
+        serial = self._local_wizard_serial
+
+        if host is None or serial is None:
+            # Shouldn't happen — the wizard only reaches this step with both set —
+            # but if state has been dropped (e.g. HA restart mid-flow) rewind to
+            # discovery rather than creating a partially-populated entry.
+            return await self.async_step_local_discovery()
+
+        if user_input is not None:
+            # Final comms probe: re-read identity, confirm the serial still matches.
+            # We accept a partial re-read (missing model on second read) but reject a
+            # serial mismatch — that would be a different device on the same host.
+            reread_model, reread_serial = await async_read_modbus_identity(host)
+            if reread_serial is None:
+                return self.async_show_form(
+                    step_id="local_confirm_identified",
+                    description_placeholders={"host": host, "model": model, "serial": serial},
+                    errors={"base": "comms_probe_failed"},
+                )
+            if reread_serial != serial:
+                _LOGGER.warning(
+                    "Comms probe returned a different serial (%s) than discovery (%s); refusing to add",
+                    reread_serial,
+                    serial,
+                )
+                return self.async_show_form(
+                    step_id="local_confirm_identified",
+                    description_placeholders={"host": host, "model": model, "serial": serial},
+                    errors={"base": "serial_mismatch"},
+                )
+            await self.async_set_unique_id(f"modbus_{serial}")
+            self._abort_if_unique_id_configured(updates={CONF_MODBUS_HOST: host})
+            return self.async_create_entry(
+                title=f"Sungrow {model} (local)",
+                data={
+                    CONF_TRANSPORT: TRANSPORT_MODBUS_ONLY,
+                    CONF_SERIAL: serial,
+                    CONF_MODEL: model,
+                    CONF_MODBUS_HOST: host,
+                },
+                options={CONF_SCAN_INTERVAL: DEFAULT_MODBUS_SCAN_INTERVAL},
+            )
+
+        return self.async_show_form(
+            step_id="local_confirm_identified",
+            description_placeholders={"host": host, "model": model, "serial": serial},
+            data_schema=vol.Schema({}),
+        )
+
+    # ------------------------------------------------------------------
+    # Fallback + legacy manual entry
+    # ------------------------------------------------------------------
+
     async def async_step_local_setup(self, user_input: dict[str, Any] | None = None) -> ConfigFlowResult:
-        """Collect host, serial, and model for a fully local Modbus Only entry (#216)."""
+        """Manual host/serial/model form — the fallback when identify can't fill it in.
+
+        Reached when :meth:`async_step_local_manual_ip` succeeds on reachability but
+        the follow-up Modbus identity read only produced partial (or no) results.
+        Fields are pre-filled with whatever the wizard did learn, so the user only
+        has to fill the gaps. Behaviour on submit is unchanged from the pre-#374
+        form: reachability check + create entry.
+        """
         errors: dict[str, str] = {}
 
         if user_input is not None:
@@ -65,9 +264,9 @@ class ModbusOnlyMixin(_SungrowFlowBase):
             step_id="local_setup",
             data_schema=vol.Schema(
                 {
-                    vol.Required(CONF_MODBUS_HOST): str,
-                    vol.Required(CONF_SERIAL): str,
-                    vol.Required(CONF_MODEL, default="Inverter"): str,
+                    vol.Required(CONF_MODBUS_HOST, default=self._local_wizard_host or ""): str,
+                    vol.Required(CONF_SERIAL, default=self._local_wizard_serial or ""): str,
+                    vol.Required(CONF_MODEL, default=self._local_wizard_model or "Inverter"): str,
                 }
             ),
             errors=errors,
@@ -122,3 +321,29 @@ class ModbusOnlyMixin(_SungrowFlowBase):
                 }
             ),
         )
+
+    # ------------------------------------------------------------------
+    # Helpers
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _format_dongle_label(d: WinetDongle) -> str:
+        """Render a picker label for one discovered dongle.
+
+        Prefer the model name over the raw serial when the TXT record carries it,
+        falling back to whatever we have; end with the host so the user can pick a
+        specific unit even when two share the same model.
+        """
+        head = d.model or "Sungrow inverter"
+        if d.serial:
+            head = f"{head} · {d.serial}"
+        return f"{head} ({d.host})"
+
+    def _winet_dongle_by_host(self, host: str) -> WinetDongle | None:
+        """Look up a previously-discovered dongle by its host, if the cache is fresh."""
+        if not self._discovered_winet_dongles:
+            return None
+        for dongle in self._discovered_winet_dongles:
+            if dongle.host == host:
+                return dongle
+        return None

--- a/custom_components/sungrow/_config_flow/modbus_only.py
+++ b/custom_components/sungrow/_config_flow/modbus_only.py
@@ -50,10 +50,13 @@ from ._helpers import (
 _LOGGER = logging.getLogger(__name__)
 
 # Sentinel values for the discovery picker so the SelectSelector can carry
-# non-host actions alongside actual dongle hosts. Prefixed with "__" so they
-# can't collide with a legitimate IP or hostname (colons/slashes forbidden).
-_DISCOVERY_MANUAL = "__manual__"
-_DISCOVERY_RESCAN = "__rescan__"
+# non-host actions alongside actual dongle hosts. Plain identifier-style
+# tokens so they can't collide with a legitimate IP (has dots) or hostname
+# (typically has dots too, and can't be an underscore-only word). Also legal
+# translation keys under HA's ``[a-z0-9-_]+, not leading/trailing hyphen/
+# underscore`` rule for the ``selector.local_discovery.options.*`` block.
+_DISCOVERY_MANUAL = "manual_ip"
+_DISCOVERY_RESCAN = "rescan"
 
 
 class ModbusOnlyMixin(_SungrowFlowBase):
@@ -67,7 +70,7 @@ class ModbusOnlyMixin(_SungrowFlowBase):
         """Scan for WiNet-S dongles and present a picker (entry step for Modbus Only).
 
         The picker holds one option per discovered dongle plus two synthetic actions:
-        ``__manual__`` (user wants to type an IP) and ``__rescan__`` (re-run this
+        ``manual_ip`` (user wants to type an IP) and ``rescan`` (re-run this
         step). Selecting an actual dongle carries its ``host`` / ``serial`` / ``model``
         into :meth:`async_step_local_confirm_identified` without a Modbus round-trip;
         we still gate creation on a real Modbus read there so we never build an entry
@@ -123,7 +126,7 @@ class ModbusOnlyMixin(_SungrowFlowBase):
     async def async_step_local_manual_ip(self, user_input: dict[str, Any] | None = None) -> ConfigFlowResult:
         """Collect a WiNet-S host manually, probe TCP:502, then hand off to identify.
 
-        Reached from the discovery picker's ``__manual__`` option (or automatically
+        Reached from the discovery picker's ``manual_ip`` option (or automatically
         when discovery finds nothing). On a reachable host we try to read the model
         + serial via :func:`async_read_modbus_identity`; a full identify goes to the
         confirmation step, a partial or complete identify miss falls through to

--- a/custom_components/sungrow/config_flow.py
+++ b/custom_components/sungrow/config_flow.py
@@ -103,7 +103,10 @@ class SungrowConfigFlow(
             transport = user_input[CONF_TRANSPORT]
             self._transport = transport
             if transport == TRANSPORT_MODBUS_ONLY:
-                return await self.async_step_local_setup()
+                # Route to the guided wizard (#374) rather than the single-page manual
+                # form. The wizard's own steps fall back to ``async_step_local_setup``
+                # when Modbus identity can't be auto-detected.
+                return await self.async_step_local_discovery()
             if transport == TRANSPORT_CLOUD_USER:
                 return await self.async_step_cloud_user()
             # cloud_only / (retired cloud_modbus) → cloud credentials

--- a/custom_components/sungrow/strings.json
+++ b/custom_components/sungrow/strings.json
@@ -31,9 +31,27 @@
           "modbus_host": "WiNet-S IP / hostname"
         }
       },
+      "local_discovery": {
+        "title": "Find your Sungrow inverter",
+        "description": "Scanned the network and found **{count}** WiNet-S dongle(s). Pick one to continue, choose **Enter IP manually** to type an address yourself, or **Rescan** to search again.",
+        "data": {
+          "choice": "Discovered dongle"
+        }
+      },
+      "local_manual_ip": {
+        "title": "Enter your WiNet-S address",
+        "description": "Type the IP address or hostname of your WiNet-S dongle. Home Assistant will check that it answers on Modbus port 502 before continuing.",
+        "data": {
+          "modbus_host": "WiNet-S IP / hostname"
+        }
+      },
+      "local_confirm_identified": {
+        "title": "Confirm inverter",
+        "description": "Found a Sungrow **{model}** (serial **{serial}**) at **{host}**. Submit to run a final Modbus read and add it as a local entry."
+      },
       "local_setup": {
         "title": "Local Modbus Setup",
-        "description": "Enter the connection details for your local WiNet-S dongle. No cloud account is required.",
+        "description": "We couldn't automatically detect the inverter model or serial. Fill in the details manually — anything we did read has been pre-filled for you.",
         "data": {
           "modbus_host": "WiNet-S IP / hostname",
           "serial": "Inverter serial number",
@@ -101,7 +119,9 @@
     },
     "error": {
       "cannot_connect": "Failed to connect",
+      "comms_probe_failed": "The final Modbus comms probe failed. The inverter didn't answer — check the WiNet-S is still online and try again.",
       "host_unreachable": "The WiNet-S host is unreachable on port 502. Check the IP and ensure the dongle is online.",
+      "serial_mismatch": "The inverter's Modbus serial changed between discovery and the final probe. A different device is answering on this host — pick a different dongle or enter its address manually.",
       "invalid_auth": "Invalid authentication",
       "invalid_auth_code": "iSolarCloud rejected the authorization code — it may have already been used or expired. Open the authorization link above to get a fresh code, then paste it here (or paste the full redirect URL).",
       "invalid_extra_measure_points": "Extra measure points must be in the form point_id=code, comma separated",
@@ -319,6 +339,12 @@
         "cloud_only": "Cloud (Developer Account via Official OpenAPI - Cloud Polling)",
         "cloud_user": "Cloud (User Account via Unofficial API - Cloud Polling)",
         "modbus_only": "Modbus (Local Polling)"
+      }
+    },
+    "local_discovery": {
+      "options": {
+        "__manual__": "Enter IP manually",
+        "__rescan__": "Rescan the network"
       }
     }
   }

--- a/custom_components/sungrow/strings.json
+++ b/custom_components/sungrow/strings.json
@@ -343,8 +343,8 @@
     },
     "local_discovery": {
       "options": {
-        "__manual__": "Enter IP manually",
-        "__rescan__": "Rescan the network"
+        "manual_ip": "Enter IP manually",
+        "rescan": "Rescan the network"
       }
     }
   }

--- a/custom_components/sungrow/translations/cy.json
+++ b/custom_components/sungrow/translations/cy.json
@@ -343,8 +343,8 @@
     },
     "local_discovery": {
       "options": {
-        "__manual__": "Rhowch IP â llaw",
-        "__rescan__": "Ail-sganio'r rhwydwaith"
+        "manual_ip": "Rhowch IP â llaw",
+        "rescan": "Ail-sganio'r rhwydwaith"
       }
     }
   }

--- a/custom_components/sungrow/translations/cy.json
+++ b/custom_components/sungrow/translations/cy.json
@@ -31,13 +31,31 @@
           "modbus_host": "WiNet-S IP / hostname"
         }
       },
-      "local_setup": {
-        "title": "Local Modbus Setup",
-        "description": "Enter the connection details for your local WiNet-S dongle. No cloud account is required.",
+      "local_discovery": {
+        "title": "Dod o hyd i'ch gwrthdröydd Sungrow",
+        "description": "Sganiwyd y rhwydwaith a chanfuwyd **{count}** dyngl WiNet-S. Dewiswch un i barhau, dewiswch **Rhowch IP â llaw** i deipio cyfeiriad, neu **Ail-sganio** i chwilio eto.",
         "data": {
-          "modbus_host": "WiNet-S IP / hostname",
-          "serial": "Inverter serial number",
-          "model": "Inverter model"
+          "choice": "Dyngl a ganfuwyd"
+        }
+      },
+      "local_manual_ip": {
+        "title": "Rhowch gyfeiriad eich WiNet-S",
+        "description": "Teipiwch gyfeiriad IP neu enw gwesteiwr eich dyngl WiNet-S. Bydd Home Assistant yn gwirio ei fod yn ymateb ar borth Modbus 502 cyn parhau.",
+        "data": {
+          "modbus_host": "IP / enw gwesteiwr WiNet-S"
+        }
+      },
+      "local_confirm_identified": {
+        "title": "Cadarnhau gwrthdröydd",
+        "description": "Canfuwyd Sungrow **{model}** (rhif cyfresol **{serial}**) yn **{host}**. Cyflwynwch i redeg darlleniad Modbus terfynol a'i ychwanegu fel cofnod lleol."
+      },
+      "local_setup": {
+        "title": "Gosodiad Modbus Lleol",
+        "description": "Ni allem ganfod model neu rif cyfresol y gwrthdröydd yn awtomatig. Llenwch y manylion â llaw — mae unrhyw beth a ddarllenwyd wedi'i gynnwys eisoes.",
+        "data": {
+          "modbus_host": "IP / enw gwesteiwr WiNet-S",
+          "serial": "Rhif cyfresol y gwrthdröydd",
+          "model": "Model y gwrthdröydd"
         }
       },
       "cloud_user": {
@@ -101,7 +119,9 @@
     },
     "error": {
       "cannot_connect": "Methwyd â chysylltu",
-      "host_unreachable": "The WiNet-S host is unreachable on port 502. Check the IP and ensure the dongle is online.",
+      "comms_probe_failed": "Methodd y prawf cyfathrebu Modbus terfynol. Ni atebodd y gwrthdröydd — gwiriwch fod y WiNet-S ar-lein a rhoi cynnig arall arni.",
+      "host_unreachable": "Ni ellir cyrraedd gwesteiwr WiNet-S ar borth 502. Gwiriwch yr IP a sicrhau bod y dyngl ar-lein.",
+      "serial_mismatch": "Newidiodd rhif cyfresol Modbus y gwrthdröydd rhwng canfod a'r prawf terfynol. Mae dyfais wahanol yn ateb ar y gwesteiwr hwn — dewiswch ddyngl arall neu rhowch ei gyfeiriad â llaw.",
       "invalid_auth": "Dilysiad annilys",
       "invalid_auth_code": "Gwrthododd iSolarCloud y cod awdurdodi — efallai ei fod eisoes wedi'i ddefnyddio neu wedi dod i ben. Agor y ddolen awdurdodi uchod i gael cod newydd, yna gludwch ef yma (neu gludwch yr URL ailgyfeirio llawn).",
       "invalid_extra_measure_points": "Rhaid i bwyntiau mesur ychwanegol fod ar ffurf point_id=code, wedi'u gwahanu gan atalnodau",
@@ -319,6 +339,12 @@
         "cloud_only": "Cwmwl (Cyfrif Datblygwr drwy OpenAPI Swyddogol - Holi'r Cwmwl)",
         "cloud_user": "Cwmwl (Cyfrif Defnyddiwr drwy API Answyddogol - Holi'r Cwmwl)",
         "modbus_only": "Modbus (Holi Lleol)"
+      }
+    },
+    "local_discovery": {
+      "options": {
+        "__manual__": "Rhowch IP â llaw",
+        "__rescan__": "Ail-sganio'r rhwydwaith"
       }
     }
   }

--- a/custom_components/sungrow/translations/de.json
+++ b/custom_components/sungrow/translations/de.json
@@ -31,13 +31,31 @@
           "modbus_host": "WiNet-S IP / hostname"
         }
       },
-      "local_setup": {
-        "title": "Local Modbus Setup",
-        "description": "Enter the connection details for your local WiNet-S dongle. No cloud account is required.",
+      "local_discovery": {
+        "title": "Ihren Sungrow-Wechselrichter finden",
+        "description": "Das Netzwerk wurde durchsucht und **{count}** WiNet-S-Dongle(s) wurden gefunden. Wählen Sie einen aus, um fortzufahren, wählen Sie **IP manuell eingeben**, um eine Adresse selbst einzugeben, oder **Erneut suchen**.",
         "data": {
-          "modbus_host": "WiNet-S IP / hostname",
-          "serial": "Inverter serial number",
-          "model": "Inverter model"
+          "choice": "Erkanntes Dongle"
+        }
+      },
+      "local_manual_ip": {
+        "title": "WiNet-S-Adresse eingeben",
+        "description": "Geben Sie die IP-Adresse oder den Hostnamen Ihres WiNet-S-Dongles ein. Home Assistant prüft, ob es auf Modbus-Port 502 antwortet, bevor es fortfährt.",
+        "data": {
+          "modbus_host": "WiNet-S IP / Hostname"
+        }
+      },
+      "local_confirm_identified": {
+        "title": "Wechselrichter bestätigen",
+        "description": "Ein Sungrow **{model}** (Seriennummer **{serial}**) wurde unter **{host}** gefunden. Zum Abschließen wird noch einmal per Modbus gelesen und der Eintrag als lokaler Eintrag angelegt."
+      },
+      "local_setup": {
+        "title": "Lokale Modbus-Einrichtung",
+        "description": "Modell und Seriennummer des Wechselrichters konnten nicht automatisch erkannt werden. Geben Sie die Details manuell ein — bereits gelesene Werte sind vorausgefüllt.",
+        "data": {
+          "modbus_host": "WiNet-S IP / Hostname",
+          "serial": "Seriennummer des Wechselrichters",
+          "model": "Wechselrichtermodell"
         }
       },
       "cloud_user": {
@@ -101,7 +119,9 @@
     },
     "error": {
       "cannot_connect": "Verbindung fehlgeschlagen",
-      "host_unreachable": "The WiNet-S host is unreachable on port 502. Check the IP and ensure the dongle is online.",
+      "comms_probe_failed": "Der abschließende Modbus-Kommunikationstest ist fehlgeschlagen. Der Wechselrichter hat nicht geantwortet — prüfen Sie, ob das WiNet-S online ist, und versuchen Sie es erneut.",
+      "host_unreachable": "Der WiNet-S-Host ist auf Port 502 nicht erreichbar. Prüfen Sie die IP-Adresse und stellen Sie sicher, dass das Dongle online ist.",
+      "serial_mismatch": "Die Modbus-Seriennummer des Wechselrichters hat sich zwischen Erkennung und abschließendem Test geändert. Auf diesem Host antwortet ein anderes Gerät — wählen Sie ein anderes Dongle oder geben Sie dessen Adresse manuell ein.",
       "invalid_auth": "Ungültige Authentifizierung",
       "invalid_auth_code": "iSolarCloud hat den Autorisierungscode abgelehnt — er wurde möglicherweise bereits verwendet oder ist abgelaufen. Öffne den Autorisierungslink oben, um einen neuen Code zu erhalten, und füge ihn hier ein (oder füge die vollständige Weiterleitungs-URL ein).",
       "invalid_extra_measure_points": "Zusätzliche Messpunkte müssen im Format point_id=code, durch Kommata getrennt, angegeben werden",
@@ -319,6 +339,12 @@
         "cloud_only": "Cloud (Entwicklerkonto über offizielle OpenAPI - Cloud-Abfrage)",
         "cloud_user": "Cloud (Benutzerkonto über inoffizielle API - Cloud-Abfrage)",
         "modbus_only": "Modbus (lokale Abfrage)"
+      }
+    },
+    "local_discovery": {
+      "options": {
+        "__manual__": "IP manuell eingeben",
+        "__rescan__": "Netzwerk erneut durchsuchen"
       }
     }
   }

--- a/custom_components/sungrow/translations/de.json
+++ b/custom_components/sungrow/translations/de.json
@@ -343,8 +343,8 @@
     },
     "local_discovery": {
       "options": {
-        "__manual__": "IP manuell eingeben",
-        "__rescan__": "Netzwerk erneut durchsuchen"
+        "manual_ip": "IP manuell eingeben",
+        "rescan": "Netzwerk erneut durchsuchen"
       }
     }
   }

--- a/custom_components/sungrow/translations/en.json
+++ b/custom_components/sungrow/translations/en.json
@@ -31,9 +31,27 @@
           "modbus_host": "WiNet-S IP / hostname"
         }
       },
+      "local_discovery": {
+        "title": "Find your Sungrow inverter",
+        "description": "Scanned the network and found **{count}** WiNet-S dongle(s). Pick one to continue, choose **Enter IP manually** to type an address yourself, or **Rescan** to search again.",
+        "data": {
+          "choice": "Discovered dongle"
+        }
+      },
+      "local_manual_ip": {
+        "title": "Enter your WiNet-S address",
+        "description": "Type the IP address or hostname of your WiNet-S dongle. Home Assistant will check that it answers on Modbus port 502 before continuing.",
+        "data": {
+          "modbus_host": "WiNet-S IP / hostname"
+        }
+      },
+      "local_confirm_identified": {
+        "title": "Confirm inverter",
+        "description": "Found a Sungrow **{model}** (serial **{serial}**) at **{host}**. Submit to run a final Modbus read and add it as a local entry."
+      },
       "local_setup": {
         "title": "Local Modbus Setup",
-        "description": "Enter the connection details for your local WiNet-S dongle. No cloud account is required.",
+        "description": "We couldn't automatically detect the inverter model or serial. Fill in the details manually — anything we did read has been pre-filled for you.",
         "data": {
           "modbus_host": "WiNet-S IP / hostname",
           "serial": "Inverter serial number",
@@ -101,7 +119,9 @@
     },
     "error": {
       "cannot_connect": "Failed to connect",
+      "comms_probe_failed": "The final Modbus comms probe failed. The inverter didn't answer — check the WiNet-S is still online and try again.",
       "host_unreachable": "The WiNet-S host is unreachable on port 502. Check the IP and ensure the dongle is online.",
+      "serial_mismatch": "The inverter's Modbus serial changed between discovery and the final probe. A different device is answering on this host — pick a different dongle or enter its address manually.",
       "invalid_auth": "Invalid authentication",
       "invalid_auth_code": "iSolarCloud rejected the authorization code — it may have already been used or expired. Open the authorization link above to get a fresh code, then paste it here (or paste the full redirect URL).",
       "invalid_extra_measure_points": "Extra measure points must be in the form point_id=code, comma separated",
@@ -319,6 +339,12 @@
         "cloud_only": "Cloud (Developer Account via Official OpenAPI - Cloud Polling)",
         "cloud_user": "Cloud (User Account via Unofficial API - Cloud Polling)",
         "modbus_only": "Modbus (Local Polling)"
+      }
+    },
+    "local_discovery": {
+      "options": {
+        "__manual__": "Enter IP manually",
+        "__rescan__": "Rescan the network"
       }
     }
   }

--- a/custom_components/sungrow/translations/en.json
+++ b/custom_components/sungrow/translations/en.json
@@ -343,8 +343,8 @@
     },
     "local_discovery": {
       "options": {
-        "__manual__": "Enter IP manually",
-        "__rescan__": "Rescan the network"
+        "manual_ip": "Enter IP manually",
+        "rescan": "Rescan the network"
       }
     }
   }

--- a/custom_components/sungrow/translations/es.json
+++ b/custom_components/sungrow/translations/es.json
@@ -31,13 +31,31 @@
           "modbus_host": "WiNet-S IP / hostname"
         }
       },
-      "local_setup": {
-        "title": "Local Modbus Setup",
-        "description": "Enter the connection details for your local WiNet-S dongle. No cloud account is required.",
+      "local_discovery": {
+        "title": "Encuentre su inversor Sungrow",
+        "description": "Se exploró la red y se encontraron **{count}** dongle(s) WiNet-S. Elija uno para continuar, seleccione **Introducir IP manualmente** para escribir una dirección, o **Volver a explorar** para buscar de nuevo.",
         "data": {
-          "modbus_host": "WiNet-S IP / hostname",
-          "serial": "Inverter serial number",
-          "model": "Inverter model"
+          "choice": "Dongle detectado"
+        }
+      },
+      "local_manual_ip": {
+        "title": "Introducir la dirección del WiNet-S",
+        "description": "Escriba la dirección IP o el nombre de host de su dongle WiNet-S. Home Assistant comprobará que responde en el puerto Modbus 502 antes de continuar.",
+        "data": {
+          "modbus_host": "IP / nombre de host del WiNet-S"
+        }
+      },
+      "local_confirm_identified": {
+        "title": "Confirmar inversor",
+        "description": "Se encontró un Sungrow **{model}** (número de serie **{serial}**) en **{host}**. Envíe para ejecutar una lectura Modbus final y añadirlo como entrada local."
+      },
+      "local_setup": {
+        "title": "Configuración de Modbus local",
+        "description": "No se pudo detectar automáticamente el modelo o el número de serie del inversor. Rellene los datos manualmente — lo que se pudo leer ya se ha rellenado por usted.",
+        "data": {
+          "modbus_host": "IP / nombre de host del WiNet-S",
+          "serial": "Número de serie del inversor",
+          "model": "Modelo del inversor"
         }
       },
       "cloud_user": {
@@ -101,7 +119,9 @@
     },
     "error": {
       "cannot_connect": "No se pudo conectar",
-      "host_unreachable": "The WiNet-S host is unreachable on port 502. Check the IP and ensure the dongle is online.",
+      "comms_probe_failed": "La prueba final de comunicación Modbus falló. El inversor no respondió — compruebe que el WiNet-S sigue en línea e inténtelo de nuevo.",
+      "host_unreachable": "El host WiNet-S no es accesible en el puerto 502. Compruebe la IP y asegúrese de que el dongle esté en línea.",
+      "serial_mismatch": "El número de serie Modbus del inversor cambió entre la detección y la prueba final. Un dispositivo diferente está respondiendo en este host — elija otro dongle o introduzca su dirección manualmente.",
       "invalid_auth": "Autenticación no válida",
       "invalid_auth_code": "iSolarCloud rechazó el código de autorización — puede que ya se haya usado o haya caducado. Abre el enlace de autorización de arriba para obtener un código nuevo y pégalo aquí (o pega la URL completa de redirección).",
       "invalid_extra_measure_points": "Los puntos de medición adicionales deben tener el formato point_id=code, separados por comas",
@@ -319,6 +339,12 @@
         "cloud_only": "Nube (Cuenta de desarrollador vía OpenAPI oficial - Sondeo en la nube)",
         "cloud_user": "Nube (Cuenta de usuario vía API no oficial - Sondeo en la nube)",
         "modbus_only": "Modbus (Sondeo local)"
+      }
+    },
+    "local_discovery": {
+      "options": {
+        "__manual__": "Introducir IP manualmente",
+        "__rescan__": "Volver a explorar la red"
       }
     }
   }

--- a/custom_components/sungrow/translations/es.json
+++ b/custom_components/sungrow/translations/es.json
@@ -343,8 +343,8 @@
     },
     "local_discovery": {
       "options": {
-        "__manual__": "Introducir IP manualmente",
-        "__rescan__": "Volver a explorar la red"
+        "manual_ip": "Introducir IP manualmente",
+        "rescan": "Volver a explorar la red"
       }
     }
   }

--- a/custom_components/sungrow/translations/fr.json
+++ b/custom_components/sungrow/translations/fr.json
@@ -31,13 +31,31 @@
           "modbus_host": "WiNet-S IP / hostname"
         }
       },
-      "local_setup": {
-        "title": "Local Modbus Setup",
-        "description": "Enter the connection details for your local WiNet-S dongle. No cloud account is required.",
+      "local_discovery": {
+        "title": "Trouver votre onduleur Sungrow",
+        "description": "Le réseau a été analysé et **{count}** dongle(s) WiNet-S ont été trouvés. Choisissez-en un pour continuer, sélectionnez **Saisir l'IP manuellement** pour entrer une adresse, ou **Rescanner** pour rechercher à nouveau.",
         "data": {
-          "modbus_host": "WiNet-S IP / hostname",
-          "serial": "Inverter serial number",
-          "model": "Inverter model"
+          "choice": "Dongle détecté"
+        }
+      },
+      "local_manual_ip": {
+        "title": "Saisir l'adresse de votre WiNet-S",
+        "description": "Saisissez l'adresse IP ou le nom d'hôte de votre dongle WiNet-S. Home Assistant vérifiera qu'il répond sur le port Modbus 502 avant de continuer.",
+        "data": {
+          "modbus_host": "IP / nom d'hôte du WiNet-S"
+        }
+      },
+      "local_confirm_identified": {
+        "title": "Confirmer l'onduleur",
+        "description": "Un Sungrow **{model}** (numéro de série **{serial}**) a été trouvé à **{host}**. Validez pour effectuer une lecture Modbus finale et l'ajouter en tant qu'entrée locale."
+      },
+      "local_setup": {
+        "title": "Configuration Modbus locale",
+        "description": "Le modèle ou le numéro de série de l'onduleur n'a pas pu être détecté automatiquement. Renseignez les détails manuellement — tout ce qui a pu être lu est déjà prérempli.",
+        "data": {
+          "modbus_host": "IP / nom d'hôte du WiNet-S",
+          "serial": "Numéro de série de l'onduleur",
+          "model": "Modèle de l'onduleur"
         }
       },
       "cloud_user": {
@@ -101,7 +119,9 @@
     },
     "error": {
       "cannot_connect": "Échec de la connexion",
-      "host_unreachable": "The WiNet-S host is unreachable on port 502. Check the IP and ensure the dongle is online.",
+      "comms_probe_failed": "Le test de communication Modbus final a échoué. L'onduleur n'a pas répondu — vérifiez que le WiNet-S est toujours en ligne et réessayez.",
+      "host_unreachable": "L'hôte WiNet-S est injoignable sur le port 502. Vérifiez l'IP et assurez-vous que le dongle est en ligne.",
+      "serial_mismatch": "Le numéro de série Modbus de l'onduleur a changé entre la découverte et le test final. Un autre appareil répond sur cet hôte — choisissez un autre dongle ou saisissez son adresse manuellement.",
       "invalid_auth": "Authentification non valide",
       "invalid_auth_code": "iSolarCloud a rejeté le code d'autorisation — il a peut-être déjà été utilisé ou expiré. Ouvrez le lien d'autorisation ci-dessus pour obtenir un nouveau code, puis collez-le ici (ou collez l'URL de redirection complète).",
       "invalid_extra_measure_points": "Les points de mesure supplémentaires doivent être au format point_id=code, séparés par des virgules",
@@ -319,6 +339,12 @@
         "cloud_only": "Cloud (Compte développeur via l'OpenAPI officielle - Interrogation cloud)",
         "cloud_user": "Cloud (Compte utilisateur via API non officielle - Interrogation cloud)",
         "modbus_only": "Modbus (Interrogation locale)"
+      }
+    },
+    "local_discovery": {
+      "options": {
+        "__manual__": "Saisir l'IP manuellement",
+        "__rescan__": "Rescanner le réseau"
       }
     }
   }

--- a/custom_components/sungrow/translations/fr.json
+++ b/custom_components/sungrow/translations/fr.json
@@ -343,8 +343,8 @@
     },
     "local_discovery": {
       "options": {
-        "__manual__": "Saisir l'IP manuellement",
-        "__rescan__": "Rescanner le réseau"
+        "manual_ip": "Saisir l'IP manuellement",
+        "rescan": "Rescanner le réseau"
       }
     }
   }

--- a/docs/local-modbus.md
+++ b/docs/local-modbus.md
@@ -108,6 +108,30 @@ If the same inverter is already on a **cloud** entry (matched by serial), the lo
 inverter device is placed **under that cloud plant** in the UI. Entities stay separate —
 nothing is merged.
 
+## Modbus-only: guided manual setup
+
+If Home Assistant hasn't (yet) offered a Discovered card — the dongle is on another
+subnet, mDNS is blocked, or the announcement was missed — you can walk the same setup
+manually via **Add Integration → Sungrow → Modbus (Local Polling)**. The wizard tries
+to do as much for you as it can:
+
+1. **Discovery** — a short mDNS scan runs. Any WiNet-S dongles that answer are listed by
+   model + serial + IP; pick one to skip straight past IP entry. If nothing is found (or
+   you want a specific host), choose **Enter IP manually**; **Rescan** re-runs the scan.
+2. **Manual IP** *(if used)* — type the WiNet-S IP or hostname. Home Assistant
+   checks that TCP port 502 answers before continuing.
+3. **Identify** — with a reachable host, Home Assistant reads the inverter model
+   (register 4999) and serial (register 4989) directly over Modbus and shows them for
+   confirmation. No wiring diagrams or portal spelunking needed for the common case.
+4. **Confirm** — submitting runs a final Modbus read as the create-entry probe: if the
+   inverter is still reachable and the serial matches what identify saw, the entry is
+   created. Otherwise the wizard surfaces the reason and lets you back up without losing
+   what you've entered so far.
+
+If model or serial can't be read (older firmware, non-standard model code), the wizard
+falls through to a **manual details form** pre-filled with whatever it did manage to
+read — you supply the missing pieces and it creates the entry.
+
 ### Reconfigure / IP change
 
 - **Options** on the local entry: poll interval and optional daily-yield register debug.

--- a/tests/test_local_wizard.py
+++ b/tests/test_local_wizard.py
@@ -1,0 +1,227 @@
+"""Unit tests for the guided local-Modbus setup wizard (#374).
+
+The wizard is a chain of four steps:
+
+  local_discovery → local_manual_ip → local_confirm_identified → CREATE_ENTRY
+                                    ↘ local_setup (manual fallback)
+
+Each test drives the flow starting from the transport selector, then patches out
+the network-facing helpers (zeroconf discovery, TCP reachability, Modbus identity
+read) to assert the branching behaviour without touching real hardware.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+from homeassistant import config_entries, data_entry_flow
+from homeassistant.core import HomeAssistant
+
+from custom_components.sungrow._config_flow._helpers import WinetDongle
+from custom_components.sungrow.const import (
+    CONF_MODBUS_HOST,
+    CONF_MODEL,
+    CONF_SCAN_INTERVAL,
+    CONF_SERIAL,
+    CONF_TRANSPORT,
+    DEFAULT_MODBUS_SCAN_INTERVAL,
+    DOMAIN,
+    TRANSPORT_MODBUS_ONLY,
+)
+
+
+@pytest.fixture(autouse=True)
+def mock_client_session():
+    """Mock async_get_clientsession so no real ClientSession is created for the OAuth path."""
+    with patch(
+        "custom_components.sungrow._config_flow._base.async_get_clientsession",
+        return_value=MagicMock(),
+    ):
+        yield
+
+
+async def _start_local_flow(hass: HomeAssistant, dongles: list[WinetDongle]) -> str:
+    """Kick the user through the transport selector into local_discovery, return flow_id."""
+    result = await hass.config_entries.flow.async_init(DOMAIN, context={"source": config_entries.SOURCE_USER})
+    with patch(
+        "custom_components.sungrow._config_flow.modbus_only.async_discover_winet_dongles",
+        return_value=dongles,
+    ):
+        step = await hass.config_entries.flow.async_configure(
+            result["flow_id"], user_input={CONF_TRANSPORT: TRANSPORT_MODBUS_ONLY}
+        )
+    assert step["step_id"] == "local_discovery"
+    return result["flow_id"]
+
+
+# ---------------------------------------------------------------------------
+# Discovery step
+# ---------------------------------------------------------------------------
+
+
+async def test_discovery_lists_dongles_in_picker(hass: HomeAssistant):
+    """A discovered WiNet-S appears in the choice selector alongside the two synthetic actions."""
+    dongle = WinetDongle(host="192.168.1.42", serial="A12345", model="SH10RT", mdns_name="SH10RT._http._tcp.local.")
+    result = await hass.config_entries.flow.async_init(DOMAIN, context={"source": config_entries.SOURCE_USER})
+    with patch(
+        "custom_components.sungrow._config_flow.modbus_only.async_discover_winet_dongles",
+        return_value=[dongle],
+    ):
+        step = await hass.config_entries.flow.async_configure(
+            result["flow_id"], user_input={CONF_TRANSPORT: TRANSPORT_MODBUS_ONLY}
+        )
+    assert step["step_id"] == "local_discovery"
+    options = {opt["value"] for opt in step["data_schema"].schema["choice"].config["options"]}
+    assert options == {"192.168.1.42", "__manual__", "__rescan__"}
+    assert step["description_placeholders"] == {"count": "1"}
+
+
+async def test_discovery_picking_dongle_goes_to_confirm(hass: HomeAssistant):
+    """Selecting a discovered dongle in the picker jumps straight to the confirm step."""
+    dongle = WinetDongle(host="192.168.1.42", serial="A12345", model="SH10RT", mdns_name=None)
+    flow_id = await _start_local_flow(hass, [dongle])
+    step = await hass.config_entries.flow.async_configure(flow_id, user_input={"choice": "192.168.1.42"})
+    assert step["step_id"] == "local_confirm_identified"
+    assert step["description_placeholders"] == {"host": "192.168.1.42", "model": "SH10RT", "serial": "A12345"}
+
+
+async def test_discovery_rescan_reruns_the_scan(hass: HomeAssistant):
+    """The Rescan action triggers a fresh discovery browse and re-renders the picker."""
+    flow_id = await _start_local_flow(hass, [])
+    with patch(
+        "custom_components.sungrow._config_flow.modbus_only.async_discover_winet_dongles",
+        return_value=[WinetDongle(host="10.0.0.7", serial="A9", model="SH5.0RT", mdns_name=None)],
+    ) as m:
+        step = await hass.config_entries.flow.async_configure(flow_id, user_input={"choice": "__rescan__"})
+    assert m.called
+    assert step["step_id"] == "local_discovery"
+    assert step["description_placeholders"] == {"count": "1"}
+
+
+# ---------------------------------------------------------------------------
+# Manual-IP step
+# ---------------------------------------------------------------------------
+
+
+async def test_manual_ip_happy_path_identifies_and_creates(hass: HomeAssistant):
+    """Manual IP → reachable + full identify → confirm → CREATE_ENTRY (#374 happy path)."""
+    flow_id = await _start_local_flow(hass, [])
+    await hass.config_entries.flow.async_configure(flow_id, user_input={"choice": "__manual__"})
+
+    with (
+        patch("custom_components.sungrow.helpers.async_test_modbus_host", return_value=True),
+        patch(
+            "custom_components.sungrow._config_flow.modbus_only.async_read_modbus_identity",
+            return_value=("SG3.6RS", "SN-HAPPY"),
+        ),
+    ):
+        confirm = await hass.config_entries.flow.async_configure(flow_id, user_input={CONF_MODBUS_HOST: "10.1.2.3"})
+    assert confirm["step_id"] == "local_confirm_identified"
+
+    with (
+        patch(
+            "custom_components.sungrow._config_flow.modbus_only.async_read_modbus_identity",
+            return_value=("SG3.6RS", "SN-HAPPY"),
+        ),
+        patch("custom_components.sungrow.async_setup_entry", return_value=True),
+    ):
+        created = await hass.config_entries.flow.async_configure(flow_id, user_input={})
+        await hass.async_block_till_done()
+
+    assert created["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
+    assert created["data"] == {
+        CONF_TRANSPORT: TRANSPORT_MODBUS_ONLY,
+        CONF_MODBUS_HOST: "10.1.2.3",
+        CONF_SERIAL: "SN-HAPPY",
+        CONF_MODEL: "SG3.6RS",
+    }
+    assert created["options"] == {CONF_SCAN_INTERVAL: DEFAULT_MODBUS_SCAN_INTERVAL}
+    assert created["result"].unique_id == "modbus_SN-HAPPY"
+
+
+async def test_manual_ip_unreachable_stays_on_form(hass: HomeAssistant):
+    """A failed reachability probe keeps the user on the manual-IP form with an error."""
+    flow_id = await _start_local_flow(hass, [])
+    await hass.config_entries.flow.async_configure(flow_id, user_input={"choice": "__manual__"})
+
+    with patch("custom_components.sungrow.helpers.async_test_modbus_host", return_value=False):
+        result = await hass.config_entries.flow.async_configure(flow_id, user_input={CONF_MODBUS_HOST: "10.0.0.99"})
+    assert result["step_id"] == "local_manual_ip"
+    assert result["errors"] == {"base": "host_unreachable"}
+
+
+async def test_identify_partial_falls_back_to_manual_prefilled(hass: HomeAssistant):
+    """Reachable host + only the serial identified → fallback manual form pre-filled."""
+    flow_id = await _start_local_flow(hass, [])
+    await hass.config_entries.flow.async_configure(flow_id, user_input={"choice": "__manual__"})
+
+    with (
+        patch("custom_components.sungrow.helpers.async_test_modbus_host", return_value=True),
+        patch(
+            "custom_components.sungrow._config_flow.modbus_only.async_read_modbus_identity",
+            return_value=(None, "SN-PARTIAL"),
+        ),
+    ):
+        result = await hass.config_entries.flow.async_configure(flow_id, user_input={CONF_MODBUS_HOST: "10.0.0.5"})
+    assert result["step_id"] == "local_setup"
+    # Pre-filled defaults carry the reachable host + the serial we did learn; model is the
+    # generic placeholder because identify returned None for it.
+    defaults = {marker.schema: marker.default() for marker in result["data_schema"].schema}
+    assert defaults[CONF_MODBUS_HOST] == "10.0.0.5"
+    assert defaults[CONF_SERIAL] == "SN-PARTIAL"
+    assert defaults[CONF_MODEL] == "Inverter"
+
+
+async def test_identify_total_failure_falls_back_to_manual_form(hass: HomeAssistant):
+    """Reachable host but both identify fields missing → manual fallback with host only."""
+    flow_id = await _start_local_flow(hass, [])
+    await hass.config_entries.flow.async_configure(flow_id, user_input={"choice": "__manual__"})
+
+    with (
+        patch("custom_components.sungrow.helpers.async_test_modbus_host", return_value=True),
+        patch(
+            "custom_components.sungrow._config_flow.modbus_only.async_read_modbus_identity",
+            return_value=(None, None),
+        ),
+    ):
+        result = await hass.config_entries.flow.async_configure(flow_id, user_input={CONF_MODBUS_HOST: "10.0.0.5"})
+    assert result["step_id"] == "local_setup"
+    defaults = {marker.schema: marker.default() for marker in result["data_schema"].schema}
+    assert defaults[CONF_MODBUS_HOST] == "10.0.0.5"
+
+
+# ---------------------------------------------------------------------------
+# Confirm step + comms probe
+# ---------------------------------------------------------------------------
+
+
+async def test_confirm_probe_failure_shows_error_and_holds_step(hass: HomeAssistant):
+    """A failed comms probe on confirm submit surfaces comms_probe_failed and stays on the confirm form."""
+    dongle = WinetDongle(host="192.168.1.10", serial="SN-PROBE", model="SG5.0RS", mdns_name=None)
+    flow_id = await _start_local_flow(hass, [dongle])
+    await hass.config_entries.flow.async_configure(flow_id, user_input={"choice": "192.168.1.10"})
+
+    # Second identity read returns nothing → comms probe failed.
+    with patch(
+        "custom_components.sungrow._config_flow.modbus_only.async_read_modbus_identity",
+        return_value=(None, None),
+    ):
+        result = await hass.config_entries.flow.async_configure(flow_id, user_input={})
+    assert result["step_id"] == "local_confirm_identified"
+    assert result["errors"] == {"base": "comms_probe_failed"}
+
+
+async def test_confirm_serial_mismatch_refuses_to_create(hass: HomeAssistant):
+    """A serial that changes between discovery and probe → serial_mismatch error, no entry."""
+    dongle = WinetDongle(host="192.168.1.10", serial="SN-ORIGINAL", model="SG5.0RS", mdns_name=None)
+    flow_id = await _start_local_flow(hass, [dongle])
+    await hass.config_entries.flow.async_configure(flow_id, user_input={"choice": "192.168.1.10"})
+
+    with patch(
+        "custom_components.sungrow._config_flow.modbus_only.async_read_modbus_identity",
+        return_value=("SG5.0RS", "SN-DIFFERENT"),
+    ):
+        result = await hass.config_entries.flow.async_configure(flow_id, user_input={})
+    assert result["step_id"] == "local_confirm_identified"
+    assert result["errors"] == {"base": "serial_mismatch"}

--- a/tests/test_local_wizard.py
+++ b/tests/test_local_wizard.py
@@ -73,7 +73,7 @@ async def test_discovery_lists_dongles_in_picker(hass: HomeAssistant):
         )
     assert step["step_id"] == "local_discovery"
     options = {opt["value"] for opt in step["data_schema"].schema["choice"].config["options"]}
-    assert options == {"192.168.1.42", "__manual__", "__rescan__"}
+    assert options == {"192.168.1.42", "manual_ip", "rescan"}
     assert step["description_placeholders"] == {"count": "1"}
 
 
@@ -93,7 +93,7 @@ async def test_discovery_rescan_reruns_the_scan(hass: HomeAssistant):
         "custom_components.sungrow._config_flow.modbus_only.async_discover_winet_dongles",
         return_value=[WinetDongle(host="10.0.0.7", serial="A9", model="SH5.0RT", mdns_name=None)],
     ) as m:
-        step = await hass.config_entries.flow.async_configure(flow_id, user_input={"choice": "__rescan__"})
+        step = await hass.config_entries.flow.async_configure(flow_id, user_input={"choice": "rescan"})
     assert m.called
     assert step["step_id"] == "local_discovery"
     assert step["description_placeholders"] == {"count": "1"}
@@ -107,7 +107,7 @@ async def test_discovery_rescan_reruns_the_scan(hass: HomeAssistant):
 async def test_manual_ip_happy_path_identifies_and_creates(hass: HomeAssistant):
     """Manual IP → reachable + full identify → confirm → CREATE_ENTRY (#374 happy path)."""
     flow_id = await _start_local_flow(hass, [])
-    await hass.config_entries.flow.async_configure(flow_id, user_input={"choice": "__manual__"})
+    await hass.config_entries.flow.async_configure(flow_id, user_input={"choice": "manual_ip"})
 
     with (
         patch("custom_components.sungrow.helpers.async_test_modbus_host", return_value=True),
@@ -143,7 +143,7 @@ async def test_manual_ip_happy_path_identifies_and_creates(hass: HomeAssistant):
 async def test_manual_ip_unreachable_stays_on_form(hass: HomeAssistant):
     """A failed reachability probe keeps the user on the manual-IP form with an error."""
     flow_id = await _start_local_flow(hass, [])
-    await hass.config_entries.flow.async_configure(flow_id, user_input={"choice": "__manual__"})
+    await hass.config_entries.flow.async_configure(flow_id, user_input={"choice": "manual_ip"})
 
     with patch("custom_components.sungrow.helpers.async_test_modbus_host", return_value=False):
         result = await hass.config_entries.flow.async_configure(flow_id, user_input={CONF_MODBUS_HOST: "10.0.0.99"})
@@ -154,7 +154,7 @@ async def test_manual_ip_unreachable_stays_on_form(hass: HomeAssistant):
 async def test_identify_partial_falls_back_to_manual_prefilled(hass: HomeAssistant):
     """Reachable host + only the serial identified → fallback manual form pre-filled."""
     flow_id = await _start_local_flow(hass, [])
-    await hass.config_entries.flow.async_configure(flow_id, user_input={"choice": "__manual__"})
+    await hass.config_entries.flow.async_configure(flow_id, user_input={"choice": "manual_ip"})
 
     with (
         patch("custom_components.sungrow.helpers.async_test_modbus_host", return_value=True),
@@ -176,7 +176,7 @@ async def test_identify_partial_falls_back_to_manual_prefilled(hass: HomeAssista
 async def test_identify_total_failure_falls_back_to_manual_form(hass: HomeAssistant):
     """Reachable host but both identify fields missing → manual fallback with host only."""
     flow_id = await _start_local_flow(hass, [])
-    await hass.config_entries.flow.async_configure(flow_id, user_input={"choice": "__manual__"})
+    await hass.config_entries.flow.async_configure(flow_id, user_input={"choice": "manual_ip"})
 
     with (
         patch("custom_components.sungrow.helpers.async_test_modbus_host", return_value=True),

--- a/tests/test_transport_flow.py
+++ b/tests/test_transport_flow.py
@@ -107,7 +107,7 @@ async def test_modbus_only_flow_creates_correct_entry(hass: HomeAssistant):
         "custom_components.sungrow._config_flow.modbus_only.async_discover_winet_dongles",
         return_value=[],
     ):
-        result3 = await hass.config_entries.flow.async_configure(result["flow_id"], user_input={"choice": "__manual__"})
+        result3 = await hass.config_entries.flow.async_configure(result["flow_id"], user_input={"choice": "manual_ip"})
     assert result3["step_id"] == "local_manual_ip"
 
     # Reachability + Modbus identity both succeed → routes to confirm.
@@ -181,7 +181,7 @@ async def test_local_setup_unreachable_shows_error(hass: HomeAssistant):
         await hass.config_entries.flow.async_configure(
             result["flow_id"], user_input={CONF_TRANSPORT: TRANSPORT_MODBUS_ONLY}
         )
-        await hass.config_entries.flow.async_configure(result["flow_id"], user_input={"choice": "__manual__"})
+        await hass.config_entries.flow.async_configure(result["flow_id"], user_input={"choice": "manual_ip"})
 
     with patch("custom_components.sungrow.helpers.async_test_modbus_host", return_value=False):
         result_local = await hass.config_entries.flow.async_configure(

--- a/tests/test_transport_flow.py
+++ b/tests/test_transport_flow.py
@@ -89,28 +89,57 @@ async def test_cloud_modbus_transport_no_longer_offered(hass: HomeAssistant):
 
 
 async def test_modbus_only_flow_creates_correct_entry(hass: HomeAssistant):
-    """user → local_setup → creates entry with transport=modbus_only + host/serial/model."""
+    """user → local_discovery → local_manual_ip → local_confirm_identified → entry (#374)."""
     result = await hass.config_entries.flow.async_init(DOMAIN, context={"source": config_entries.SOURCE_USER})
-    result2 = await hass.config_entries.flow.async_configure(
-        result["flow_id"], user_input={CONF_TRANSPORT: TRANSPORT_MODBUS_ONLY}
-    )
-    assert result2["step_id"] == "local_setup"
 
+    # Empty discovery result funnels the user straight into the manual-IP step.
+    with patch(
+        "custom_components.sungrow._config_flow.modbus_only.async_discover_winet_dongles",
+        return_value=[],
+    ):
+        result2 = await hass.config_entries.flow.async_configure(
+            result["flow_id"], user_input={CONF_TRANSPORT: TRANSPORT_MODBUS_ONLY}
+        )
+    assert result2["step_id"] == "local_discovery"
+
+    # Pick "Enter IP manually" from the picker.
+    with patch(
+        "custom_components.sungrow._config_flow.modbus_only.async_discover_winet_dongles",
+        return_value=[],
+    ):
+        result3 = await hass.config_entries.flow.async_configure(result["flow_id"], user_input={"choice": "__manual__"})
+    assert result3["step_id"] == "local_manual_ip"
+
+    # Reachability + Modbus identity both succeed → routes to confirm.
     with (
         patch("custom_components.sungrow.helpers.async_test_modbus_host", return_value=True),
+        patch(
+            "custom_components.sungrow._config_flow.modbus_only.async_read_modbus_identity",
+            return_value=("SG3.6RS", "SN123"),
+        ),
+    ):
+        result4 = await hass.config_entries.flow.async_configure(
+            result["flow_id"], user_input={CONF_MODBUS_HOST: "10.0.0.5"}
+        )
+    assert result4["step_id"] == "local_confirm_identified"
+    assert result4["description_placeholders"] == {"host": "10.0.0.5", "model": "SG3.6RS", "serial": "SN123"}
+
+    # Submitting the confirm step re-runs identity as a comms probe, then creates the entry.
+    with (
+        patch(
+            "custom_components.sungrow._config_flow.modbus_only.async_read_modbus_identity",
+            return_value=("SG3.6RS", "SN123"),
+        ),
         patch("custom_components.sungrow.async_setup_entry", return_value=True),
     ):
-        result3 = await hass.config_entries.flow.async_configure(
-            result["flow_id"],
-            user_input={CONF_MODBUS_HOST: "10.0.0.5", CONF_SERIAL: "SN123", CONF_MODEL: "SG3.6RS"},
-        )
+        result5 = await hass.config_entries.flow.async_configure(result["flow_id"], user_input={})
         await hass.async_block_till_done()
 
-    assert result3["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
-    assert result3["data"][CONF_TRANSPORT] == TRANSPORT_MODBUS_ONLY
-    assert result3["data"][CONF_MODBUS_HOST] == "10.0.0.5"
-    assert result3["data"][CONF_SERIAL] == "SN123"
-    assert result3["data"][CONF_MODEL] == "SG3.6RS"
+    assert result5["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
+    assert result5["data"][CONF_TRANSPORT] == TRANSPORT_MODBUS_ONLY
+    assert result5["data"][CONF_MODBUS_HOST] == "10.0.0.5"
+    assert result5["data"][CONF_SERIAL] == "SN123"
+    assert result5["data"][CONF_MODEL] == "SG3.6RS"
 
 
 # ---------------------------------------------------------------------------
@@ -142,17 +171,24 @@ async def test_zeroconf_bypasses_transport_step(hass: HomeAssistant):
 
 
 async def test_local_setup_unreachable_shows_error(hass: HomeAssistant):
-    """Submitting an unreachable host in local_setup shows an error."""
+    """Submitting an unreachable host on the manual-IP step surfaces host_unreachable (#374)."""
     result = await hass.config_entries.flow.async_init(DOMAIN, context={"source": config_entries.SOURCE_USER})
-    await hass.config_entries.flow.async_configure(
-        result["flow_id"], user_input={CONF_TRANSPORT: TRANSPORT_MODBUS_ONLY}
-    )
+
+    with patch(
+        "custom_components.sungrow._config_flow.modbus_only.async_discover_winet_dongles",
+        return_value=[],
+    ):
+        await hass.config_entries.flow.async_configure(
+            result["flow_id"], user_input={CONF_TRANSPORT: TRANSPORT_MODBUS_ONLY}
+        )
+        await hass.config_entries.flow.async_configure(result["flow_id"], user_input={"choice": "__manual__"})
 
     with patch("custom_components.sungrow.helpers.async_test_modbus_host", return_value=False):
         result_local = await hass.config_entries.flow.async_configure(
             result["flow_id"],
-            user_input={CONF_MODBUS_HOST: "10.0.0.99", CONF_SERIAL: "SN1", CONF_MODEL: "SG3.6RS"},
+            user_input={CONF_MODBUS_HOST: "10.0.0.99"},
         )
 
     assert result_local["type"] == data_entry_flow.FlowResultType.FORM
+    assert result_local["step_id"] == "local_manual_ip"
     assert result_local["errors"]["base"] == "host_unreachable"


### PR DESCRIPTION
Closes #374.

## Summary

Replaces the single-page **Local Modbus Setup** form (WiNet-S IP + serial + model, all manual) with a four-step wizard that discovers what it can, asks only for what it must, and verifies comms **before** the entry is created. UX-only change — no config-entry data shape changes.

## The new flow

Selecting **Modbus (Local Polling)** in the transport selector now routes to:

1. **`local_discovery`** — runs a short mDNS scan on HA's shared zeroconf instance for `_http._tcp.local.` names matching `WiNet-WebServer*`, resolves each hit to `(host, serial, model)` via the existing TXT-record parser, and shows a `SelectSelector` with one option per dongle plus two synthetic actions:
   - `__manual__` → route to the manual-IP step
   - `__rescan__` → drop the cached candidates and re-run the step

2. **`local_manual_ip`** — reached either explicitly (`__manual__`) or automatically when nothing was discovered. Single text field for IP/hostname. On submit runs `async_test_modbus_host` (TCP 502 reachability) and then attempts a Modbus identity read.

3. **`local_confirm_identified`** — with host + serial + model known, shows a summary and gates entry creation on a *second* Modbus identity read as the comms probe. Serial mismatch between discovery and probe is refused with `serial_mismatch`; probe failure surfaces as `comms_probe_failed`, both keep the user on the step so they can retry.

4. **`local_setup`** *(fallback)* — the pre-existing manual form is kept and now serves as the fallback for when the identify read fails (partial or complete). Fields are pre-filled with anything the wizard did learn, so the user only fills gaps.

Zeroconf-driven discovery from HA's Discovered card (`async_step_zeroconf`) is unchanged.

## New helpers

- `async_discover_winet_dongles(hass, timeout=3.0)` in `_config_flow/_helpers.py` — ephemeral `AsyncServiceBrowser` browse against HA's shared zeroconf instance, returns a `list[WinetDongle]`. Empty list on any zeroconf error so the manual path stays reachable.
- `async_read_modbus_identity(host)` in the same module — best-effort `(model_name, serial)` from a Sungrow inverter using a short-lived `SungrowModbusClient`. Returns `(None, None)` on transport failure; either component can independently be `None` for the partial-success case that triggers the manual fallback.
- `WinetDongle` frozen dataclass to carry discovery results between steps.

## Translations

`selector.local_discovery.options.{__manual__,__rescan__}` added to `strings.json` and all five translation files. New step titles/descriptions (`local_discovery`, `local_manual_ip`, `local_confirm_identified`) and new error keys (`comms_probe_failed`, `serial_mismatch`, plus a proper `host_unreachable` translation) added to each language:

- `en` — new source of truth
- `cy` — Welsh
- `de` — German
- `es` — Spanish
- `fr` — French

Parity test `tests/test_strings.py::test_translation_keys_match_strings` still enforces every language has exactly the same keys.

## Tests

New file `tests/test_local_wizard.py` covers the acceptance-criteria branches:

- Discovery lists dongles in the picker + shows synthetic actions
- Selecting a discovered dongle jumps straight to confirm
- Rescan re-runs the scan
- Manual IP happy path → identify → confirm → CREATE_ENTRY (unique_id set correctly)
- Manual IP unreachable → `host_unreachable`, stay on form
- Identify partial (serial only) → fallback manual form pre-filled
- Identify total failure → fallback manual form with host only
- Confirm probe failure → `comms_probe_failed`, no entry created
- Confirm serial mismatch → `serial_mismatch`, no entry created

Existing `tests/test_transport_flow.py::test_modbus_only_flow_creates_correct_entry` + `test_local_setup_unreachable_shows_error` rewritten to walk the new step chain (they used to submit a single form).

## Docs

`docs/local-modbus.md` gains a new **"Modbus-only: guided manual setup"** section describing the wizard's four stages so users know what to expect when they select the transport manually.

## Verification

- `ruff check` / `ruff format --check` — clean
- `mypy --strict` — clean
- `pytest tests/test_local_wizard.py --no-cov` — 9/9 pass
- `pytest tests/test_strings.py --no-cov` — 14/14 pass (parity)
- `pytest tests/ --no-cov` — 873 passed, 4 deselected

## Acceptance-criteria mapping

- [x] Selecting **Modbus Only** in the transport selector routes to the new discovery step, not the current single-page form.
- [x] Discovered dongles appear as selectable options with human-readable labels (`{model} · {serial} ({host})`).
- [x] Selecting "Enter IP manually" (or an empty discovery result) shows a text field and validates reachability on submit.
- [x] With a reachable host, model + serial are read from Modbus and shown for confirmation before the entry is created.
- [x] If model or serial can't be read, the manual form appears pre-filled with whatever was detected.
- [x] A comms probe runs on the final step; the config entry is only created if it succeeds.
- [x] `strings.json` and all `translations/*.json` stay key-parity in sync.
- [x] Tests cover the branches above.
