### PR TITLE
docs: v6 upgrading notes for enum-sensor and SBH SOC changes

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -94,6 +94,12 @@ modelled.
     setup? See [Local Modbus (WiNet-S)](local-modbus.md). If something goes wrong, the
     [Troubleshooting](TROUBLESHOOTING.md) page covers the common auth and "unavailable" issues.
 
+!!! warning "Upgrading from v5.x?"
+    Two behaviour changes need a check on your automations: `running_state_raw` and
+    `device_type_code` now emit enum labels instead of raw integers, and SBH cloud plants
+    report battery SOC as a proper 0-100 percentage. See [Upgrading](upgrading.md) for the
+    full list and how to fix affected automations/templates.
+
 ## Links
 
 - Source & issues: [github.com/KRoperUK/sungrow-hass](https://github.com/KRoperUK/sungrow-hass)

--- a/docs/upgrading.md
+++ b/docs/upgrading.md
@@ -1,0 +1,94 @@
+---
+icon: lucide/arrow-up-right
+---
+
+# Upgrading
+
+Changes that need action on your side, per major version. Minor and patch releases
+are always safe to install without reading anything in advance — see the
+[GitHub releases](https://github.com/KRoperUK/sungrow-hass/releases) page for the
+full per-release changelog.
+
+## v5.x → v6.0
+
+Two changes to be aware of before upgrading. Neither requires re-adding the
+integration or re-authorizing.
+
+### Automations comparing to the numeric state of `running_state_raw` or `device_type_code` will break
+
+**Affects:** cloud entries with per-device sensors enabled, and every local Modbus entry.
+
+Since [#325](https://github.com/KRoperUK/sungrow-hass/issues/325), those two sensors are
+classified as `enum` and expose the **decoded label** (`"Running"`, `"Standby"`,
+`"Emergency Stop"`, `"SG3.6RS"`, `"SH10RT"`, …) instead of the raw integer code they
+used to hold. This makes them useful on dashboards and in the Logbook, but it means an
+automation like this no longer matches:
+
+```yaml
+# BEFORE (v5.x) — stops working after upgrade
+- trigger: state
+  entity_id: sensor.my_inverter_running_state_raw
+  to: "4"
+```
+
+Change the comparison to the enum label:
+
+```yaml
+# AFTER (v6.x)
+- trigger: state
+  entity_id: sensor.my_inverter_running_state_raw
+  to: "Emergency Stop"
+```
+
+The label set is the values shown on the [Sensors](SENSORS.md) page for each enum
+sensor. Any automation that used the raw integer is worth checking after upgrade — HA
+won't warn you: it just silently stops firing.
+
+!!! tip "Finding stale references"
+    Search your automations and dashboards for `running_state_raw`, `device_type_code`
+    (and the older `inverter_state` alias if you used it). Anything comparing to a
+    numeric-looking string on those entities needs the enum label instead.
+
+### SBH cloud plants — battery State of Charge is now a proper percentage
+
+**Affects:** cloud entries for SBH (residential battery / hybrid) plants where SOC
+previously reported values in the `0.00 – 1.00` range instead of `0 – 100`.
+
+Since [#228](https://github.com/KRoperUK/sungrow-hass/issues/228), the integration
+scales those SOC readings to a proper 0-100 percentage server-side. If you added a
+manual **`* 100`** in a template sensor, automation or Lovelace card to work around
+the old value, remove it — otherwise your value now reads e.g. `4200` when the
+battery is at 42%.
+
+```yaml
+# BEFORE (v5.x) — remove after upgrade
+template:
+  - sensor:
+      - name: "Battery SOC (percent)"
+        state: "{{ states('sensor.plant_battery_soc') | float * 100 }}"
+
+# AFTER (v6.x) — read the sensor directly
+# sensor.plant_battery_soc already reports 0-100
+```
+
+Long-term statistics for these entities are **not** rewritten on upgrade — the old
+0-1 values stay in the historical series. If your Energy dashboard graph has a step
+change at the upgrade time, that's why. Use the `sungrow.backfill` service to
+re-import the affected period if you want a clean history.
+
+### Also worth knowing
+
+Not breaking (no user action required), but shape-changing enough to mention:
+
+- **`cloud_modbus` transport retired.** Entries that used the pre-v5 hybrid transport
+  are **auto-migrated on load** — the `modbus_host` value is stripped from the cloud
+  entry, and if the inverter serial is known, a **separate local Modbus entry** is
+  created automatically alongside it. No user action needed, but the shape of what
+  used to be one entry is now two. See
+  [Upgrading from hybrid](local-modbus.md#upgrading-from-hybrid-old-modbus-host-on-cloud).
+- **Charge/Discharge Command select replaced by Battery Mode.** The old
+  `select.*_charge_discharge_command` entity has been superseded by
+  `select.*_battery_mode` with a richer option set (Self-consumption / Force charge /
+  Force discharge / Stop). Restored *Charge* / *Discharge* / *Stop* states from the
+  old entity map onto the new options, so existing automations keep working; new
+  automations should use the new entity or the `sungrow.set_battery_mode` service.

--- a/zensical.toml
+++ b/zensical.toml
@@ -17,6 +17,7 @@ nav = [
   { "Sensors" = "SENSORS.md" },
   { "Model support" = "model-support.md" },
   { "Troubleshooting" = "TROUBLESHOOTING.md" },
+  { "Upgrading" = "upgrading.md" },
 ]
 
 [project.theme]


### PR DESCRIPTION
## Summary

Documents the two behaviour changes shipped in the v5.x line that will silently break automations / templates on upgrade if not surfaced, and flags them as `BREAKING CHANGE:` so release-please rolls the accumulated v5.7.0 changes into a **v6.0.0** release with a prominent BREAKING CHANGES section.

## Changes

- **New:** `docs/upgrading.md` — dedicated Upgrading page with a **v5.x → v6.0** section covering:
  - `running_state_raw` / `device_type_code` moving from raw ints to enum labels (#325). Automations comparing to `to: "4"` etc. silently stop matching; fix is to compare to the enum label. Before/after YAML included.
  - SBH cloud plant SOC now reports 0-100 % instead of the previous 0.00-1.00 fraction (#228). Manual `* 100` template workarounds need removing.
  - Non-breaking-but-shape-changing notes: the `cloud_modbus` retirement / auto-migration (#348) and the `charge_discharge_command` → `battery_mode` select rename (#314).
- **Updated:** `docs/index.md` — new `⚠ Upgrading from v5.x?` warning admonition below the "New here?" tip pointing at the Upgrading page.
- **Updated:** `zensical.toml` — Upgrading page added to the docs nav.

## Release-please signalling

Two `BREAKING CHANGE:` footers on the commit body — release-please will pick them up on the next workflow run, promote the accumulated `chore(main): release 5.7.0` PR to **`release 6.0.0`**, and mirror both footers into a **⚠ BREAKING CHANGES** section of the release notes.

## Non-changes

- No code changes, only docs + nav config. `pytest tests/ --no-cov` — 873 passed. Ruff / mypy — clean.
- The affected sensor changes themselves are already on `main` (from #325 and the SBH SOC fix); this PR only documents them and signals the version bump. No user-facing behaviour changes here.
