### PR TITLE
feat: add India (isolarcloud.in) gateway region

### DIFF
--- a/custom_components/sungrow/const.py
+++ b/custom_components/sungrow/const.py
@@ -87,6 +87,7 @@ GATEWAYS = {
     "International": "https://gateway.isolarcloud.com.hk",
     "China": "https://gateway.isolarcloud.com",
     "Australia": "https://augateway.isolarcloud.com",
+    "India": "https://gateway.isolarcloud.in",
 }
 
 # Web console URL per region, used as the device `configuration_url` so the
@@ -96,6 +97,7 @@ GATEWAY_CONSOLE_URLS = {
     "International": "https://isolarcloud.com.hk",
     "China": "https://isolarcloud.com",
     "Australia": "https://au.isolarcloud.com",
+    "India": "https://isolarcloud.in",
 }
 
 DEFAULT_HOST = GATEWAYS["Europe"]

--- a/tests/test_const.py
+++ b/tests/test_const.py
@@ -24,7 +24,7 @@ def test_gateways_all_https():
 
 def test_gateways_expected_regions():
     """Test expected gateway regions are present."""
-    expected_regions = {"Europe", "International", "China", "Australia"}
+    expected_regions = {"Europe", "International", "China", "Australia", "India"}
     assert set(GATEWAYS.keys()) == expected_regions
 
 


### PR DESCRIPTION
## Summary

Adds **India** as a new selectable gateway region: `gateway.isolarcloud.in` (API) and `isolarcloud.in` (web console), alongside the existing Europe, International, China, and Australia regions.

The India region isn't in the upstream `pysolarcloud` `Server` enum yet, but this integration only ever passes `host=` to `pysolarcloud.Auth` as a plain string (see `custom_components/sungrow/const.py`'s `GATEWAYS` dict), so no `pysolarcloud` change is required to support it here.

The exact hostname was confirmed by capturing traffic from the official iSolarCloud mobile app while logged into an India-region account (`iot.isolarcloud.in`, `gateway.isolarcloud.in`), and verified end-to-end (auth + realtime data) by manually deploying this branch to a live Home Assistant instance and completing setup against a real India iSolarCloud account.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change
- [ ] Documentation / chore

## Checklist

- [ ] `ruff check custom_components/` passes
- [ ] `ruff format --check custom_components/` passes
- [ ] `pytest` passes and new/changed behaviour is covered by tests
- [ ] I have updated documentation where relevant

🤖 Generated with [Claude Code](https://claude.com/claude-code)
